### PR TITLE
178 align data model documentation with seaorm migrations

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,7 +104,7 @@ The Status List Server is built using modern, performant, and scalable technolog
 
 #### Storage
 
-- **Database**: to map and store statuslist to id and credentials.
+- **Database**: to map and store status lists (keyed by `list_id`) and issuer credentials (keyed by `issuer`). See [Database Overview](../src/database/README.md) for the schema.
 
 ### Data Flow
 

--- a/src/database/README.md
+++ b/src/database/README.md
@@ -11,9 +11,9 @@ SeaORM migrations in [`mod.rs`](./mod.rs) and the entity models in [`../models.r
 Stores information about issuers and their cryptographic public keys. Each issuer is
 identified by its `issuer` value, which acts as the primary key.
 
-| Column       | Type | Null | Key | Description                           |
-|--------------|------|------|-----|---------------------------------------|
-| `issuer`     | TEXT | NO   | PK  | Unique identifier for the issuer      |
+| Column       | Type  | Null | Key | Description                           |
+| ------------ | ----- | ---- | --- | ------------------------------------- |
+| `issuer`     | TEXT  | NO   | PK  | Unique identifier for the issuer      |
 | `public_key` | JSONB | NO   |     | Public key associated with the issuer |
 
 ### `status_lists`
@@ -21,19 +21,19 @@ identified by its `issuer` value, which acts as the primary key.
 Stores status list entries and their associated issuer. Each status list is identified
 by its `list_id`, which acts as the primary key.
 
-| Column        | Type | Null | Key | Description                                         |
-|---------------|------|------|-----|-----------------------------------------------------|
-| `list_id`     | TEXT | NO   | PK  | Unique identifier for the status list               |
-| `issuer`      | TEXT | NO   | FK  | References `credentials.issuer` (ON DELETE CASCADE) |
+| Column        | Type  | Null | Key | Description                                         |
+| ------------- | ----- | ---- | --- | --------------------------------------------------- |
+| `list_id`     | TEXT  | NO   | PK  | Unique identifier for the status list               |
+| `issuer`      | TEXT  | NO   | FK  | References `credentials.issuer` (ON DELETE CASCADE) |
 | `status_list` | JSONB | NO   |     | The status list entry                               |
-| `sub`         | TEXT | NO   |     | String identifier for the Status List Token         |
+| `sub`         | TEXT  | NO   |     | String identifier for the Status List Token         |
 
 #### Indexes
 
 The following indexes are created on the `status_lists` table to speed up lookups:
 
 | Index name                 | Column    |
-|----------------------------|-----------|
+| -------------------------- | --------- |
 | `idx_status_lists_list_id` | `list_id` |
 | `idx_status_lists_issuer`  | `issuer`  |
 | `idx_status_lists_sub`     | `sub`     |

--- a/src/database/README.md
+++ b/src/database/README.md
@@ -1,15 +1,12 @@
 # Database Overview
 
-This document provides an overview of the database schema, including its tables,
-columns, indexes, and the relationships between them. The schema is defined by the
-SeaORM migrations in [`mod.rs`](./mod.rs) and the entity models in [`../models.rs`](../models.rs).
+This document provides an overview of the database schema, including its tables and columns.
 
 ## Tables
 
 ### `credentials`
 
-Stores information about issuers and their cryptographic public keys. Each issuer is
-identified by its `issuer` value, which acts as the primary key.
+Stores information about issuers and their cryptographic public keys.
 
 | Column       | Type  | Null | Key | Description                           |
 | ------------ | ----- | ---- | --- | ------------------------------------- |
@@ -54,11 +51,3 @@ erDiagram
     }
     credentials ||--|{ status_lists : "issuer (ON DELETE CASCADE, ON UPDATE CASCADE)"
 ```
-
-## Notes
-
-- Neither table has an auto-incrementing `id` column. The primary keys are the
-  natural keys `credentials.issuer` and `status_lists.list_id`, matching the
-  SeaORM migrations.
-- `status_lists.issuer` references `credentials.issuer` via the
-  `fk_status_lists_issuer` foreign key, which cascades on both delete and update.

--- a/src/database/README.md
+++ b/src/database/README.md
@@ -1,27 +1,64 @@
 # Database Overview
 
-This document provides an overview of the database schema, including its tables and columns.
+This document provides an overview of the database schema, including its tables,
+columns, indexes, and the relationships between them. The schema is defined by the
+SeaORM migrations in [`mod.rs`](./mod.rs) and the entity models in [`../models.rs`](../models.rs).
 
 ## Tables
 
 ### `credentials`
 
-Stores information about issuers and their cryptographic public keys.
+Stores information about issuers and their cryptographic public keys. Each issuer is
+identified by its `issuer` value, which acts as the primary key.
 
-| Column       | Type   | Description                                 |
-| ------------ | ------ | ------------------------------------------- |
-| `id`         | SERIAL | Auto-incrementing primary key               |
-| `issuer`     | TEXT   | Unique identifier for the issuer            |
-| `public_key` | JSONB  | Public key associated with the issuer       |
+| Column       | Type | Null | Key | Description                           |
+| ------------ | ---- | ---- | --- | ------------------------------------- |
+| `issuer`     | TEXT | NO   | PK  | Unique identifier for the issuer     |
+| `public_key` | JSON | NO   |     | Public key associated with the issuer |
 
 ### `status_lists`
 
-Stores information about status lists entries and their associated issuer.
+Stores status list entries and their associated issuer. Each status list is identified
+by its `list_id`, which acts as the primary key.
 
-| Column        | Type   | Description                                        |
-| ------------- | ------ | -------------------------------------------------- |
-| `id`          | SERIAL | Auto-incrementing primary key                      |
-| `list_id`     | TEXT   | Unique identifier for the status list              |
-| `issuer`      | TEXT   | Unique identifier for the issuer                   |
-| `status_list` | JSONB  | status list entry                                  |
-| `sub`         | TEXT   | Unique string identifier for the Status List Token |
+| Column        | Type | Null | Key | Description                                        |
+| ------------- | ---- | ---- | --- | -------------------------------------------------- |
+| `list_id`     | TEXT | NO   | PK  | Unique identifier for the status list              |
+| `issuer`      | TEXT | NO   | FK  | References `credentials.issuer` (ON DELETE CASCADE) |
+| `status_list` | JSON | NO   |     | The status list entry                              |
+| `sub`         | TEXT | NO   |     | Unique string identifier for the Status List Token |
+
+#### Indexes
+
+The following indexes are created on the `status_lists` table to speed up lookups:
+
+| Index name               | Column    |
+| ------------------------ | --------- |
+| `idx_status_lists_list_id` | `list_id` |
+| `idx_status_lists_issuer`  | `issuer`  |
+| `idx_status_lists_sub`     | `sub`     |
+
+## Entity Relationship Diagram
+
+```mermaid
+erDiagram
+    credentials {
+        TEXT issuer PK "Unique identifier for the issuer"
+        JSON public_key "Public key associated with the issuer"
+    }
+    status_lists {
+        TEXT list_id PK "Unique identifier for the status list"
+        TEXT issuer FK "References credentials.issuer"
+        JSON status_list "The status list entry"
+        TEXT sub "Status List Token identifier"
+    }
+    credentials ||--o{ status_lists : "issuer (ON DELETE CASCADE, ON UPDATE CASCADE)"
+```
+
+## Notes
+
+- Neither table has an auto-incrementing `id` column. The primary keys are the
+  natural keys `credentials.issuer` and `status_lists.list_id`, matching the
+  SeaORM migrations.
+- `status_lists.issuer` references `credentials.issuer` via the
+  `fk_status_lists_issuer` foreign key, which cascades on both delete and update.

--- a/src/database/README.md
+++ b/src/database/README.md
@@ -14,7 +14,7 @@ identified by its `issuer` value, which acts as the primary key.
 | Column       | Type | Null | Key | Description                           |
 |--------------|------|------|-----|---------------------------------------|
 | `issuer`     | TEXT | NO   | PK  | Unique identifier for the issuer      |
-| `public_key` | JSON | NO   |     | Public key associated with the issuer |
+| `public_key` | JSONB | NO   |     | Public key associated with the issuer |
 
 ### `status_lists`
 
@@ -25,8 +25,8 @@ by its `list_id`, which acts as the primary key.
 |---------------|------|------|-----|-----------------------------------------------------|
 | `list_id`     | TEXT | NO   | PK  | Unique identifier for the status list               |
 | `issuer`      | TEXT | NO   | FK  | References `credentials.issuer` (ON DELETE CASCADE) |
-| `status_list` | JSON | NO   |     | The status list entry                               |
-| `sub`         | TEXT | NO   |     | Unique string identifier for the Status List Token  |
+| `status_list` | JSONB | NO   |     | The status list entry                               |
+| `sub`         | TEXT | NO   |     | String identifier for the Status List Token         |
 
 #### Indexes
 
@@ -44,15 +44,15 @@ The following indexes are created on the `status_lists` table to speed up lookup
 erDiagram
     credentials {
         TEXT issuer PK "Unique identifier for the issuer"
-        JSON public_key "Public key associated with the issuer"
+        JSONB public_key "Public key associated with the issuer"
     }
     status_lists {
         TEXT list_id PK "Unique identifier for the status list"
         TEXT issuer FK "References credentials.issuer"
-        JSON status_list "The status list entry"
-        TEXT sub "Status List Token identifier"
+        JSONB status_list "The status list entry"
+        TEXT sub "String identifier for the Status List Token"
     }
-    credentials ||--o{ status_lists : "issuer (ON DELETE CASCADE, ON UPDATE CASCADE)"
+    credentials ||--|{ status_lists : "issuer (ON DELETE CASCADE, ON UPDATE CASCADE)"
 ```
 
 ## Notes

--- a/src/database/README.md
+++ b/src/database/README.md
@@ -12,8 +12,8 @@ Stores information about issuers and their cryptographic public keys. Each issue
 identified by its `issuer` value, which acts as the primary key.
 
 | Column       | Type | Null | Key | Description                           |
-| ------------ | ---- | ---- | --- | ------------------------------------- |
-| `issuer`     | TEXT | NO   | PK  | Unique identifier for the issuer     |
+|--------------|------|------|-----|---------------------------------------|
+| `issuer`     | TEXT | NO   | PK  | Unique identifier for the issuer      |
 | `public_key` | JSON | NO   |     | Public key associated with the issuer |
 
 ### `status_lists`
@@ -21,19 +21,19 @@ identified by its `issuer` value, which acts as the primary key.
 Stores status list entries and their associated issuer. Each status list is identified
 by its `list_id`, which acts as the primary key.
 
-| Column        | Type | Null | Key | Description                                        |
-| ------------- | ---- | ---- | --- | -------------------------------------------------- |
-| `list_id`     | TEXT | NO   | PK  | Unique identifier for the status list              |
+| Column        | Type | Null | Key | Description                                         |
+|---------------|------|------|-----|-----------------------------------------------------|
+| `list_id`     | TEXT | NO   | PK  | Unique identifier for the status list               |
 | `issuer`      | TEXT | NO   | FK  | References `credentials.issuer` (ON DELETE CASCADE) |
-| `status_list` | JSON | NO   |     | The status list entry                              |
-| `sub`         | TEXT | NO   |     | Unique string identifier for the Status List Token |
+| `status_list` | JSON | NO   |     | The status list entry                               |
+| `sub`         | TEXT | NO   |     | Unique string identifier for the Status List Token  |
 
 #### Indexes
 
 The following indexes are created on the `status_lists` table to speed up lookups:
 
-| Index name               | Column    |
-| ------------------------ | --------- |
+| Index name                 | Column    |
+|----------------------------|-----------|
 | `idx_status_lists_list_id` | `list_id` |
 | `idx_status_lists_issuer`  | `issuer`  |
 | `idx_status_lists_sub`     | `sub`     |


### PR DESCRIPTION
Fix `src/database/README.md` etc to reflect actual primary keys (`issuer` and `list_id`), not `id SERIAL`.