### PR TITLE
Fix Status enum ApplicationSpecific variant to conform with spec

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+edition = "2021"
+tab_spaces = 4
+newline_style = "Unix"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,0 @@
-edition = "2021"
-tab_spaces = 4
-newline_style = "Unix"

--- a/src/models.rs
+++ b/src/models.rs
@@ -123,7 +123,7 @@ impl<'de> Deserialize<'de> for Status {
                 return Err(serde::de::Error::custom(format!(
                     "status value {} is reserved (only 0, 1, 2, or >= 256 allowed)",
                     other
-                )))
+                )));
             }
         })
     }

--- a/src/models.rs
+++ b/src/models.rs
@@ -119,10 +119,12 @@ impl<'de> Deserialize<'de> for Status {
             1 => Status::INVALID,
             2 => Status::SUSPENDED,
             n if n >= 256 => Status::ApplicationSpecific(n),
-            other => return Err(serde::de::Error::custom(format!(
-                "status value {} is reserved (only 0, 1, 2, or >= 256 allowed)",
-                other
-            ))),
+            other => {
+                return Err(serde::de::Error::custom(format!(
+                    "status value {} is reserved (only 0, 1, 2, or >= 256 allowed)",
+                    other
+                )))
+            }
         })
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -97,7 +97,7 @@ pub enum Status {
     VALID,
     INVALID,
     SUSPENDED,
-    APPLICATIONSPECIFIC,
+    ApplicationSpecific(u32),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, FromJsonQueryResult)]

--- a/src/models.rs
+++ b/src/models.rs
@@ -92,12 +92,39 @@ pub mod status_lists {
 pub type StatusListRecord = status_lists::Model;
 
 // Additional types for status list handling
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Status {
     VALID,
     INVALID,
     SUSPENDED,
     ApplicationSpecific(u32),
+}
+
+impl Serialize for Status {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_u32(match self {
+            Status::VALID => 0,
+            Status::INVALID => 1,
+            Status::SUSPENDED => 2,
+            Status::ApplicationSpecific(v) => *v,
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for Status {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let v = u32::deserialize(d)?;
+        Ok(match v {
+            0 => Status::VALID,
+            1 => Status::INVALID,
+            2 => Status::SUSPENDED,
+            n if n >= 256 => Status::ApplicationSpecific(n),
+            other => return Err(serde::de::Error::custom(format!(
+                "status value {} is reserved (only 0, 1, 2, or >= 256 allowed)",
+                other
+            ))),
+        })
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, FromJsonQueryResult)]

--- a/src/utils/lst_gen.rs
+++ b/src/utils/lst_gen.rs
@@ -22,16 +22,14 @@ fn determine_bits(
         .max()
         .ok_or_else(|| Error::Generic("Failed to determine max status value".to_string()))?;
 
-    // Validate ApplicationSpecific values are >= 256
-    if let Some(value) = status_updates.iter().find_map(|entry| match entry.status {
-        Status::ApplicationSpecific(v) => Some(v),
-        _ => None,
-    }) {
-        if value < 256 {
-            return Err(Error::Generic(
-                "ApplicationSpecific value must be >= 256".to_string(),
-            ));
-        }
+    // Validate ALL ApplicationSpecific values are >= 256
+    if status_updates
+        .iter()
+        .any(|e| matches!(e.status, Status::ApplicationSpecific(v) if v < 256))
+    {
+        return Err(Error::Generic(
+            "ApplicationSpecific value must be >= 256".to_string(),
+        ));
     }
 
     let required_bits = match max_status_value {
@@ -72,8 +70,8 @@ fn calculate_array_size(status_updates: &[StatusEntry], bits: usize) -> Result<u
         return Err(Error::InvalidIndex);
     }
 
-    let required_len = (max_index as usize + 1) * bits + 7;
-    Ok(required_len / 8)
+    let end_bit = (max_index as usize) * bits + bits - 1;
+    Ok(end_bit / 8 + 1)
 }
 
 // Helper function to apply updates
@@ -110,17 +108,40 @@ fn apply_updates(
             }
         };
 
-        let mask = ((1u32 << bits) - 1) << bit_offset;
-        status_array[byte_index] &= !(mask as u8);
-        status_array[byte_index] |= ((status_value as u8) << bit_offset) & (mask as u8);
+        let total_bit_pos = idx * bits;
+        let start_byte = total_bit_pos / 8;
+        let _start_offset = total_bit_pos % 8;
 
-        if bit_offset + bits > 8 {
-            let overflow_bits = (bit_offset + bits) - 8;
-            let overflow_mask = ((1u32 << overflow_bits) - 1) as u8;
-            if byte_index + 1 < status_array.len() {
-                status_array[byte_index + 1] &= !overflow_mask;
-                status_array[byte_index + 1] |=
-                    (status_value >> (bits - overflow_bits)) as u8 & overflow_mask;
+        if bit_offset + bits <= 8 {
+            let mask: u8 = (((1u32 << bits) - 1) << bit_offset) as u8;
+            status_array[byte_index] &= !mask;
+            status_array[byte_index] |= ((status_value as u8) << bit_offset) & mask;
+        } else {
+            let first_byte_bits = 8 - bit_offset;
+            let first_mask: u8 = (((1u32 << first_byte_bits) - 1) << bit_offset) as u8;
+            status_array[byte_index] &= !first_mask;
+            status_array[byte_index] |= ((status_value as u8) << bit_offset) & first_mask;
+
+            let mut bits_written = first_byte_bits;
+            let mut cur_byte = start_byte + 1;
+            let mut cur_offset = 0;
+
+            while bits_written < bits {
+                let remaining_bits = bits - bits_written;
+                let bits_this_byte = remaining_bits.min(8);
+
+                for i in 0..bits_this_byte {
+                    let global_bit = bits_written + i;
+                    let value_bit = (status_value >> global_bit) & 1;
+                    status_array[cur_byte] &= !(1u8 << cur_offset);
+                    status_array[cur_byte] |= (value_bit as u8) << cur_offset;
+                    cur_offset += 1;
+                    if cur_offset >= 8 {
+                        cur_byte += 1;
+                        cur_offset = 0;
+                    }
+                }
+                bits_written += bits_this_byte;
             }
         }
     }
@@ -162,20 +183,36 @@ pub fn create_status_list(status_updates: Vec<StatusEntry>) -> Result<StatusList
 fn decode_status_array(array: &[u8], bits: usize) -> Result<Vec<Status>, Error> {
     let mut statuses = Vec::new();
     for i in 0..(array.len() * 8 / bits) {
-        let byte_index = (i * bits) / 8;
-        let bit_offset = (i * bits) % 8;
-        let status_value: u32 = if bits == 8 {
-            array[i] as u32
-        } else {
-            let mut value = 0u32;
-            for j in 0..bits {
-                if byte_index < array.len() && bit_offset + j < 8 {
-                    value |= ((array[byte_index] as u32 >> (bit_offset + j)) & 1) << j;
-                }
+        let total_bit_pos = i * bits;
+        let start_byte = total_bit_pos / 8;
+        let start_offset = total_bit_pos % 8;
+
+        let mut value: u32 = 0;
+        let mut bits_read = 0;
+        let mut cur_byte = start_byte;
+        let mut cur_offset = start_offset;
+        let mut bits_in_current_byte = 8 - start_offset;
+
+        while bits_read < bits {
+            if cur_byte >= array.len() {
+                break;
             }
-            value
-        };
-        statuses.push(match status_value {
+            let bits_this_iter = bits_in_current_byte.min(bits - bits_read);
+
+            let extracted = ((array[cur_byte] as u16 >> cur_offset) & ((1u16 << bits_this_iter) - 1)) as u32;
+            value |= extracted << bits_read;
+
+            bits_read += bits_this_iter;
+            bits_in_current_byte -= bits_this_iter;
+
+            if bits_in_current_byte == 0 {
+                cur_byte += 1;
+                cur_offset = 0;
+                bits_in_current_byte = 8;
+            }
+        }
+
+        statuses.push(match value {
             0 => Status::VALID,
             1 => Status::INVALID,
             2 => Status::SUSPENDED,
@@ -500,5 +537,105 @@ mod tests {
             updated_status_array, expected_status_array,
             "The status array was not re-encoded correctly with wider bit size"
         );
+    }
+
+    #[test]
+    fn test_create_lst_with_2_bit_statuses_original() {
+        let updates = vec![
+            StatusEntry {
+                index: 0,
+                status: Status::VALID,
+            },
+            StatusEntry {
+                index: 1,
+                status: Status::INVALID,
+            },
+            StatusEntry {
+                index: 2,
+                status: Status::SUSPENDED,
+            },
+            StatusEntry {
+                index: 3,
+                status: Status::INVALID,
+            },
+        ];
+
+        let result = create_status_list(updates).unwrap();
+        let decoded = base64url::decode(&result.lst).unwrap();
+        let mut decoder = flate2::read::ZlibDecoder::new(&decoded[..]);
+        let mut decompressed = Vec::new();
+        decoder.read_to_end(&mut decompressed).unwrap();
+
+        assert_eq!(decompressed, vec![0b01100100]);
+    }
+
+    #[test]
+    fn test_app_specific_rejects_values_3_to_255() {
+        for val in [3u32, 100, 255] {
+            let updates = vec![StatusEntry {
+                index: 0,
+                status: Status::ApplicationSpecific(val),
+            }];
+            let result = create_status_list(updates);
+            assert!(
+                matches!(result, Err(Error::Generic(ref s)) if s.contains(">= 256")),
+                "value {} should be rejected",
+                val
+            );
+        }
+    }
+
+    #[test]
+    fn test_decode_rejects_values_3_to_255() {
+        let arr = vec![3u8];
+        let result = decode_status_array(&arr, 2);
+        assert!(matches!(result, Err(Error::Generic(_))));
+    }
+
+    #[test]
+    fn test_app_specific_multibyte_roundtrip() {
+        let updates = vec![
+            StatusEntry {
+                index: 0,
+                status: Status::ApplicationSpecific(512),
+            },
+            StatusEntry {
+                index: 3,
+                status: Status::ApplicationSpecific(256),
+            },
+        ];
+        let result = create_status_list(updates).unwrap();
+        let decoded_bytes = base64url::decode(&result.lst).unwrap();
+        let mut decoder = flate2::read::ZlibDecoder::new(&decoded_bytes[..]);
+        let mut raw = Vec::new();
+        decoder.read_to_end(&mut raw).unwrap();
+
+        let statuses = decode_status_array(&raw, result.bits as usize).unwrap();
+        assert_eq!(statuses[0], Status::ApplicationSpecific(512));
+        assert_eq!(statuses[3], Status::ApplicationSpecific(256));
+    }
+
+    #[test]
+    fn test_status_serde_integer_roundtrip() {
+        use crate::models::Status;
+        use serde_json;
+
+        assert_eq!(serde_json::from_str::<Status>("0").unwrap(), Status::VALID);
+        assert_eq!(serde_json::from_str::<Status>("1").unwrap(), Status::INVALID);
+        assert_eq!(serde_json::from_str::<Status>("2").unwrap(), Status::SUSPENDED);
+        assert_eq!(
+            serde_json::from_str::<Status>("256").unwrap(),
+            Status::ApplicationSpecific(256)
+        );
+        assert_eq!(serde_json::to_string(&Status::VALID).unwrap(), "0");
+        assert_eq!(serde_json::to_string(&Status::INVALID).unwrap(), "1");
+        assert_eq!(serde_json::to_string(&Status::SUSPENDED).unwrap(), "2");
+        assert_eq!(
+            serde_json::to_string(&Status::ApplicationSpecific(256)).unwrap(),
+            "256"
+        );
+        assert!(serde_json::from_str::<Status>("3").is_err());
+        assert!(serde_json::from_str::<Status>("100").is_err());
+        assert!(serde_json::from_str::<Status>("255").is_err());
     }
 }

--- a/src/utils/lst_gen.rs
+++ b/src/utils/lst_gen.rs
@@ -17,20 +17,43 @@ fn determine_bits(
             Status::VALID => 0,
             Status::INVALID => 1,
             Status::SUSPENDED => 2,
-            Status::APPLICATIONSPECIFIC => 3,
+            Status::ApplicationSpecific(value) => value,
         })
         .max()
         .ok_or_else(|| Error::Generic("Failed to determine max status value".to_string()))?;
+
+    // Validate ApplicationSpecific values are >= 256
+    if let Some(value) = status_updates.iter().find_map(|entry| match entry.status {
+        Status::ApplicationSpecific(v) => Some(v),
+        _ => None,
+    }) {
+        if value < 256 {
+            return Err(Error::Generic(
+                "ApplicationSpecific value must be >= 256".to_string(),
+            ));
+        }
+    }
 
     let required_bits = match max_status_value {
         0 | 1 => 1,
         2 | 3 => 2,
         4..=15 => 4,
         16..=255 => 8,
-        _ => return Err(Error::Generic("Status value too large".to_string())),
+        _ => {
+            // For values >= 256, compute minimal bits needed
+            let bits_needed = (max_status_value as usize + 1)
+                .next_power_of_two()
+                .trailing_zeros();
+            if bits_needed == 0 {
+                return Err(Error::Generic("Status value too large".to_string()));
+            }
+            bits_needed
+        }
     };
 
-    Ok(original_bits.unwrap_or(required_bits).max(required_bits))
+    Ok(original_bits
+        .unwrap_or(required_bits as usize)
+        .max(required_bits as usize))
 }
 
 // Helper function to calculate the required status array size
@@ -77,7 +100,14 @@ fn apply_updates(
             Status::VALID => 0,
             Status::INVALID => 1,
             Status::SUSPENDED => 2,
-            Status::APPLICATIONSPECIFIC => 3,
+            Status::ApplicationSpecific(value) => {
+                if value < 256 {
+                    return Err(Error::Generic(
+                        "ApplicationSpecific value must be >= 256".to_string(),
+                    ));
+                }
+                value
+            }
         };
 
         let mask = ((1u32 << bits) - 1) << bit_offset;
@@ -90,7 +120,7 @@ fn apply_updates(
             if byte_index + 1 < status_array.len() {
                 status_array[byte_index + 1] &= !overflow_mask;
                 status_array[byte_index + 1] |=
-                    ((status_value as u8) >> (bits - overflow_bits)) & overflow_mask;
+                    (status_value >> (bits - overflow_bits)) as u8 & overflow_mask;
             }
         }
     }
@@ -134,13 +164,13 @@ fn decode_status_array(array: &[u8], bits: usize) -> Result<Vec<Status>, Error> 
     for i in 0..(array.len() * 8 / bits) {
         let byte_index = (i * bits) / 8;
         let bit_offset = (i * bits) % 8;
-        let status_value = if bits == 8 {
-            array[i]
+        let status_value: u32 = if bits == 8 {
+            array[i] as u32
         } else {
-            let mut value = 0;
+            let mut value = 0u32;
             for j in 0..bits {
                 if byte_index < array.len() && bit_offset + j < 8 {
-                    value |= ((array[byte_index] >> (bit_offset + j)) & 1) << j;
+                    value |= ((array[byte_index] as u32 >> (bit_offset + j)) & 1) << j;
                 }
             }
             value
@@ -149,7 +179,7 @@ fn decode_status_array(array: &[u8], bits: usize) -> Result<Vec<Status>, Error> 
             0 => Status::VALID,
             1 => Status::INVALID,
             2 => Status::SUSPENDED,
-            3 => Status::APPLICATIONSPECIFIC,
+            value if value >= 256 => Status::ApplicationSpecific(value),
             _ => {
                 return Err(Error::Generic(
                     "Invalid status value in existing list".to_string(),
@@ -313,7 +343,7 @@ mod tests {
             },
             StatusEntry {
                 index: 3,
-                status: Status::APPLICATIONSPECIFIC,
+                status: Status::ApplicationSpecific(256),
             },
         ];
 
@@ -323,7 +353,10 @@ mod tests {
         let mut decompressed = Vec::new();
         decoder.read_to_end(&mut decompressed).unwrap();
 
-        assert_eq!(decompressed, vec![0b11100100]);
+        // Verify we got a result with 5 bytes (4 entries * 9 bits = 36 bits = 5 bytes)
+        assert_eq!(decompressed.len(), 5);
+        // Verify bits is 9 (to accommodate 256)
+        assert_eq!(result.bits, 9);
     }
 
     #[test]

--- a/src/utils/lst_gen.rs
+++ b/src/utils/lst_gen.rs
@@ -199,7 +199,8 @@ fn decode_status_array(array: &[u8], bits: usize) -> Result<Vec<Status>, Error> 
             }
             let bits_this_iter = bits_in_current_byte.min(bits - bits_read);
 
-            let extracted = ((array[cur_byte] as u16 >> cur_offset) & ((1u16 << bits_this_iter) - 1)) as u32;
+            let extracted =
+                ((array[cur_byte] as u16 >> cur_offset) & ((1u16 << bits_this_iter) - 1)) as u32;
             value |= extracted << bits_read;
 
             bits_read += bits_this_iter;
@@ -391,7 +392,11 @@ mod tests {
         decoder.read_to_end(&mut decompressed).unwrap();
 
         assert_eq!(result.bits, 9, "Should require 9 bits for value 256");
-        assert_eq!(decompressed.len(), 5, "4 entries * 9 bits = 36 bits = 5 bytes");
+        assert_eq!(
+            decompressed.len(),
+            5,
+            "4 entries * 9 bits = 36 bits = 5 bytes"
+        );
 
         let statuses = decode_status_array(&decompressed, 9).unwrap();
         assert_eq!(statuses[0], Status::VALID);
@@ -612,7 +617,11 @@ mod tests {
         assert!(!raw.is_empty(), "Should have encoded bytes");
 
         let statuses = decode_status_array(&raw, 9).unwrap();
-        assert_eq!(statuses[0], Status::ApplicationSpecific(256), "Round-trip should preserve value");
+        assert_eq!(
+            statuses[0],
+            Status::ApplicationSpecific(256),
+            "Round-trip should preserve value"
+        );
     }
 
     #[test]
@@ -673,8 +682,14 @@ mod tests {
         use serde_json;
 
         assert_eq!(serde_json::from_str::<Status>("0").unwrap(), Status::VALID);
-        assert_eq!(serde_json::from_str::<Status>("1").unwrap(), Status::INVALID);
-        assert_eq!(serde_json::from_str::<Status>("2").unwrap(), Status::SUSPENDED);
+        assert_eq!(
+            serde_json::from_str::<Status>("1").unwrap(),
+            Status::INVALID
+        );
+        assert_eq!(
+            serde_json::from_str::<Status>("2").unwrap(),
+            Status::SUSPENDED
+        );
         assert_eq!(
             serde_json::from_str::<Status>("256").unwrap(),
             Status::ApplicationSpecific(256)

--- a/src/utils/lst_gen.rs
+++ b/src/utils/lst_gen.rs
@@ -364,7 +364,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_lst_with_2_bit_statuses() {
+    fn test_create_lst_with_9_bit_app_specific_exact_bytes() {
         let updates = vec![
             StatusEntry {
                 index: 0,
@@ -390,10 +390,14 @@ mod tests {
         let mut decompressed = Vec::new();
         decoder.read_to_end(&mut decompressed).unwrap();
 
-        // Verify we got a result with 5 bytes (4 entries * 9 bits = 36 bits = 5 bytes)
-        assert_eq!(decompressed.len(), 5);
-        // Verify bits is 9 (to accommodate 256)
-        assert_eq!(result.bits, 9);
+        assert_eq!(result.bits, 9, "Should require 9 bits for value 256");
+        assert_eq!(decompressed.len(), 5, "4 entries * 9 bits = 36 bits = 5 bytes");
+
+        let statuses = decode_status_array(&decompressed, 9).unwrap();
+        assert_eq!(statuses[0], Status::VALID);
+        assert_eq!(statuses[1], Status::INVALID);
+        assert_eq!(statuses[2], Status::SUSPENDED);
+        assert_eq!(statuses[3], Status::ApplicationSpecific(256));
     }
 
     #[test]
@@ -593,6 +597,25 @@ mod tests {
     }
 
     #[test]
+    fn test_app_specific_256_at_offset_exact_bytes() {
+        let updates = vec![StatusEntry {
+            index: 0,
+            status: Status::ApplicationSpecific(256),
+        }];
+        let result = create_status_list(updates).unwrap();
+        let decoded = base64url::decode(&result.lst).unwrap();
+        let mut decoder = flate2::read::ZlibDecoder::new(&decoded[..]);
+        let mut raw = Vec::new();
+        decoder.read_to_end(&mut raw).unwrap();
+
+        assert_eq!(result.bits, 9, "Value 256 requires 9 bits");
+        assert!(!raw.is_empty(), "Should have encoded bytes");
+
+        let statuses = decode_status_array(&raw, 9).unwrap();
+        assert_eq!(statuses[0], Status::ApplicationSpecific(256), "Round-trip should preserve value");
+    }
+
+    #[test]
     fn test_app_specific_multibyte_roundtrip() {
         let updates = vec![
             StatusEntry {
@@ -613,6 +636,35 @@ mod tests {
         let statuses = decode_status_array(&raw, result.bits as usize).unwrap();
         assert_eq!(statuses[0], Status::ApplicationSpecific(512));
         assert_eq!(statuses[3], Status::ApplicationSpecific(256));
+    }
+
+    #[test]
+    fn test_app_specific_large_value_at_offset() {
+        let updates = vec![
+            StatusEntry {
+                index: 0,
+                status: Status::INVALID,
+            },
+            StatusEntry {
+                index: 3,
+                status: Status::ApplicationSpecific(4096),
+            },
+        ];
+        let result = create_status_list(updates).unwrap();
+        let decoded = base64url::decode(&result.lst).unwrap();
+        let mut decoder = flate2::read::ZlibDecoder::new(&decoded[..]);
+        let mut raw = Vec::new();
+        decoder.read_to_end(&mut raw).unwrap();
+
+        assert_eq!(result.bits, 13, "Value 4096 requires 13 bits (2^13 = 8192)");
+
+        let statuses = decode_status_array(&raw, result.bits as usize).unwrap();
+        assert_eq!(statuses[0], Status::INVALID, "Index 0 should be INVALID");
+        assert_eq!(
+            statuses[3],
+            Status::ApplicationSpecific(4096),
+            "Index 3 should decode as 4096 (the reviewer's original failing case)"
+        );
     }
 
     #[test]
@@ -637,5 +689,28 @@ mod tests {
         assert!(serde_json::from_str::<Status>("3").is_err());
         assert!(serde_json::from_str::<Status>("100").is_err());
         assert!(serde_json::from_str::<Status>("255").is_err());
+    }
+
+    #[test]
+    fn test_legacy_status_3_is_rejected() {
+        let arr = vec![0b11100100];
+        let result = decode_status_array(&arr, 2);
+        assert!(
+            matches!(result, Err(Error::Generic(_))),
+            "Legacy value 3 (old APPLICATIONSPECIFIC) should be rejected per spec: values 3-255 are reserved"
+        );
+    }
+
+    #[test]
+    fn test_decode_rejects_values_3_to_255_various_bits() {
+        for (arr, bits) in &[(vec![3u8], 2), (vec![100u8], 8)] {
+            let result = decode_status_array(arr, *bits);
+            assert!(
+                matches!(result, Err(Error::Generic(_))),
+                "Value {} in {:?}-bit encoding should be rejected",
+                arr[0],
+                bits
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fix the `Status` enum's `ApplicationSpecific` variant to correctly conform to the [OAuth Status List spec draft 21](https://datatracker.ietf.org/doc/draft-ietf-oauth-status-list/).

## Changes

- **Changed enum variant**: `Status::APPLICATIONSPECIFIC` → `Status::ApplicationSpecific(u32)`
- **Added validation**: ApplicationSpecific values must be >= 256
- **Updated bit calculation**: `determine_bits()` now calculates bits needed for values >= 256
- **Updated encoding/decoding**: Properly handle ApplicationSpecific payload in `apply_updates()` and `decode_status_array()`
- **Added tests**: Unit tests for ApplicationSpecific encoding/decoding

## Testing

All existing tests pass, plus new tests for ApplicationSpecific values.

## Fixes

Fixes #152