### PR TITLE
refactor: implement configurable TTL and disablement for all caching layers

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -23,6 +23,12 @@ APP_DATABASE__URL=postgres://postgres:postgres@db:5432/status-list
 # Redis configuration
 APP_REDIS__URI=redis://redis:6379
 APP_REDIS__REQUIRE_CLIENT_AUTH=false
+# TTL for the certificate cache in Redis. 
+# Set to 0 to disable and always fetch from S3.
+APP_REDIS__CERT_CACHE_TTL=3600
+# TTL for the Secrets Manager cache. 
+# Set to 0 to disable and always fetch from AWS API directly.
+APP_REDIS__SECRETS_CACHE_TTL=300
 
 # AWS SDK
 APP_AWS__REGION=us-east-1
@@ -31,6 +37,8 @@ AWS_ACCESS_KEY_ID=test
 AWS_SECRET_ACCESS_KEY=test
 
 # Cache configuration
+# TTL for the status list record cache. 
+# Set to 0 to disable and always fetch from the database.
 APP_CACHE__TTL=300
 APP_CACHE__MAX_CAPACITY=1000
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,7 +43,6 @@ pub struct RedisConfig {
     pub uri: SecretString,
     pub require_client_auth: bool,
     pub cert_cache_ttl: u64,
-    pub secrets_cache_ttl: u64,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -54,6 +53,7 @@ pub struct DatabaseConfig {
 #[derive(Debug, Clone, Deserialize)]
 pub struct AwsConfig {
     pub region: String,
+    pub secrets_cache_ttl: u64,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -138,7 +138,7 @@ impl Config {
             .set_default("redis.uri", "redis://localhost:6379")?
             .set_default("redis.require_client_auth", false)?
             .set_default("redis.cert_cache_ttl", 3600)? // Default 1 hour
-            .set_default("redis.secrets_cache_ttl", 300)? // Default 5 minutes
+            .set_default("aws.secrets_cache_ttl", 300)? // Default 5 minutes
             .set_default("server.cert.email", "admin@example.com")?
             .set_default("server.cert.eku", vec![1, 3, 6, 1, 5, 5, 7, 3, 30])?
             .set_default("server.cert.organization", "adorsys GmbH & CO KG")?
@@ -228,6 +228,7 @@ mod tests {
         ("APP_SERVER__CERT__ORGANIZATION", "Test Org"),
         ("APP_SERVER__CERT__EKU", "1,3,6,1,5,5,7,3,30"),
         ("APP_AWS__REGION", "us-west-2"),
+        ("APP_AWS__SECRETS_CACHE_TTL", "600"),
         ("APP_CACHE__TTL", "600"),
         ("APP_CACHE__MAX_CAPACITY", "2000"),
     ])]

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,6 +42,8 @@ pub struct CertConfig {
 pub struct RedisConfig {
     pub uri: SecretString,
     pub require_client_auth: bool,
+    pub cert_cache_ttl: u64,
+    pub secrets_cache_ttl: u64,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -135,6 +137,8 @@ impl Config {
             )?
             .set_default("redis.uri", "redis://localhost:6379")?
             .set_default("redis.require_client_auth", false)?
+            .set_default("redis.cert_cache_ttl", 3600)? // Default 1 hour
+            .set_default("redis.secrets_cache_ttl", 300)? // Default 5 minutes
             .set_default("server.cert.email", "admin@example.com")?
             .set_default("server.cert.eku", vec![1, 3, 6, 1, 5, 5, 7, 3, 30])?
             .set_default("server.cert.organization", "adorsys GmbH & CO KG")?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,4 +10,4 @@ pub mod models;
 pub mod startup;
 pub mod web;
 
-pub use utils::{cert_manager, state};
+pub use utils::{bits_validation::BitFlag, cert_manager, state};

--- a/src/utils/bits_validation.rs
+++ b/src/utils/bits_validation.rs
@@ -24,7 +24,7 @@ impl BitFlag {
     /// # Examples
     ///
     /// ```
-    /// use crate::status_list_server::utils::bits_validation::BitFlag;
+    /// use status_list_server::BitFlag;
     /// let valid = BitFlag::new(4);
     /// assert!(valid.is_some());
     ///
@@ -43,7 +43,7 @@ impl BitFlag {
     /// # Examples
     ///
     /// ```
-    /// use crate::status_list_server::utils::bits_validation::BitFlag;
+    /// use status_list_server::BitFlag;
     /// let bit = BitFlag::new(2).unwrap();
     /// assert_eq!(bit.value(), 2);
     /// ```

--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -5,16 +5,74 @@ use crate::models::StatusListRecord;
 
 #[derive(Clone)]
 pub struct Cache {
-    pub status_list_record_cache: MokaCache<String, StatusListRecord>,
+    inner: Option<MokaCache<String, StatusListRecord>>,
 }
 
 impl Cache {
-    pub fn new(ttl: u64, max_capacity: u64) -> Self {
-        Self {
-            status_list_record_cache: MokaCache::builder()
-                .time_to_live(Duration::from_secs(ttl))
-                .max_capacity(max_capacity)
-                .build(),
+    /// Creates a cache; TTL=0 disables it.
+    pub fn new(ttl_secs: u64, max_capacity: u64) -> Self {
+        let inner = if ttl_secs == 0 {
+            tracing::info!("Cache disabled (TTL=0)");
+            None
+        } else {
+            Some(
+                MokaCache::builder()
+                    .time_to_live(Duration::from_secs(ttl_secs))
+                    .max_capacity(max_capacity)
+                    .build(),
+            )
+        };
+        Self { inner }
+    }
+
+    pub async fn get(&self, key: &str) -> Option<StatusListRecord> {
+        self.inner.as_ref()?.get(key).await
+    }
+
+    pub async fn insert(&self, key: String, value: StatusListRecord) {
+        if let Some(cache) = &self.inner {
+            cache.insert(key, value).await;
         }
+    }
+
+    pub async fn invalidate(&self, key: &str) {
+        if let Some(cache) = &self.inner {
+            cache.invalidate(key).await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{StatusList, StatusListRecord};
+
+    fn sample_record(id: &str) -> StatusListRecord {
+        StatusListRecord {
+            list_id: id.to_string(),
+            issuer: "issuer".to_string(),
+            sub: "sub".to_string(),
+            status_list: StatusList {
+                bits: 1,
+                lst: "test".to_string(),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn cache_enabled_works() {
+        let cache = Cache::new(60, 10);
+        let record = sample_record("list-1");
+        cache.insert("list-1".to_string(), record.clone()).await;
+        assert!(cache.get("list-1").await.is_some());
+    }
+
+    #[tokio::test]
+    async fn cache_disabled_returns_none() {
+        let cache = Cache::new(0, 10);
+        cache
+            .insert("list-1".to_string(), sample_record("list-1"))
+            .await;
+        assert!(cache.get("list-1").await.is_none());
     }
 }

--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -5,40 +5,32 @@ use crate::models::StatusListRecord;
 
 #[derive(Clone)]
 pub struct Cache {
-    inner: Option<MokaCache<String, StatusListRecord>>,
+    inner: MokaCache<String, StatusListRecord>,
 }
 
 impl Cache {
-    /// Creates a cache; TTL=0 disables it.
+    /// Creates a cache; TTL=0 disables it naturally.
     pub fn new(ttl_secs: u64, max_capacity: u64) -> Self {
-        let inner = (ttl_secs > 0).then(|| {
-            MokaCache::builder()
-                .time_to_live(Duration::from_secs(ttl_secs))
-                .max_capacity(max_capacity)
-                .build()
-        });
-
-        if inner.is_none() {
+        if ttl_secs == 0 {
             tracing::info!("Cache disabled (TTL=0)");
         }
-
+        let inner = MokaCache::builder()
+            .time_to_live(Duration::from_secs(ttl_secs))
+            .max_capacity(max_capacity)
+            .build();
         Self { inner }
     }
 
     pub async fn get(&self, key: &str) -> Option<StatusListRecord> {
-        self.inner.as_ref()?.get(key).await
+        self.inner.get(key).await
     }
 
     pub async fn insert(&self, key: String, value: StatusListRecord) {
-        if let Some(cache) = &self.inner {
-            cache.insert(key, value).await;
-        }
+        self.inner.insert(key, value).await;
     }
 
     pub async fn invalidate(&self, key: &str) {
-        if let Some(cache) = &self.inner {
-            cache.invalidate(key).await;
-        }
+        self.inner.invalidate(key).await;
     }
 }
 

--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -11,17 +11,17 @@ pub struct Cache {
 impl Cache {
     /// Creates a cache; TTL=0 disables it.
     pub fn new(ttl_secs: u64, max_capacity: u64) -> Self {
-        let inner = if ttl_secs == 0 {
+        let inner = (ttl_secs > 0).then(|| {
+            MokaCache::builder()
+                .time_to_live(Duration::from_secs(ttl_secs))
+                .max_capacity(max_capacity)
+                .build()
+        });
+
+        if inner.is_none() {
             tracing::info!("Cache disabled (TTL=0)");
-            None
-        } else {
-            Some(
-                MokaCache::builder()
-                    .time_to_live(Duration::from_secs(ttl_secs))
-                    .max_capacity(max_capacity)
-                    .build(),
-            )
-        };
+        }
+
         Self { inner }
     }
 

--- a/src/utils/cert_manager/storage/aws.rs
+++ b/src/utils/cert_manager/storage/aws.rs
@@ -21,38 +21,35 @@ use crate::{cert_manager::storage::StorageError, utils::cert_manager::Storage};
 /// Type used for AWS Secrets Manager operations
 pub struct AwsSecretsManager {
     client: SecretsClient,
-    cache: SecretsCacheClient,
-    secrets_cache_ttl: Duration,
+    cache: Option<SecretsCacheClient>,
 }
 
 impl AwsSecretsManager {
     /// Create a new instance of [AwsSecretsManager] with the given AWS SDK config
-    pub async fn new(config: &SdkConfig, ttl: Duration) -> Result<Self, StorageError> {
+    pub async fn new(
+        config: &SdkConfig,
+        secrets_cache_ttl: Duration,
+    ) -> Result<Self, StorageError> {
         let client = SecretsClient::new(config);
-        let asm_builder = SecretsConfig::from(config).to_builder();
 
-        // SecretsCacheClient requires a non-zero TTL to build.
-        // If the intended TTL is 0, we use a dummy 1s TTL and bypass it in our methods.
-        let internal_ttl = if ttl.is_zero() {
-            Duration::from_secs(1)
+        let cache = if !secrets_cache_ttl.is_zero() {
+            let asm_builder = SecretsConfig::from(config).to_builder();
+
+            Some(
+                SecretsCacheClient::from_builder(
+                    asm_builder,
+                    NonZeroUsize::new(100).unwrap(),
+                    secrets_cache_ttl,
+                    true,
+                )
+                .await
+                .map_err(|e| StorageError::AwsSdk(e.into()))?,
+            )
         } else {
-            ttl
+            None
         };
 
-        let cache = SecretsCacheClient::from_builder(
-            asm_builder,
-            NonZeroUsize::new(100).unwrap(),
-            internal_ttl,
-            true,
-        )
-        .await
-        .map_err(|e| StorageError::AwsSdk(e.into()))?;
-
-        Ok(Self {
-            client,
-            cache,
-            secrets_cache_ttl: ttl,
-        })
+        Ok(Self { client, cache })
     }
 }
 
@@ -85,30 +82,31 @@ impl Storage for AwsSecretsManager {
     async fn load(&self, name: &str) -> Result<Option<String>, StorageError> {
         use aws_sdk_secretsmanager::error::SdkError;
 
-        // Bypass cache if TTL is 0
-        if self.secrets_cache_ttl.is_zero() {
-            match self.client.get_secret_value().secret_id(name).send().await {
+        // Use cache if enabled
+        if let Some(cache) = &self.cache {
+            match cache.get_secret_value(name, None, None, false).await {
                 Ok(value) => return Ok(value.secret_string),
-                Err(SdkError::ServiceError(err)) if err.err().is_resource_not_found_exception() => {
-                    return Ok(None);
+                Err(err) => {
+                    // Check for ResourceNotFoundException
+                    if let Some(SdkError::ServiceError(service_err)) =
+                        err.downcast_ref::<SdkError<GetSecretValueError>>()
+                    {
+                        if service_err.err().is_resource_not_found_exception() {
+                            return Ok(None);
+                        }
+                    }
+                    return Err(StorageError::AwsSdk(eyre!("{err}")));
                 }
-                Err(sdk_err) => return Err(StorageError::AwsSdk(sdk_err.into())),
             }
         }
 
-        match self.cache.get_secret_value(name, None, None, false).await {
+        // Direct call if cache is disabled or bypass
+        match self.client.get_secret_value().secret_id(name).send().await {
             Ok(value) => Ok(value.secret_string),
-            Err(err) => {
-                // Check for ResourceNotFoundException
-                if let Some(SdkError::ServiceError(service_err)) =
-                    err.downcast_ref::<SdkError<GetSecretValueError>>()
-                {
-                    if service_err.err().is_resource_not_found_exception() {
-                        return Ok(None);
-                    }
-                }
-                Err(StorageError::AwsSdk(eyre!("{err}")))
+            Err(SdkError::ServiceError(err)) if err.err().is_resource_not_found_exception() => {
+                Ok(None)
             }
+            Err(sdk_err) => Err(StorageError::AwsSdk(sdk_err.into())),
         }
     }
 
@@ -122,8 +120,8 @@ impl Storage for AwsSecretsManager {
             .map_err(|e| StorageError::AwsSdk(e.into()))?;
 
         // Force the secret refresh in the cache only if enabled
-        if !self.secrets_cache_ttl.is_zero() {
-            let _ = self.cache.get_secret_value(name, None, None, true).await;
+        if let Some(cache) = &self.cache {
+            let _ = cache.get_secret_value(name, None, None, true).await;
         }
         Ok(())
     }
@@ -137,8 +135,8 @@ impl Storage for AwsSecretsManager {
             .map_err(|e| StorageError::AwsSdk(e.into()))?;
 
         // Invalidate cache by refreshing the secret only if enabled
-        if !self.secrets_cache_ttl.is_zero() {
-            let _ = self.cache.get_secret_value(name, None, None, true).await;
+        if let Some(cache) = &self.cache {
+            let _ = cache.get_secret_value(name, None, None, true).await;
         }
         Ok(())
     }

--- a/src/utils/cert_manager/storage/aws.rs
+++ b/src/utils/cert_manager/storage/aws.rs
@@ -22,24 +22,37 @@ use crate::{cert_manager::storage::StorageError, utils::cert_manager::Storage};
 pub struct AwsSecretsManager {
     client: SecretsClient,
     cache: SecretsCacheClient,
+    secrets_cache_ttl: Duration,
 }
 
 impl AwsSecretsManager {
     /// Create a new instance of [AwsSecretsManager] with the given AWS SDK config
-    pub async fn new(config: &SdkConfig) -> Result<Self, StorageError> {
+    pub async fn new(config: &SdkConfig, ttl: Duration) -> Result<Self, StorageError> {
         let client = SecretsClient::new(config);
         let asm_builder = SecretsConfig::from(config).to_builder();
-        // Cache size: 100 and a TTL of 5 minutes
+
+        // SecretsCacheClient requires a non-zero TTL to build.
+        // If the intended TTL is 0, we use a dummy 1s TTL and bypass it in our methods.
+        let internal_ttl = if ttl.is_zero() {
+            Duration::from_secs(1)
+        } else {
+            ttl
+        };
+
         let cache = SecretsCacheClient::from_builder(
             asm_builder,
             NonZeroUsize::new(100).unwrap(),
-            Duration::from_secs(300),
+            internal_ttl,
             true,
         )
         .await
         .map_err(|e| StorageError::AwsSdk(e.into()))?;
 
-        Ok(Self { client, cache })
+        Ok(Self {
+            client,
+            cache,
+            secrets_cache_ttl: ttl,
+        })
     }
 }
 
@@ -72,6 +85,17 @@ impl Storage for AwsSecretsManager {
     async fn load(&self, name: &str) -> Result<Option<String>, StorageError> {
         use aws_sdk_secretsmanager::error::SdkError;
 
+        // Bypass cache if TTL is 0
+        if self.secrets_cache_ttl.is_zero() {
+            match self.client.get_secret_value().secret_id(name).send().await {
+                Ok(value) => return Ok(value.secret_string),
+                Err(SdkError::ServiceError(err)) if err.err().is_resource_not_found_exception() => {
+                    return Ok(None);
+                }
+                Err(sdk_err) => return Err(StorageError::AwsSdk(sdk_err.into())),
+            }
+        }
+
         match self.cache.get_secret_value(name, None, None, false).await {
             Ok(value) => Ok(value.secret_string),
             Err(err) => {
@@ -97,8 +121,10 @@ impl Storage for AwsSecretsManager {
             .await
             .map_err(|e| StorageError::AwsSdk(e.into()))?;
 
-        // Force the secret refresh in the cache
-        let _ = self.cache.get_secret_value(name, None, None, true).await;
+        // Force the secret refresh in the cache only if enabled
+        if !self.secrets_cache_ttl.is_zero() {
+            let _ = self.cache.get_secret_value(name, None, None, true).await;
+        }
         Ok(())
     }
 
@@ -110,8 +136,10 @@ impl Storage for AwsSecretsManager {
             .await
             .map_err(|e| StorageError::AwsSdk(e.into()))?;
 
-        // Invalidate cache by refreshing the secret
-        let _ = self.cache.get_secret_value(name, None, None, true).await;
+        // Invalidate cache by refreshing the secret only if enabled
+        if !self.secrets_cache_ttl.is_zero() {
+            let _ = self.cache.get_secret_value(name, None, None, true).await;
+        }
         Ok(())
     }
 }

--- a/src/utils/cert_manager/storage/aws.rs
+++ b/src/utils/cert_manager/storage/aws.rs
@@ -21,7 +21,7 @@ use crate::{cert_manager::storage::StorageError, utils::cert_manager::Storage};
 /// Type used for AWS Secrets Manager operations
 pub struct AwsSecretsManager {
     client: SecretsClient,
-    cache: Option<SecretsCacheClient>,
+    cache: SecretsCacheClient,
 }
 
 impl AwsSecretsManager {
@@ -31,23 +31,16 @@ impl AwsSecretsManager {
         secrets_cache_ttl: Duration,
     ) -> Result<Self, StorageError> {
         let client = SecretsClient::new(config);
+        let asm_builder = SecretsConfig::from(config).to_builder();
 
-        let cache = if !secrets_cache_ttl.is_zero() {
-            let asm_builder = SecretsConfig::from(config).to_builder();
-
-            Some(
-                SecretsCacheClient::from_builder(
-                    asm_builder,
-                    NonZeroUsize::new(100).unwrap(),
-                    secrets_cache_ttl,
-                    true,
-                )
-                .await
-                .map_err(|e| StorageError::AwsSdk(e.into()))?,
-            )
-        } else {
-            None
-        };
+        let cache = SecretsCacheClient::from_builder(
+            asm_builder,
+            NonZeroUsize::new(100).unwrap(),
+            secrets_cache_ttl,
+            true,
+        )
+        .await
+        .map_err(|e| StorageError::AwsSdk(e.into()))?;
 
         Ok(Self { client, cache })
     }
@@ -82,31 +75,19 @@ impl Storage for AwsSecretsManager {
     async fn load(&self, name: &str) -> Result<Option<String>, StorageError> {
         use aws_sdk_secretsmanager::error::SdkError;
 
-        // Use cache if enabled
-        if let Some(cache) = &self.cache {
-            match cache.get_secret_value(name, None, None, false).await {
-                Ok(value) => return Ok(value.secret_string),
-                Err(err) => {
-                    // Check for ResourceNotFoundException
-                    if let Some(SdkError::ServiceError(service_err)) =
-                        err.downcast_ref::<SdkError<GetSecretValueError>>()
-                    {
-                        if service_err.err().is_resource_not_found_exception() {
-                            return Ok(None);
-                        }
-                    }
-                    return Err(StorageError::AwsSdk(eyre!("{err}")));
-                }
-            }
-        }
-
-        // Direct call if cache is disabled or bypass
-        match self.client.get_secret_value().secret_id(name).send().await {
+        match self.cache.get_secret_value(name, None, None, false).await {
             Ok(value) => Ok(value.secret_string),
-            Err(SdkError::ServiceError(err)) if err.err().is_resource_not_found_exception() => {
-                Ok(None)
+            Err(err) => {
+                // Check for ResourceNotFoundException
+                if let Some(SdkError::ServiceError(service_err)) =
+                    err.downcast_ref::<SdkError<GetSecretValueError>>()
+                {
+                    if service_err.err().is_resource_not_found_exception() {
+                        return Ok(None);
+                    }
+                }
+                Err(StorageError::AwsSdk(eyre!("{err}")))
             }
-            Err(sdk_err) => Err(StorageError::AwsSdk(sdk_err.into())),
         }
     }
 
@@ -119,10 +100,8 @@ impl Storage for AwsSecretsManager {
             .await
             .map_err(|e| StorageError::AwsSdk(e.into()))?;
 
-        // Force the secret refresh in the cache only if enabled
-        if let Some(cache) = &self.cache {
-            let _ = cache.get_secret_value(name, None, None, true).await;
-        }
+        // Force the secret refresh in the cache
+        let _ = self.cache.get_secret_value(name, None, None, true).await;
         Ok(())
     }
 
@@ -134,10 +113,8 @@ impl Storage for AwsSecretsManager {
             .await
             .map_err(|e| StorageError::AwsSdk(e.into()))?;
 
-        // Invalidate cache by refreshing the secret only if enabled
-        if let Some(cache) = &self.cache {
-            let _ = cache.get_secret_value(name, None, None, true).await;
-        }
+        // Invalidate cache by refreshing the secret
+        let _ = self.cache.get_secret_value(name, None, None, true).await;
         Ok(())
     }
 }

--- a/src/utils/cert_manager/storage/redis.rs
+++ b/src/utils/cert_manager/storage/redis.rs
@@ -30,15 +30,23 @@ impl Redis {
 impl Storage for Redis {
     async fn store(&self, key: &str, value: &str) -> Result<(), StorageError> {
         let mut conn = self.conn.clone();
-        if let Some(ttl) = self.ttl {
-            let _: () = conn.set_ex(key, value, ttl).await?;
-        } else {
-            let _: () = conn.set(key, value).await?;
+        match self.ttl {
+            Some(0) => Ok(()), // Cache disabled
+            Some(ttl) => {
+                let _: () = conn.set_ex(key, value, ttl).await?;
+                Ok(())
+            }
+            None => {
+                let _: () = conn.set(key, value).await?;
+                Ok(())
+            }
         }
-        Ok(())
     }
 
     async fn load(&self, key: &str) -> Result<Option<String>, StorageError> {
+        if self.ttl == Some(0) {
+            return Ok(None);
+        }
         let mut conn = self.conn.clone();
         Ok(conn.get(key).await?)
     }

--- a/src/utils/cert_manager/storage/redis.rs
+++ b/src/utils/cert_manager/storage/redis.rs
@@ -32,19 +32,13 @@ impl Storage for Redis {
         let mut conn = self.conn.clone();
         match self.ttl {
             Some(0) => Ok(()), // Cache disabled
-            Some(ttl) => {
-                let _: () = conn.set_ex(key, value, ttl).await?;
-                Ok(())
-            }
-            None => {
-                let _: () = conn.set(key, value).await?;
-                Ok(())
-            }
+            Some(ttl) => Ok(conn.set_ex(key, value, ttl).await?),
+            None => Ok(conn.set(key, value).await?),
         }
     }
 
     async fn load(&self, key: &str) -> Result<Option<String>, StorageError> {
-        if self.ttl == Some(0) {
+        if matches!(self.ttl, Some(0)) {
             return Ok(None);
         }
         let mut conn = self.conn.clone();

--- a/src/utils/cert_manager/storage/redis.rs
+++ b/src/utils/cert_manager/storage/redis.rs
@@ -7,34 +7,38 @@ use crate::cert_manager::storage::{Storage, StorageError};
 #[derive(Clone)]
 pub struct Redis {
     conn: ConnectionManager,
-    ttl: u64, // 0 means disabled
+    ttl: Option<u64>,
 }
 
 impl Redis {
     /// Create a new instance of [RedisStorage]
     /// with the given Redis connection manager
     pub fn new(conn: ConnectionManager) -> Self {
-        Self { conn, ttl: 0 }
+        Self { conn, ttl: None }
     }
 
     /// Set the time-to-live (TTL) for the stored data
     pub fn with_ttl(self, ttl: u64) -> Self {
-        Self { ttl, ..self }
+        Self {
+            ttl: Some(ttl),
+            ..self
+        }
     }
 }
 
 #[async_trait]
 impl Storage for Redis {
     async fn store(&self, key: &str, value: &str) -> Result<(), StorageError> {
-        if self.ttl == 0 {
-            return Ok(());
-        }
         let mut conn = self.conn.clone();
-        Ok(conn.set_ex(key, value, self.ttl).await?)
+        match self.ttl {
+            Some(0) => Ok(()), // Cache disabled
+            Some(v) => Ok(conn.set_ex(key, value, v).await?),
+            None => Ok(conn.set(key, value).await?),
+        }
     }
 
     async fn load(&self, key: &str) -> Result<Option<String>, StorageError> {
-        if self.ttl == 0 {
+        if matches!(self.ttl, Some(0)) {
             return Ok(None);
         }
         let mut conn = self.conn.clone();

--- a/src/utils/cert_manager/storage/redis.rs
+++ b/src/utils/cert_manager/storage/redis.rs
@@ -7,38 +7,34 @@ use crate::cert_manager::storage::{Storage, StorageError};
 #[derive(Clone)]
 pub struct Redis {
     conn: ConnectionManager,
-    ttl: Option<u64>,
+    ttl: u64, // 0 means disabled
 }
 
 impl Redis {
     /// Create a new instance of [RedisStorage]
     /// with the given Redis connection manager
     pub fn new(conn: ConnectionManager) -> Self {
-        Self { conn, ttl: None }
+        Self { conn, ttl: 0 }
     }
 
     /// Set the time-to-live (TTL) for the stored data
     pub fn with_ttl(self, ttl: u64) -> Self {
-        Self {
-            ttl: Some(ttl),
-            ..self
-        }
+        Self { ttl, ..self }
     }
 }
 
 #[async_trait]
 impl Storage for Redis {
     async fn store(&self, key: &str, value: &str) -> Result<(), StorageError> {
-        let mut conn = self.conn.clone();
-        match self.ttl {
-            Some(0) => Ok(()), // Cache disabled
-            Some(ttl) => Ok(conn.set_ex(key, value, ttl).await?),
-            None => Ok(conn.set(key, value).await?),
+        if self.ttl == 0 {
+            return Ok(());
         }
+        let mut conn = self.conn.clone();
+        Ok(conn.set_ex(key, value, self.ttl).await?)
     }
 
     async fn load(&self, key: &str) -> Result<Option<String>, StorageError> {
-        if matches!(self.ttl, Some(0)) {
+        if self.ttl == 0 {
             return Ok(None);
         }
         let mut conn = self.conn.clone();

--- a/src/utils/state.rs
+++ b/src/utils/state.rs
@@ -13,7 +13,7 @@ use color_eyre::eyre::{Context, Result as EyeResult};
 use sea_orm::Database;
 use sea_orm_migration::MigratorTrait;
 use secrecy::ExposeSecret;
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use super::{
     cache::Cache,
@@ -67,10 +67,14 @@ pub async fn build_state(config: &AppConfig) -> EyeResult<AppState> {
     };
 
     // Initialize the storage backends for the certificate manager
-    let cache = Redis::new(redis_conn.clone());
+    let cache = Redis::new(redis_conn.clone()).with_ttl(config.redis.cert_cache_ttl);
     let cert_storage =
         AwsS3::new(&aws_config, BUCKET_NAME, config.aws.region.clone()).with_cache(cache);
-    let secrets_storage = AwsSecretsManager::new(&aws_config).await?;
+    let secrets_storage = AwsSecretsManager::new(
+        &aws_config,
+        Duration::from_secs(config.redis.secrets_cache_ttl),
+    )
+    .await?;
 
     let mut certificate_manager = CertManager::new(
         [&config.server.domain],

--- a/src/utils/state.rs
+++ b/src/utils/state.rs
@@ -72,7 +72,7 @@ pub async fn build_state(config: &AppConfig) -> EyeResult<AppState> {
         AwsS3::new(&aws_config, BUCKET_NAME, config.aws.region.clone()).with_cache(cache);
     let secrets_storage = AwsSecretsManager::new(
         &aws_config,
-        Duration::from_secs(config.redis.secrets_cache_ttl),
+        Duration::from_secs(config.aws.secrets_cache_ttl),
     )
     .await?;
 

--- a/src/web/handlers/status_list/get_status_list.rs
+++ b/src/web/handlers/status_list/get_status_list.rs
@@ -61,7 +61,7 @@ async fn build_status_list_token(
     state: &AppState,
 ) -> Result<impl IntoResponse + Debug, StatusListError> {
     // Check cache for status list record
-    if let Some(cached_record) = state.cache.status_list_record_cache.get(list_id).await {
+    if let Some(cached_record) = state.cache.get(list_id).await {
         tracing::info!("Cache hit for status list record: {list_id}");
         // Record is in cache, proceed with building the response
         return build_response_from_record(accept, &cached_record, state).await;
@@ -82,7 +82,6 @@ async fn build_status_list_token(
     // Store the token in the cache for future requests
     state
         .cache
-        .status_list_record_cache
         .insert(list_id.to_string(), status_record.clone())
         .await;
 

--- a/src/web/handlers/status_list/update_status.rs
+++ b/src/web/handlers/status_list/update_status.rs
@@ -77,11 +77,7 @@ pub async fn update_status(
         })?;
 
     // Invalidate cache entry to ensure next read fetches the updated record
-    appstate
-        .cache
-        .status_list_record_cache
-        .invalidate(&exact_status_list.list_id)
-        .await;
+    appstate.cache.invalidate(&exact_status_list.list_id).await;
     tracing::info!(
         "Invalidated cache for status list: {}",
         exact_status_list.list_id


### PR DESCRIPTION
This PR addresses several caching-related issues by ensuring rotated signing keys and certificates are picked up immediately through configurable cache durations. It also introduces a “zero-to-disable” option for development environments.

## Changes

### Unified Cache Configuration
Introduced configurable TTLs for all three cache layers:
- `APP_CACHE__TTL`: Status List data (`moka` cache)
- `APP_REDIS__CERT_CACHE_TTL`: Certificate chain cache (Redis)
- `APP_REDIS__SECRETS_CACHE_TTL`: Signing keys and ACME credentials (AWS Secrets Manager)

### "Zero-to-Disable" Support
All cache layers now interpret a TTL of `0` as an instruction to bypass caching entirely. This ensures data freshness in development environments (e.g., when testing rotation with Localstack) without waiting for cache expiration.

### Fixed Stale Signing Key / Certificate Issues
Corrected logic where:
- Redis cached certificates indefinitely
- AWS Secrets Manager cached signing keys using a hard-coded 5-minute TTL

### Doc-test Fix
Re-exported `BitFlag` in the crate root to resolve pre-existing visibility issues that caused doc-tests to fail.

Related to https://github.com/ADORSYS-GIS/keycloak-oid4vp-plugin/issues/31