### PR TITLE
Allingning the data model documentation with SeaORM migrations for cl…

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -14,8 +14,10 @@ info:
     (`application/problem+json`). This is the canonical error format intended
     for the API; individual endpoints may migrate to this format over time.
 
-    Status list tokens are signed by the server and delivered gzip-compressed
-    via `application/statuslist+jwt` or `application/statuslist+cwt`.
+    Status list tokens are signed by the server and delivered as
+    `application/statuslist+jwt` or `application/statuslist+cwt`. JWT-format
+    tokens are gzip-compressed only when the client requests it via
+    `Accept-Encoding: gzip`; CWT-format tokens are never compressed.
   contact:
     name: adorsys Status List Server
     url: https://github.com/adorsys/status-list-server
@@ -192,9 +194,14 @@ paths:
       operationId: getStatusList
       summary: Retrieve a status list token
       description: |
-        Returns the status list token for the requested `list_id`. The response
-        is gzip-compressed and encoded as a JWT or CWT depending on the
-        `Accept` header.
+        Returns the status list token for the requested `list_id`, encoded as a
+        JWT or CWT depending on the `Accept` header.
+
+        JWT-format responses are gzip-compressed (`Content-Encoding: gzip`)
+        only when the client has advertised support via `Accept-Encoding: gzip`
+        (see draft-ietf-oauth-status-list-21 §8.2). CWT-format responses are
+        never gzip-compressed. Because the representation varies by
+        `Accept-Encoding`, every response carries `Vary: Accept-Encoding`.
 
         The decoded token conforms to the
         [OAuth Status List](https://datatracker.ietf.org/doc/draft-ietf-oauth-status-list/)
@@ -222,6 +229,17 @@ paths:
               - application/statuslist+jwt
               - application/statuslist+cwt
             default: application/statuslist+jwt
+        - name: Accept-Encoding
+          in: header
+          required: false
+          description: |
+            Content codings the client is willing to accept. When `gzip` is
+            advertised (default q-value), JWT-format responses are
+            gzip-compressed and carry `Content-Encoding: gzip`. CWT-format
+            responses are never compressed regardless of this header.
+          schema:
+            type: string
+            example: gzip
       responses:
         "200":
           description: |
@@ -237,13 +255,31 @@ paths:
               schema:
                 type: string
                 format: binary
-              example: "H4sIAAAAAAAAE6tW..."
+              description: |
+                Raw COSE_Sign1_Tagged CBOR bytes (CBOR tag 18). Never
+                gzip-compressed regardless of the request's `Accept-Encoding`.
+              example: "0gEAAQ..."
           headers:
             Content-Encoding:
               schema:
                 type: string
-              description: Always `gzip`.
+              description: |
+                Present with value `gzip` only when the response body has been
+                gzip-compressed. Compression is applied to JWT-format tokens
+                (`application/statuslist+jwt`) exclusively, and only when the
+                client has advertised support for it via an
+                `Accept-Encoding: gzip` request header. CWT-format tokens are
+                never compressed. Absent otherwise.
               example: gzip
+            Vary:
+              schema:
+                type: string
+              description: |
+                Always `Accept-Encoding`. Because the response body varies by
+                the request's `Accept-Encoding` header, this is required so
+                that shared caches/CDNs do not serve a gzipped variant to a
+                client that did not request one (RFC 9111 §4.2).
+              example: Accept-Encoding
         "404":
           $ref: "#/components/responses/NotFound"
         "406":
@@ -383,10 +419,11 @@ components:
       type: object
       description: |
         Decoded payload of a JWT or CWT status list token. The actual response
-        from `GET /statuslists/{list_id}` is the signed, gzip-compressed token
-        string. The token is signed by the server using the configured signing
-        key and contains the certificate chain in the `x5c` header (JWT) or
-        protected header (CWT).
+        from `GET /statuslists/{list_id}` is the signed token — a JWT string
+        (optionally gzip-compressed when the client requests it) or raw
+        COSE_Sign1_Tagged CBOR bytes for CWT. The token is signed by the server
+        using the configured signing key and contains the certificate chain in
+        the `x5c` header (JWT) or protected header (CWT).
       required:
         - sub
         - iat

--- a/src/web/handlers/status_list/get_status_list.rs
+++ b/src/web/handlers/status_list/get_status_list.rs
@@ -60,34 +60,55 @@ pub async fn get_status_list(
     }
 }
 
-/// Parses the request's `Accept-Encoding` header (RFC 9110 content negotiation)
-/// and reports whether the client has advertised support for gzip.
+/// Parses the request's `Accept-Encoding` header(s) (RFC 9110 content
+/// negotiation) and reports whether the client has advertised support for
+/// gzip.
 ///
 /// Returns `false` when the header is absent, so responses are only compressed
 /// when the client has explicitly opted in (see draft-21 §8.2).
+///
+/// Per RFC 9110 §12.5.3, an explicitly-named coding takes precedence over the
+/// `*` wildcard. This means `gzip;q=0, *` is treated as "anything but gzip"
+/// — the explicit `q=0` disables gzip even though the wildcard alone would
+/// accept it.
+///
+/// Multiple `Accept-Encoding` field lines are combined as if comma-separated
+/// (RFC 9110 §5.3), so all header lines are inspected via `get_all`.
 fn client_accepts_gzip(headers: &HeaderMap) -> bool {
-    headers
-        .get(header::ACCEPT_ENCODING)
-        .and_then(|h| h.to_str().ok())
-        .is_some_and(|val| {
-            val.split(',')
-                .map(|s| {
-                    let s = s.trim();
-                    let (coding, params) = s
-                        .split_once(';')
-                        .map(|(c, p)| (c.trim(), p.trim()))
-                        .unwrap_or((s, ""));
-                    let q = params
-                        .split(';')
-                        .find_map(|p| p.trim().strip_prefix("q=").map(|q| q.trim()))
-                        .and_then(|q| q.parse::<f32>().ok());
-                    (coding, q)
-                })
-                .any(|(coding, q)| {
-                    (coding.eq_ignore_ascii_case("gzip") || coding == "*")
-                        && (q.is_none() || q > Some(0.0))
-                })
-        })
+    let mut entries: Vec<(&str, Option<f32>)> = Vec::new();
+    for val in headers.get_all(header::ACCEPT_ENCODING) {
+        let Ok(val) = val.to_str() else { continue };
+        for s in val.split(',') {
+            let s = s.trim();
+            if s.is_empty() {
+                continue;
+            }
+            let (coding, params) = s
+                .split_once(';')
+                .map(|(c, p)| (c.trim(), p.trim()))
+                .unwrap_or((s, ""));
+            let q = params
+                .split(';')
+                .find_map(|p| p.trim().strip_prefix("q=").map(|q| q.trim()))
+                .and_then(|q| q.parse::<f32>().ok());
+            entries.push((coding, q));
+        }
+    }
+
+    match entries
+        .iter()
+        .find(|(c, _)| c.eq_ignore_ascii_case("gzip"))
+        .map(|(_, q)| *q)
+    {
+        // gzip explicitly named with no q -> default weight 1.0 -> accept
+        Some(None) => true,
+        // gzip;q=v -> accept only if v > 0
+        Some(Some(q)) => q > 0.0,
+        // gzip not named: consult the * wildcard only
+        None => entries.iter().any(|(c, q)| {
+            c.eq_ignore_ascii_case("*") && (q.is_none() || q.map(|v| v > 0.0).unwrap_or(false))
+        }),
+    }
 }
 
 async fn build_status_list_token(
@@ -212,12 +233,21 @@ async fn build_response_from_record(
             [
                 (header::CONTENT_TYPE, accept),
                 (header::CONTENT_ENCODING, GZIP_HEADER),
+                (header::VARY, "Accept-Encoding"),
             ],
             body,
         )
             .into_response()
     } else {
-        (StatusCode::OK, [(header::CONTENT_TYPE, accept)], body).into_response()
+        (
+            StatusCode::OK,
+            [
+                (header::CONTENT_TYPE, accept),
+                (header::VARY, "Accept-Encoding"),
+            ],
+            body,
+        )
+            .into_response()
     };
 
     Ok(response)
@@ -454,6 +484,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         let headers = response.headers();
         assert_eq!(headers.get(http::header::CONTENT_ENCODING).unwrap(), "gzip");
+        assert_eq!(headers.get(http::header::VARY).unwrap(), "Accept-Encoding");
 
         let compressed_body_bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
         let mut decoder = flate2::read::GzDecoder::new(&compressed_body_bytes[..]);
@@ -531,6 +562,8 @@ mod tests {
             headers.get(http::header::CONTENT_ENCODING).is_none(),
             "Content-Encoding must not be present when gzip was not applied"
         );
+        // Vary must be present even without gzip so caches key on Accept-Encoding.
+        assert_eq!(headers.get(http::header::VARY).unwrap(), "Accept-Encoding");
 
         let body_bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
         let body_str = std::str::from_utf8(&body_bytes).unwrap();
@@ -604,6 +637,7 @@ mod tests {
             headers.get(http::header::CONTENT_ENCODING).is_none(),
             "CWT responses must never be gzipped"
         );
+        assert_eq!(headers.get(http::header::VARY).unwrap(), "Accept-Encoding");
 
         let body_bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
 
@@ -728,6 +762,7 @@ mod tests {
             http::header::ACCEPT,
             ACCEPT_STATUS_LISTS_HEADER_JWT.parse().unwrap(),
         );
+        headers.insert(http::header::ACCEPT_ENCODING, "gzip".parse().unwrap());
 
         let response = get_status_list(
             State(app_state.clone()),
@@ -739,6 +774,9 @@ mod tests {
         .into_response();
 
         assert_eq!(response.status(), StatusCode::OK);
+        let headers = response.headers();
+        assert_eq!(headers.get(http::header::CONTENT_ENCODING).unwrap(), "gzip");
+        assert_eq!(headers.get(http::header::VARY).unwrap(), "Accept-Encoding");
         let compressed = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
         let mut decoder = flate2::read::GzDecoder::new(&compressed[..]);
         let mut body = Vec::new();
@@ -798,11 +836,14 @@ mod tests {
         .into_response();
 
         assert_eq!(response.status(), StatusCode::OK);
-        let compressed = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
-        let mut decoder = flate2::read::GzDecoder::new(&compressed[..]);
-        let mut body = Vec::new();
-        decoder.read_to_end(&mut body).unwrap();
-        let body_str = std::str::from_utf8(&body).unwrap();
+        let headers = response.headers();
+        assert!(
+            headers.get(http::header::CONTENT_ENCODING).is_none(),
+            "no gzip without Accept-Encoding"
+        );
+        assert_eq!(headers.get(http::header::VARY).unwrap(), "Accept-Encoding");
+        let raw = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        let body_str = std::str::from_utf8(&raw).unwrap();
 
         let signing_key_pem = app_state.cert_manager.signing_key_pem().await.unwrap();
         let keypair = Keypair::from_pkcs8_pem(&signing_key_pem).unwrap();
@@ -857,10 +898,13 @@ mod tests {
         .into_response();
 
         assert_eq!(response.status(), StatusCode::OK);
-        let compressed = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
-        let mut decoder = flate2::read::GzDecoder::new(&compressed[..]);
-        let mut body = Vec::new();
-        decoder.read_to_end(&mut body).unwrap();
+        let headers = response.headers();
+        assert!(
+            headers.get(http::header::CONTENT_ENCODING).is_none(),
+            "CWT responses must never be gzipped"
+        );
+        assert_eq!(headers.get(http::header::VARY).unwrap(), "Accept-Encoding");
+        let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
 
         let cwt = CoseSign1::from_tagged_slice(&body).unwrap();
 
@@ -936,10 +980,13 @@ mod tests {
         .into_response();
 
         assert_eq!(response.status(), StatusCode::OK);
-        let compressed = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
-        let mut decoder = flate2::read::GzDecoder::new(&compressed[..]);
-        let mut body = Vec::new();
-        decoder.read_to_end(&mut body).unwrap();
+        let headers = response.headers();
+        assert!(
+            headers.get(http::header::CONTENT_ENCODING).is_none(),
+            "CWT responses must never be gzipped"
+        );
+        assert_eq!(headers.get(http::header::VARY).unwrap(), "Accept-Encoding");
+        let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
 
         let cwt = CoseSign1::from_tagged_slice(&body).unwrap();
 
@@ -1022,5 +1069,99 @@ mod tests {
             StatusCode::NOT_ACCEPTABLE
         );
         assert_eq!(err, StatusListError::InvalidAcceptHeader);
+    }
+
+    // --- client_accepts_gzip: RFC 9110 §12.5.3 wildcard precedence ---
+
+    #[test]
+    fn test_accepts_gzip_simple() {
+        let mut h = HeaderMap::new();
+        h.insert(header::ACCEPT_ENCODING, "gzip".parse().unwrap());
+        assert!(client_accepts_gzip(&h));
+    }
+
+    #[test]
+    fn test_accepts_gzip_with_qvalue() {
+        let mut h = HeaderMap::new();
+        h.insert(header::ACCEPT_ENCODING, "gzip;q=0.5".parse().unwrap());
+        assert!(client_accepts_gzip(&h));
+    }
+
+    #[test]
+    fn test_rejects_gzip_q0() {
+        let mut h = HeaderMap::new();
+        h.insert(header::ACCEPT_ENCODING, "gzip;q=0".parse().unwrap());
+        assert!(!client_accepts_gzip(&h));
+    }
+
+    #[test]
+    fn test_rejects_gzip_q0_with_wildcard_accept() {
+        // "gzip;q=0, *" means "anything except gzip" → must NOT gzip.
+        let mut h = HeaderMap::new();
+        h.insert(header::ACCEPT_ENCODING, "gzip;q=0, *".parse().unwrap());
+        assert!(!client_accepts_gzip(&h));
+    }
+
+    #[test]
+    fn test_accepts_via_wildcard_only() {
+        // gzip not named, only * → wildcard accepts gzip.
+        let mut h = HeaderMap::new();
+        h.insert(header::ACCEPT_ENCODING, "*".parse().unwrap());
+        assert!(client_accepts_gzip(&h));
+    }
+
+    #[test]
+    fn test_accepts_via_wildcard_q1() {
+        let mut h = HeaderMap::new();
+        h.insert(header::ACCEPT_ENCODING, "*;q=1".parse().unwrap());
+        assert!(client_accepts_gzip(&h));
+    }
+
+    #[test]
+    fn test_rejects_wildcard_q0() {
+        let mut h = HeaderMap::new();
+        h.insert(header::ACCEPT_ENCODING, "*;q=0".parse().unwrap());
+        assert!(!client_accepts_gzip(&h));
+    }
+
+    #[test]
+    fn test_rejects_identity_q0_gzip_q0() {
+        // identity;q=0, gzip;q=0 → gzip explicitly disabled.
+        let mut h = HeaderMap::new();
+        h.insert(
+            header::ACCEPT_ENCODING,
+            "identity;q=0, gzip;q=0".parse().unwrap(),
+        );
+        assert!(!client_accepts_gzip(&h));
+    }
+
+    #[test]
+    fn test_rejects_when_header_absent() {
+        let h = HeaderMap::new();
+        assert!(!client_accepts_gzip(&h));
+    }
+
+    #[test]
+    fn test_multiple_accept_encoding_lines() {
+        // RFC 9110 §5.3: multiple field lines are combined as comma-separated.
+        let mut h = HeaderMap::new();
+        h.append(header::ACCEPT_ENCODING, "deflate".parse().unwrap());
+        h.append(header::ACCEPT_ENCODING, "gzip".parse().unwrap());
+        assert!(client_accepts_gzip(&h));
+    }
+
+    #[test]
+    fn test_multiple_lines_explicit_gzip_q0_blocks_wildcard() {
+        let mut h = HeaderMap::new();
+        h.append(header::ACCEPT_ENCODING, "gzip;q=0".parse().unwrap());
+        h.append(header::ACCEPT_ENCODING, "*".parse().unwrap());
+        assert!(!client_accepts_gzip(&h));
+    }
+
+    #[test]
+    fn test_case_insensitive_gzip() {
+        let mut h = HeaderMap::new();
+        h.insert(header::ACCEPT_ENCODING, "GZIP".parse().unwrap());
+        assert!(client_accepts_gzip(&h));
     }
 }

--- a/src/web/handlers/status_list/get_status_list.rs
+++ b/src/web/handlers/status_list/get_status_list.rs
@@ -35,34 +35,73 @@ pub async fn get_status_list(
     headers: HeaderMap,
 ) -> Result<impl IntoResponse + Debug + use<>, StatusListError> {
     let accept = headers.get(header::ACCEPT).and_then(|h| h.to_str().ok());
+    let client_accepts_gzip = client_accepts_gzip(&headers);
 
     // build the token depending on the accept header
     match accept {
         None =>
         // assume jwt by default if no accept header is provided
         {
-            build_status_list_token(ACCEPT_STATUS_LISTS_HEADER_JWT, &list_id, &state).await
+            build_status_list_token(
+                ACCEPT_STATUS_LISTS_HEADER_JWT,
+                &list_id,
+                &state,
+                client_accepts_gzip,
+            )
+            .await
         }
         Some(accept)
             if accept == ACCEPT_STATUS_LISTS_HEADER_JWT
                 || accept == ACCEPT_STATUS_LISTS_HEADER_CWT =>
         {
-            build_status_list_token(accept, &list_id, &state).await
+            build_status_list_token(accept, &list_id, &state, client_accepts_gzip).await
         }
         Some(_) => Err(StatusListError::InvalidAcceptHeader),
     }
+}
+
+/// Parses the request's `Accept-Encoding` header (RFC 9110 content negotiation)
+/// and reports whether the client has advertised support for gzip.
+///
+/// Returns `false` when the header is absent, so responses are only compressed
+/// when the client has explicitly opted in (see draft-21 §8.2).
+fn client_accepts_gzip(headers: &HeaderMap) -> bool {
+    headers
+        .get(header::ACCEPT_ENCODING)
+        .and_then(|h| h.to_str().ok())
+        .is_some_and(|val| {
+            val.split(',')
+                .map(|s| {
+                    let s = s.trim();
+                    let (coding, params) = s
+                        .split_once(';')
+                        .map(|(c, p)| (c.trim(), p.trim()))
+                        .unwrap_or((s, ""));
+                    let q = params
+                        .split(';')
+                        .find_map(|p| p.trim().strip_prefix("q=").map(|q| q.trim()))
+                        .and_then(|q| q.parse::<f32>().ok());
+                    (coding, q)
+                })
+                .any(|(coding, q)| {
+                    (coding.eq_ignore_ascii_case("gzip") || coding == "*")
+                        && (q.is_none() || q > Some(0.0))
+                })
+        })
 }
 
 async fn build_status_list_token(
     accept: &str,
     list_id: &str,
     state: &AppState,
+    client_accepts_gzip: bool,
 ) -> Result<impl IntoResponse + Debug + use<>, StatusListError> {
     // Check cache for status list record
     if let Some(cached_record) = state.cache.get(list_id).await {
         tracing::info!("Cache hit for status list record: {list_id}");
         // Record is in cache, proceed with building the response
-        return build_response_from_record(accept, &cached_record, state).await;
+        return build_response_from_record(accept, &cached_record, state, client_accepts_gzip)
+            .await;
     }
 
     tracing::info!("Cache miss for status list token: {list_id}");
@@ -83,13 +122,14 @@ async fn build_status_list_token(
         .insert(list_id.to_string(), status_record.clone())
         .await;
 
-    build_response_from_record(accept, &status_record, state).await
+    build_response_from_record(accept, &status_record, state, client_accepts_gzip).await
 }
 
 async fn build_response_from_record(
     accept: &str,
     status_record: &StatusListRecord,
     state: &AppState,
+    client_accepts_gzip: bool,
 ) -> Result<impl IntoResponse + Debug + use<>, StatusListError> {
     // Get the certificate chain
     let certs_parts = state
@@ -117,7 +157,9 @@ async fn build_response_from_record(
     let token_exp_secs = state.token_exp_secs;
     let token_ttl_secs = state.token_ttl_secs;
 
-    let compressed_token = tokio::task::spawn_blocking(move || {
+    let should_gzip = client_accepts_gzip && accept_header == ACCEPT_STATUS_LISTS_HEADER_JWT;
+
+    let (body, gzipped) = tokio::task::spawn_blocking(move || {
         let keypair = Keypair::from_pkcs8_pem(&signing_key_pem).map_err(|e| {
             tracing::error!("Failed to parse server key: {e:?}");
             StatusListError::InternalServerError
@@ -143,16 +185,20 @@ async fn build_response_from_record(
             .into_bytes(),
         };
 
-        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
-        encoder.write_all(&token_bytes).map_err(|err| {
-            tracing::error!("Failed to compress payload: {err:?}");
-            StatusListError::InternalServerError
-        })?;
-
-        encoder.finish().map_err(|err| {
-            tracing::error!("Failed to finish compression: {err:?}");
-            StatusListError::InternalServerError
-        })
+        if should_gzip {
+            let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+            encoder.write_all(&token_bytes).map_err(|err| {
+                tracing::error!("Failed to compress payload: {err:?}");
+                StatusListError::InternalServerError
+            })?;
+            let compressed = encoder.finish().map_err(|err| {
+                tracing::error!("Failed to finish compression: {err:?}");
+                StatusListError::InternalServerError
+            })?;
+            Ok::<(Vec<u8>, bool), StatusListError>((compressed, true))
+        } else {
+            Ok((token_bytes, false))
+        }
     })
     .await
     .map_err(|err| {
@@ -160,15 +206,21 @@ async fn build_response_from_record(
         StatusListError::InternalServerError
     })??;
 
-    Ok((
-        StatusCode::OK,
-        [
-            (header::CONTENT_TYPE, accept),
-            (header::CONTENT_ENCODING, GZIP_HEADER),
-        ],
-        compressed_token,
-    )
-        .into_response())
+    let response = if gzipped {
+        (
+            StatusCode::OK,
+            [
+                (header::CONTENT_TYPE, accept),
+                (header::CONTENT_ENCODING, GZIP_HEADER),
+            ],
+            body,
+        )
+            .into_response()
+    } else {
+        (StatusCode::OK, [(header::CONTENT_TYPE, accept)], body).into_response()
+    };
+
+    Ok(response)
 }
 
 // Function to create a CWT per the specification
@@ -388,6 +440,7 @@ mod tests {
             http::header::ACCEPT,
             ACCEPT_STATUS_LISTS_HEADER_JWT.parse().unwrap(),
         );
+        headers.insert(http::header::ACCEPT_ENCODING, "gzip".parse().unwrap());
 
         let response = get_status_list(
             State(app_state.clone()),
@@ -434,6 +487,76 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_get_status_list_jwt_no_gzip_when_client_does_not_accept() {
+        let mock_db = MockDatabase::new(DatabaseBackend::Postgres);
+        let status_list = StatusList {
+            bits: 8,
+            lst: encode_compressed(&[0, 0, 0]).unwrap(),
+        };
+        let status_list_token = StatusListRecord {
+            list_id: "test_list".to_string(),
+            issuer: "issuer1".to_string(),
+            status_list,
+            sub: "test_subject".to_string(),
+        };
+        let db_conn = Arc::new(
+            mock_db
+                .append_query_results::<status_lists::Model, Vec<_>, _>(vec![vec![
+                    status_list_token,
+                ]])
+                .into_connection(),
+        );
+
+        let app_state = test_app_state(Some(db_conn.clone())).await;
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            http::header::ACCEPT,
+            ACCEPT_STATUS_LISTS_HEADER_JWT.parse().unwrap(),
+        );
+        // No Accept-Encoding header: the client did not advertise gzip support.
+
+        let response = get_status_list(
+            State(app_state.clone()),
+            Path("test_list".to_string()),
+            headers,
+        )
+        .await
+        .unwrap()
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let headers = response.headers();
+        assert!(
+            headers.get(http::header::CONTENT_ENCODING).is_none(),
+            "Content-Encoding must not be present when gzip was not applied"
+        );
+
+        let body_bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        let body_str = std::str::from_utf8(&body_bytes).unwrap();
+
+        let signing_key_pem = app_state.cert_manager.signing_key_pem().await.unwrap();
+        let keypair = Keypair::from_pkcs8_pem(&signing_key_pem).unwrap();
+        let decoding_key_pem = keypair
+            .verifying_key()
+            .to_public_key_pem(LineEnding::default())
+            .unwrap()
+            .into_bytes();
+        let decoding_key = DecodingKey::from_ec_pem(&decoding_key_pem).unwrap();
+        let mut validation = Validation::new(jsonwebtoken::Algorithm::ES256);
+        validation.validate_exp = false;
+        let token_data =
+            jsonwebtoken::decode::<StatusListToken>(body_str, &decoding_key, &validation).unwrap();
+
+        assert_eq!(token_data.claims.sub, "test_subject");
+        assert_eq!(token_data.claims.status_list.bits, 8);
+        assert_eq!(
+            token_data.claims.status_list.lst,
+            encode_compressed(&[0, 0, 0]).unwrap()
+        );
+    }
+
+    #[tokio::test]
     async fn test_get_status_list_success_cwt() {
         let mock_db = MockDatabase::new(DatabaseBackend::Postgres);
         let status_list = StatusList {
@@ -461,6 +584,10 @@ mod tests {
             http::header::ACCEPT,
             ACCEPT_STATUS_LISTS_HEADER_CWT.parse().unwrap(),
         );
+        // Even though the client advertises gzip support, CWT responses must
+        // never be gzipped (draft-21 §8.2 recommends Content-Encoding only for
+        // JWT-format tokens).
+        headers.insert(http::header::ACCEPT_ENCODING, "gzip".parse().unwrap());
 
         let response = get_status_list(
             State(app_state.clone()),
@@ -473,12 +600,12 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::OK);
         let headers = response.headers();
-        assert_eq!(headers.get(http::header::CONTENT_ENCODING).unwrap(), "gzip");
+        assert!(
+            headers.get(http::header::CONTENT_ENCODING).is_none(),
+            "CWT responses must never be gzipped"
+        );
 
-        let compressed_body_bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
-        let mut decoder = flate2::read::GzDecoder::new(&compressed_body_bytes[..]);
-        let mut body_bytes = Vec::new();
-        decoder.read_to_end(&mut body_bytes).unwrap();
+        let body_bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
 
         // Tagged decode: the CWT MUST be COSE_Sign1_Tagged (CBOR tag 18) per §5.2.
         let cwt = CoseSign1::from_tagged_slice(&body_bytes).unwrap();


### PR DESCRIPTION
Here's a PR description:

---

## Respect Accept-Encoding and stop double-compressing CWT responses (draft-21 §8.2)

Closes #185

### Problem

The status-list endpoint unconditionally gzipped every response, regardless of:
1. Whether the client advertised gzip support via `Accept-Encoding` (violating RFC 9110 content negotiation)
2. The response format — CWT responses were gzipped despite draft-21 §8.2 scoping the `Content-Encoding` recommendation to JWT-format tokens only

### Changes

- **Gate gzip on `Accept-Encoding`**: Added a `client_accepts_gzip` helper that parses the `Accept-Encoding` header per RFC 9110, respecting `q=0` values and recognizing both `gzip` and `*` codings. Responses are only compressed when the client has explicitly opted in.
- **Skip gzip for CWT**: Gzip is now only applied to `application/statuslist+jwt` responses. CWT responses are returned uncompressed, since the embedded `lst` is already zlib-compressed — wrapping it in gzip wastes CPU for negligible size reduction.
- **Accurate `Content-Encoding` header**: The `Content-Encoding: gzip` header is only set when gzip was actually applied; it is omitted entirely for uncompressed responses.

### Tests

- `test_get_status_list_jwt_success` — JWT + `Accept-Encoding: gzip` → response is gzipped with `Content-Encoding: gzip`
- `test_get_status_list_jwt_no_gzip_when_client_does_not_accept` — JWT, no `Accept-Encoding` → response is not gzipped, no `Content-Encoding` header
- `test_get_status_list_success_cwt` — CWT + `Accept-Encoding: gzip` → response is never gzipped, no `Content-Encoding` header

### References

- draft-ietf-oauth-status-list-21 §8.2
- RFC 9110 (content negotiation)
- Compliance matrix row 17