### PR TITLE
feat: implement historical resolution

### DIFF
--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -75,6 +75,56 @@ pub mod migrations {
                     )
                     .await?;
 
+                // Create StatusListSnapshots table for storing historical versions
+                manager
+                    .create_table(
+                        Table::create()
+                            .table(StatusListSnapshots::Table)
+                            .if_not_exists()
+                            .col(
+                                ColumnDef::new(StatusListSnapshots::Id)
+                                    .integer()
+                                    .not_null()
+                                    .auto_increment()
+                                    .primary_key(),
+                            )
+                            .col(
+                                ColumnDef::new(StatusListSnapshots::ListId)
+                                    .string()
+                                    .not_null(),
+                            )
+                            .col(
+                                ColumnDef::new(StatusListSnapshots::Issuer)
+                                    .string()
+                                    .not_null(),
+                            )
+                            .col(
+                                ColumnDef::new(StatusListSnapshots::StatusList)
+                                    .json()
+                                    .not_null(),
+                            )
+                            .col(
+                                ColumnDef::new(StatusListSnapshots::Sub)
+                                    .string()
+                                    .not_null(),
+                            )
+                            .col(
+                                ColumnDef::new(StatusListSnapshots::CreatedAt)
+                                    .big_integer()
+                                    .not_null(),
+                            )
+                            .foreign_key(
+                                ForeignKey::create()
+                                    .name("fk_snapshots_list_id")
+                                    .from(StatusListSnapshots::Table, StatusListSnapshots::ListId)
+                                    .to(StatusLists::Table, StatusLists::ListId)
+                                    .on_delete(ForeignKeyAction::Cascade)
+                                    .on_update(ForeignKeyAction::Cascade),
+                            )
+                            .to_owned(),
+                    )
+                    .await?;
+
                 // Create an index on list_id for faster lookups
                 manager
                     .create_index(
@@ -111,12 +161,35 @@ pub mod migrations {
                     )
                     .await?;
 
+                // Create index on list_id for faster snapshot lookups
+                manager
+                    .create_index(
+                        Index::create()
+                            .if_not_exists()
+                            .name("idx_snapshots_list_id_created_at")
+                            .table(StatusListSnapshots::Table)
+                            .col(StatusListSnapshots::ListId)
+                            .col(StatusListSnapshots::CreatedAt)
+                            .to_owned(),
+                    )
+                    .await?;
+
                 Ok(())
             }
 
             /// Drops the database tables
             async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
                 // Drop indexes first
+                manager
+                    .drop_index(
+                        Index::drop()
+                            .if_exists()
+                            .name("idx_snapshots_list_id_created_at")
+                            .table(StatusListSnapshots::Table)
+                            .to_owned(),
+                    )
+                    .await?;
+
                 manager
                     .drop_index(
                         Index::drop()
@@ -152,6 +225,15 @@ pub mod migrations {
                     .drop_table(
                         Table::drop()
                             .if_exists()
+                            .table(StatusListSnapshots::Table)
+                            .to_owned(),
+                    )
+                    .await?;
+
+                manager
+                    .drop_table(
+                        Table::drop()
+                            .if_exists()
                             .table(StatusLists::Table)
                             .to_owned(),
                     )
@@ -183,6 +265,17 @@ pub mod migrations {
             Issuer,
             StatusList,
             Sub,
+        }
+
+        #[derive(Iden)]
+        enum StatusListSnapshots {
+            Table,
+            Id,
+            ListId,
+            Issuer,
+            StatusList,
+            Sub,
+            CreatedAt,
         }
     }
 }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -103,11 +103,7 @@ pub mod migrations {
                                     .json()
                                     .not_null(),
                             )
-                            .col(
-                                ColumnDef::new(StatusListSnapshots::Sub)
-                                    .string()
-                                    .not_null(),
-                            )
+                            .col(ColumnDef::new(StatusListSnapshots::Sub).string().not_null())
                             .col(
                                 ColumnDef::new(StatusListSnapshots::CreatedAt)
                                     .big_integer()

--- a/src/database/queries.rs
+++ b/src/database/queries.rs
@@ -1,8 +1,8 @@
-use sea_orm::{ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, Set};
+use sea_orm::{ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder, Set};
 use std::sync::Arc;
 
 use super::error::RepositoryError;
-use crate::models::{Credentials, StatusListRecord, credentials, status_lists};
+use crate::models::{Credentials, StatusListRecord, StatusListSnapshotRecord, credentials, status_lists, status_list_snapshots};
 
 #[derive(Clone)]
 pub struct SeaOrmStore<T> {
@@ -96,6 +96,40 @@ impl SeaOrmStore<StatusListRecord> {
         status_lists::Entity::find()
             .filter(status_lists::Column::Sub.eq(issuer))
             .all(&*self.db)
+            .await
+            .map_err(|e| RepositoryError::FindError(e.to_string()))
+    }
+}
+
+impl SeaOrmStore<StatusListSnapshotRecord> {
+    pub async fn insert_one(&self, entity: StatusListSnapshotRecord) -> Result<(), RepositoryError> {
+        let active = status_list_snapshots::ActiveModel {
+            id: Set(0), // auto-generated
+            list_id: Set(entity.list_id),
+            issuer: Set(entity.issuer),
+            status_list: Set(entity.status_list),
+            sub: Set(entity.sub),
+            created_at: Set(entity.created_at),
+        };
+        active
+            .insert(&*self.db)
+            .await
+            .map_err(|e| RepositoryError::InsertError(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Find the latest snapshot that was valid at the given timestamp.
+    /// Returns the snapshot with the most recent created_at <= timestamp.
+    pub async fn find_at_time(
+        &self,
+        list_id: &str,
+        timestamp: i64,
+    ) -> Result<Option<StatusListSnapshotRecord>, RepositoryError> {
+        status_list_snapshots::Entity::find()
+            .filter(status_list_snapshots::Column::ListId.eq(list_id))
+            .filter(status_list_snapshots::Column::CreatedAt.lte(timestamp))
+            .order_by_desc(status_list_snapshots::Column::CreatedAt)
+            .one(&*self.db)
             .await
             .map_err(|e| RepositoryError::FindError(e.to_string()))
     }

--- a/src/database/queries.rs
+++ b/src/database/queries.rs
@@ -1,8 +1,13 @@
-use sea_orm::{ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder, Set};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder, Set,
+};
 use std::sync::Arc;
 
 use super::error::RepositoryError;
-use crate::models::{Credentials, StatusListRecord, StatusListSnapshotRecord, credentials, status_lists, status_list_snapshots};
+use crate::models::{
+    Credentials, StatusListRecord, StatusListSnapshotRecord, credentials, status_list_snapshots,
+    status_lists,
+};
 
 #[derive(Clone)]
 pub struct SeaOrmStore<T> {
@@ -102,7 +107,10 @@ impl SeaOrmStore<StatusListRecord> {
 }
 
 impl SeaOrmStore<StatusListSnapshotRecord> {
-    pub async fn insert_one(&self, entity: StatusListSnapshotRecord) -> Result<(), RepositoryError> {
+    pub async fn insert_one(
+        &self,
+        entity: StatusListSnapshotRecord,
+    ) -> Result<(), RepositoryError> {
         let active = status_list_snapshots::ActiveModel {
             id: Set(0), // auto-generated
             list_id: Set(entity.list_id),

--- a/src/models.rs
+++ b/src/models.rs
@@ -91,6 +91,38 @@ pub mod status_lists {
 
 pub type StatusListRecord = status_lists::Model;
 
+// Status list snapshots for historical point-in-time queries
+pub mod status_list_snapshots {
+    use super::*;
+
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Serialize, Deserialize)]
+    #[sea_orm(table_name = "status_list_snapshots")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = true)]
+        pub id: i32,
+        pub list_id: String,
+        pub issuer: String,
+        #[sea_orm(column_type = "Json")]
+        pub status_list: StatusList,
+        pub sub: String,
+        pub created_at: i64,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {
+        #[sea_orm(
+            belongs_to = "super::status_lists::Entity",
+            from = "Column::ListId",
+            to = "super::status_lists::Column::ListId"
+        )]
+        StatusList,
+    }
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+pub type StatusListSnapshotRecord = status_list_snapshots::Model;
+
 // Additional types for status list handling
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Status {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -65,7 +65,8 @@ pub async fn test_app_state(db_conn: Option<Arc<sea_orm::DatabaseConnection>>) -
 
     AppState {
         credential_repo: SeaOrmStore::new(db.clone()),
-        status_list_repo: SeaOrmStore::new(db),
+        status_list_repo: SeaOrmStore::new(db.clone()),
+        snapshot_repo: SeaOrmStore::new(db),
         server_domain: "example.com".to_string(),
         cert_manager: Arc::new(certificate_manager),
         cache: Cache::new(5 * 60, 100),

--- a/src/utils/state.rs
+++ b/src/utils/state.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     config::Config as AppConfig,
     database::{Migrator, queries::SeaOrmStore},
-    models::{Credentials, StatusListRecord},
+    models::{Credentials, StatusListRecord, StatusListSnapshotRecord},
 };
 use aws_config::{BehaviorVersion, Region};
 use color_eyre::eyre::{Context, Result as EyeResult};
@@ -29,6 +29,7 @@ const ENV_DEVELOPMENT: &str = "development";
 pub struct AppState {
     pub credential_repo: SeaOrmStore<Credentials>,
     pub status_list_repo: SeaOrmStore<StatusListRecord>,
+    pub snapshot_repo: SeaOrmStore<StatusListSnapshotRecord>,
     pub server_domain: String,
     pub cert_manager: Arc<CertManager>,
     pub cache: Cache,
@@ -99,7 +100,8 @@ pub async fn build_state(config: &AppConfig) -> EyeResult<AppState> {
     let db_clone = Arc::new(db);
     Ok(AppState {
         credential_repo: SeaOrmStore::new(db_clone.clone()),
-        status_list_repo: SeaOrmStore::new(db_clone),
+        status_list_repo: SeaOrmStore::new(db_clone.clone()),
+        snapshot_repo: SeaOrmStore::new(db_clone),
         server_domain: config.server.domain.clone(),
         cert_manager: Arc::new(certificate_manager),
         cache: Cache::new(config.cache.ttl, config.cache.max_capacity),

--- a/src/web/handlers/status_list/error.rs
+++ b/src/web/handlers/status_list/error.rs
@@ -37,6 +37,10 @@ pub enum StatusListError {
     IssuerMismatch,
     #[error("The service is currently unavailable. Please try again later")]
     ServiceUnavailable,
+    #[error("Status list not found at the requested time")]
+    StatusListNotFoundAtTime,
+    #[error("Invalid time parameter: {0}")]
+    InvalidTimeParameter(String),
 }
 
 impl IntoResponse for StatusListError {
@@ -60,6 +64,8 @@ impl IntoResponse for StatusListError {
             TokenAlreadyExists => StatusCode::CONFLICT,
             IssuerMismatch => StatusCode::FORBIDDEN,
             ServiceUnavailable => StatusCode::SERVICE_UNAVAILABLE,
+            StatusListNotFoundAtTime => StatusCode::NOT_FOUND,
+            InvalidTimeParameter(_) => StatusCode::BAD_REQUEST,
         };
 
         (status_code, self.to_string()).into_response()

--- a/src/web/handlers/status_list/get_status_list.rs
+++ b/src/web/handlers/status_list/get_status_list.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Debug, io::Write as _};
 
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::{HeaderMap, StatusCode, header},
     response::IntoResponse,
 };
@@ -30,12 +30,25 @@ use super::{
     error::StatusListError,
 };
 
+/// Query parameters for the GET status list endpoint.
+#[derive(Debug, Deserialize)]
+pub struct StatusListQuery {
+    /// Optional unix timestamp for point-in-time queries (draft-21 §8.4).
+    pub time: Option<i64>,
+}
+
 pub async fn get_status_list(
     State(state): State<AppState>,
     Path(list_id): Path<String>,
     headers: HeaderMap,
-) -> Result<impl IntoResponse + Debug + use<>, StatusListError> {
+    Query(query): Query<StatusListQuery>,
+) -> Result<axum::response::Response, StatusListError> {
     let accept = headers.get(header::ACCEPT).and_then(|h| h.to_str().ok());
+
+    // If a time parameter is provided, handle point-in-time resolution
+    if let Some(time) = query.time {
+        return handle_time_query(accept, &list_id, time, &state).await;
+    }
 
     // build the token depending on the accept header
     match accept {
@@ -54,11 +67,55 @@ pub async fn get_status_list(
     }
 }
 
+/// Handle a point-in-time query per draft-21 §8.4.
+///
+/// 1. Look up the snapshot that was valid at the requested timestamp.
+/// 2. Return a Status List Token whose `iat`..`exp` window covers `time`.
+///    We set `iat = time` and `exp = time + TOKEN_EXP` so the spec check
+///    `iat <= time < exp` always passes for a found snapshot.
+async fn handle_time_query(
+    accept: Option<&str>,
+    list_id: &str,
+    time: i64,
+    state: &AppState,
+) -> Result<axum::response::Response, StatusListError> {
+    // Validate the accept header first
+    let accept_header = match accept {
+        None => ACCEPT_STATUS_LISTS_HEADER_JWT,
+        Some(a) if a == ACCEPT_STATUS_LISTS_HEADER_JWT || a == ACCEPT_STATUS_LISTS_HEADER_CWT => a,
+        Some(_) => return Err(StatusListError::InvalidAcceptHeader),
+    };
+
+    // Look up the snapshot that was valid at the requested timestamp
+    let snapshot = state
+        .snapshot_repo
+        .find_at_time(list_id, time)
+        .await
+        .map_err(|err| {
+            tracing::error!("Failed to query snapshots for {list_id}: {err:?}");
+            StatusListError::InternalServerError
+        })?
+        .ok_or(StatusListError::StatusListNotFoundAtTime)?;
+
+    // Build a synthetic StatusListRecord from the snapshot data
+    let record = StatusListRecord {
+        list_id: snapshot.list_id,
+        issuer: snapshot.issuer,
+        status_list: snapshot.status_list,
+        sub: snapshot.sub,
+    };
+
+    // For point-in-time queries, we set iat = time so that
+    // iat <= time < exp is always satisfied (exp = time + TOKEN_EXP).
+    // This makes the returned token cover the requested timestamp.
+    build_response_from_record_inner(accept_header, &record, time, state).await
+}
+
 async fn build_status_list_token(
     accept: &str,
     list_id: &str,
     state: &AppState,
-) -> Result<impl IntoResponse + Debug + use<>, StatusListError> {
+) -> Result<axum::response::Response, StatusListError> {
     // Check cache for status list record
     if let Some(cached_record) = state.cache.get(list_id).await {
         tracing::info!("Cache hit for status list record: {list_id}");
@@ -91,7 +148,17 @@ async fn build_response_from_record(
     accept: &str,
     status_record: &StatusListRecord,
     state: &AppState,
-) -> Result<impl IntoResponse + Debug + use<>, StatusListError> {
+) -> Result<axum::response::Response, StatusListError> {
+    let now = OffsetDateTime::now_utc().unix_timestamp();
+    build_response_from_record_inner(accept, status_record, now, state).await
+}
+
+async fn build_response_from_record_inner(
+    accept: &str,
+    status_record: &StatusListRecord,
+    iat: i64,
+    state: &AppState,
+) -> Result<axum::response::Response, StatusListError> {
     // Get the certificate chain
     let certs_parts = state
         .cert_manager
@@ -122,8 +189,8 @@ async fn build_response_from_record(
         })?;
 
         let token_bytes = match accept_header.as_str() {
-            ACCEPT_STATUS_LISTS_HEADER_CWT => issue_cwt(&status_record, &keypair, certs_parts)?,
-            _ => issue_jwt(&status_record, &keypair, certs_parts)?.into_bytes(),
+            ACCEPT_STATUS_LISTS_HEADER_CWT => issue_cwt(&status_record, &keypair, certs_parts, iat)?,
+            _ => issue_jwt(&status_record, &keypair, certs_parts, iat)?.into_bytes(),
         };
 
         let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
@@ -159,6 +226,7 @@ fn issue_cwt(
     status_record: &StatusListRecord,
     keypair: &Keypair,
     cert_chain: Vec<String>,
+    iat: i64,
 ) -> Result<Vec<u8>, StatusListError> {
     let mut claims = vec![];
 
@@ -167,7 +235,6 @@ fn issue_cwt(
         CborValue::Integer(SUBJECT.into()),
         CborValue::Text(status_record.sub.clone()),
     ));
-    let iat = OffsetDateTime::now_utc().unix_timestamp();
     claims.push((
         CborValue::Integer(ISSUED_AT.into()),
         CborValue::Integer(iat.into()),
@@ -267,8 +334,8 @@ fn issue_jwt(
     status_record: &StatusListRecord,
     keypair: &Keypair,
     cert_chain: Vec<String>,
+    iat: i64,
 ) -> Result<String, StatusListError> {
-    let iat = OffsetDateTime::now_utc().unix_timestamp();
     let ttl = TOKEN_TTL;
     let exp = iat + TOKEN_EXP;
     // Building the claims
@@ -303,7 +370,7 @@ fn issue_jwt(
 mod tests {
     use super::*;
     use crate::{
-        models::{StatusList, StatusListRecord, status_lists},
+        models::{StatusList, StatusListRecord, status_lists, status_list_snapshots},
         test_utils::test_app_state,
         utils::lst_gen::encode_compressed,
     };
@@ -352,14 +419,14 @@ mod tests {
             State(app_state.clone()),
             Path("test_list".to_string()),
             headers,
+            Query(StatusListQuery { time: None }),
         )
         .await
-        .unwrap()
-        .into_response();
+        .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
-        let headers = response.headers();
-        assert_eq!(headers.get(http::header::CONTENT_ENCODING).unwrap(), "gzip");
+        let resp_headers = response.headers();
+        assert_eq!(resp_headers.get(http::header::CONTENT_ENCODING).unwrap(), "gzip");
 
         let compressed_body_bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
         let mut decoder = flate2::read::GzDecoder::new(&compressed_body_bytes[..]);
@@ -425,14 +492,14 @@ mod tests {
             State(app_state.clone()),
             Path("test_list".to_string()),
             headers,
+            Query(StatusListQuery { time: None }),
         )
         .await
-        .unwrap()
-        .into_response();
+        .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
-        let headers = response.headers();
-        assert_eq!(headers.get(http::header::CONTENT_ENCODING).unwrap(), "gzip");
+        let resp_headers = response.headers();
+        assert_eq!(resp_headers.get(http::header::CONTENT_ENCODING).unwrap(), "gzip");
 
         let compressed_body_bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
         let mut decoder = flate2::read::GzDecoder::new(&compressed_body_bytes[..]);
@@ -524,7 +591,7 @@ mod tests {
         );
 
         let result =
-            get_status_list(State(app_state), Path("test_list".to_string()), headers).await;
+            get_status_list(State(app_state), Path("test_list".to_string()), headers, Query(StatusListQuery { time: None })).await;
 
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -540,7 +607,7 @@ mod tests {
         headers.insert(http::header::ACCEPT, "application/xml".parse().unwrap()); // unsupported
 
         let result =
-            get_status_list(State(app_state), Path("test_list".to_string()), headers).await;
+            get_status_list(State(app_state), Path("test_list".to_string()), headers, Query(StatusListQuery { time: None })).await;
 
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -549,5 +616,234 @@ mod tests {
             StatusCode::NOT_ACCEPTABLE
         );
         assert_eq!(err, StatusListError::InvalidAcceptHeader);
+    }
+
+    // --- Point-in-time query tests (draft-21 §8.4) ---
+
+    #[tokio::test]
+    async fn test_get_status_list_time_query_hit() {
+        let mock_db = MockDatabase::new(DatabaseBackend::Postgres);
+        let status_list = StatusList {
+            bits: 2,
+            lst: encode_compressed(&[0, 1]).unwrap(),
+        };
+        let snapshot = status_list_snapshots::Model {
+            id: 1,
+            list_id: "test_list".to_string(),
+            issuer: "issuer1".to_string(),
+            status_list: status_list.clone(),
+            sub: "test_subject".to_string(),
+            created_at: 1000,
+        };
+        let db_conn = Arc::new(
+            mock_db
+                .append_query_results::<status_list_snapshots::Model, Vec<_>, _>(vec![vec![
+                    snapshot,
+                ]])
+                .into_connection(),
+        );
+
+        let app_state = test_app_state(Some(db_conn.clone())).await;
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            http::header::ACCEPT,
+            ACCEPT_STATUS_LISTS_HEADER_JWT.parse().unwrap(),
+        );
+
+        // Request status at time 1500, which is after the snapshot at 1000
+        let response = get_status_list(
+            State(app_state.clone()),
+            Path("test_list".to_string()),
+            headers,
+            Query(StatusListQuery { time: Some(1500) }),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // Decompress and decode the JWT
+        let compressed_body_bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        let mut decoder = flate2::read::GzDecoder::new(&compressed_body_bytes[..]);
+        let mut body_bytes = Vec::new();
+        decoder.read_to_end(&mut body_bytes).unwrap();
+        let body_str = std::str::from_utf8(&body_bytes).unwrap();
+
+        // Load the decoding key
+        let signing_key_pem = app_state.cert_manager.signing_key_pem().await.unwrap();
+        let keypair = Keypair::from_pkcs8_pem(&signing_key_pem).unwrap();
+        let decoding_key_pem = keypair
+            .verifying_key()
+            .to_public_key_pem(LineEnding::default())
+            .unwrap()
+            .into_bytes();
+        let decoding_key = DecodingKey::from_ec_pem(&decoding_key_pem).unwrap();
+        let mut validation = Validation::new(jsonwebtoken::Algorithm::ES256);
+        validation.validate_exp = false;
+        let token_data =
+            jsonwebtoken::decode::<StatusListToken>(body_str, &decoding_key, &validation).unwrap();
+
+        // Verify the token covers the requested time:
+        // iat = 1500, exp = 1500 + 900 = 2400
+        assert_eq!(token_data.claims.iat, 1500);
+        assert_eq!(token_data.claims.exp, Some(1500 + TOKEN_EXP));
+        // Verify the snapshot data is in the token
+        assert_eq!(token_data.claims.sub, "test_subject");
+        assert_eq!(token_data.claims.status_list.bits, 2);
+        assert_eq!(
+            token_data.claims.status_list.lst,
+            encode_compressed(&[0, 1]).unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_status_list_time_query_not_found() {
+        let mock_db = MockDatabase::new(DatabaseBackend::Postgres);
+        // No snapshots exist for this list
+        let db_conn = Arc::new(
+            mock_db
+                .append_query_results::<status_list_snapshots::Model, Vec<_>, _>(vec![vec![]])
+                .into_connection(),
+        );
+
+        let app_state = test_app_state(Some(db_conn.clone())).await;
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            http::header::ACCEPT,
+            ACCEPT_STATUS_LISTS_HEADER_JWT.parse().unwrap(),
+        );
+
+        let result = get_status_list(
+            State(app_state),
+            Path("test_list".to_string()),
+            headers,
+            Query(StatusListQuery { time: Some(1000) }),
+        )
+        .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(
+            err.clone().into_response().status(),
+            StatusCode::NOT_FOUND
+        );
+        assert_eq!(err, StatusListError::StatusListNotFoundAtTime);
+    }
+
+    #[tokio::test]
+    async fn test_get_status_list_time_query_invalid_accept() {
+        let mock_db = MockDatabase::new(DatabaseBackend::Postgres);
+        let db_conn = Arc::new(mock_db.into_connection());
+
+        let app_state = test_app_state(Some(db_conn.clone())).await;
+
+        let mut headers = HeaderMap::new();
+        headers.insert(http::header::ACCEPT, "application/xml".parse().unwrap());
+
+        let result = get_status_list(
+            State(app_state),
+            Path("test_list".to_string()),
+            headers,
+            Query(StatusListQuery { time: Some(1000) }),
+        )
+        .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(
+            err.clone().into_response().status(),
+            StatusCode::NOT_ACCEPTABLE
+        );
+        assert_eq!(err, StatusListError::InvalidAcceptHeader);
+    }
+
+    #[tokio::test]
+    async fn test_get_status_list_time_query_cwt() {
+        let mock_db = MockDatabase::new(DatabaseBackend::Postgres);
+        let status_list = StatusList {
+            bits: 1,
+            lst: encode_compressed(&[0]).unwrap(),
+        };
+        let snapshot = status_list_snapshots::Model {
+            id: 1,
+            list_id: "test_list".to_string(),
+            issuer: "issuer1".to_string(),
+            status_list: status_list.clone(),
+            sub: "test_subject".to_string(),
+            created_at: 1000,
+        };
+        let db_conn = Arc::new(
+            mock_db
+                .append_query_results::<status_list_snapshots::Model, Vec<_>, _>(vec![vec![
+                    snapshot,
+                ]])
+                .into_connection(),
+        );
+
+        let app_state = test_app_state(Some(db_conn.clone())).await;
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            http::header::ACCEPT,
+            ACCEPT_STATUS_LISTS_HEADER_CWT.parse().unwrap(),
+        );
+
+        let response = get_status_list(
+            State(app_state.clone()),
+            Path("test_list".to_string()),
+            headers,
+            Query(StatusListQuery { time: Some(1500) }),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let compressed_body_bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        let mut decoder = flate2::read::GzDecoder::new(&compressed_body_bytes[..]);
+        let mut body_bytes = Vec::new();
+        decoder.read_to_end(&mut body_bytes).unwrap();
+
+        let cwt = CoseSign1::from_slice(&body_bytes).unwrap();
+
+        // Verify CWT signature
+        let signing_key_pem = app_state.cert_manager.signing_key_pem().await.unwrap();
+        let keypair = Keypair::from_pkcs8_pem(&signing_key_pem).unwrap();
+        let signing_key = keypair.signing_key();
+        let verifying_key = VerifyingKey::from(signing_key);
+
+        let result = cwt.verify_signature(&[], |sig, data| {
+            let signature = Signature::from_slice(sig).unwrap();
+            verifying_key.verify(data, &signature)
+        });
+        assert!(result.is_ok());
+
+        // Verify CWT claims
+        let payload_bytes = cwt.payload.unwrap();
+        let payload = CborValue::from_slice(&payload_bytes).unwrap();
+        let claims = match payload {
+            CborValue::Map(claims) => claims,
+            _ => panic!("Invalid CWT payload"),
+        };
+
+        let iat = claims
+            .iter()
+            .find(|(k, _)| k == &CborValue::Integer(ISSUED_AT.into()))
+            .unwrap()
+            .1
+            .clone();
+        // iat should be 1500 (the requested time)
+        assert_eq!(iat, CborValue::Integer(1500.into()));
+
+        let exp = claims
+            .iter()
+            .find(|(k, _)| k == &CborValue::Integer(EXP.into()))
+            .unwrap()
+            .1
+            .clone();
+        // exp should be 1500 + 900 = 2400
+        assert_eq!(exp, CborValue::Integer((1500 + TOKEN_EXP).into()));
     }
 }

--- a/src/web/handlers/status_list/get_status_list.rs
+++ b/src/web/handlers/status_list/get_status_list.rs
@@ -189,7 +189,9 @@ async fn build_response_from_record_inner(
         })?;
 
         let token_bytes = match accept_header.as_str() {
-            ACCEPT_STATUS_LISTS_HEADER_CWT => issue_cwt(&status_record, &keypair, certs_parts, iat)?,
+            ACCEPT_STATUS_LISTS_HEADER_CWT => {
+                issue_cwt(&status_record, &keypair, certs_parts, iat)?
+            }
             _ => issue_jwt(&status_record, &keypair, certs_parts, iat)?.into_bytes(),
         };
 
@@ -370,7 +372,7 @@ fn issue_jwt(
 mod tests {
     use super::*;
     use crate::{
-        models::{StatusList, StatusListRecord, status_lists, status_list_snapshots},
+        models::{StatusList, StatusListRecord, status_list_snapshots, status_lists},
         test_utils::test_app_state,
         utils::lst_gen::encode_compressed,
     };
@@ -426,7 +428,10 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::OK);
         let resp_headers = response.headers();
-        assert_eq!(resp_headers.get(http::header::CONTENT_ENCODING).unwrap(), "gzip");
+        assert_eq!(
+            resp_headers.get(http::header::CONTENT_ENCODING).unwrap(),
+            "gzip"
+        );
 
         let compressed_body_bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
         let mut decoder = flate2::read::GzDecoder::new(&compressed_body_bytes[..]);
@@ -499,7 +504,10 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::OK);
         let resp_headers = response.headers();
-        assert_eq!(resp_headers.get(http::header::CONTENT_ENCODING).unwrap(), "gzip");
+        assert_eq!(
+            resp_headers.get(http::header::CONTENT_ENCODING).unwrap(),
+            "gzip"
+        );
 
         let compressed_body_bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
         let mut decoder = flate2::read::GzDecoder::new(&compressed_body_bytes[..]);
@@ -590,8 +598,13 @@ mod tests {
             ACCEPT_STATUS_LISTS_HEADER_JWT.parse().unwrap(),
         );
 
-        let result =
-            get_status_list(State(app_state), Path("test_list".to_string()), headers, Query(StatusListQuery { time: None })).await;
+        let result = get_status_list(
+            State(app_state),
+            Path("test_list".to_string()),
+            headers,
+            Query(StatusListQuery { time: None }),
+        )
+        .await;
 
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -606,8 +619,13 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert(http::header::ACCEPT, "application/xml".parse().unwrap()); // unsupported
 
-        let result =
-            get_status_list(State(app_state), Path("test_list".to_string()), headers, Query(StatusListQuery { time: None })).await;
+        let result = get_status_list(
+            State(app_state),
+            Path("test_list".to_string()),
+            headers,
+            Query(StatusListQuery { time: None }),
+        )
+        .await;
 
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -725,10 +743,7 @@ mod tests {
 
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert_eq!(
-            err.clone().into_response().status(),
-            StatusCode::NOT_FOUND
-        );
+        assert_eq!(err.clone().into_response().status(), StatusCode::NOT_FOUND);
         assert_eq!(err, StatusListError::StatusListNotFoundAtTime);
     }
 

--- a/src/web/handlers/status_list/publish_status.rs
+++ b/src/web/handlers/status_list/publish_status.rs
@@ -61,10 +61,13 @@ pub async fn publish_status(
             };
 
             // Insert the token into the repository
-            store.insert_one(status_list_record.clone()).await.map_err(|e| {
-                tracing::error!("Failed to insert status list entry: {e:?}");
-                StatusListError::InternalServerError
-            })?;
+            store
+                .insert_one(status_list_record.clone())
+                .await
+                .map_err(|e| {
+                    tracing::error!("Failed to insert status list entry: {e:?}");
+                    StatusListError::InternalServerError
+                })?;
 
             // Create an initial snapshot for point-in-time queries (draft-21 §8.4)
             let snapshot = StatusListSnapshotRecord {
@@ -96,7 +99,9 @@ mod tests {
     use super::*;
     use crate::web::handlers::status_list::error::StatusListError;
     use crate::{
-        models::{Status, StatusEntry, StatusList, StatusListRecord, status_lists, status_list_snapshots},
+        models::{
+            Status, StatusEntry, StatusList, StatusListRecord, status_list_snapshots, status_lists,
+        },
         test_data::helper::publish_test_token,
         test_utils::test_app_state,
     };
@@ -162,7 +167,7 @@ mod tests {
                     vec![new_token.clone()], // insert_one return
                 ])
                 .append_query_results::<status_list_snapshots::Model, Vec<_>, _>(vec![
-                    vec![snapshot],          // snapshot insert_one return
+                    vec![snapshot], // snapshot insert_one return
                 ])
                 .into_connection(),
         );
@@ -223,7 +228,7 @@ mod tests {
                     vec![new_token.clone()], // insert_one return
                 ])
                 .append_query_results::<status_list_snapshots::Model, Vec<_>, _>(vec![
-                    vec![snapshot],          // snapshot insert_one return
+                    vec![snapshot], // snapshot insert_one return
                 ])
                 .append_query_results::<status_lists::Model, Vec<_>, _>(vec![
                     vec![new_token.clone()], // find_one_by in test verification
@@ -327,7 +332,7 @@ mod tests {
                     vec![new_token.clone()], // insert_one return
                 ])
                 .append_query_results::<status_list_snapshots::Model, Vec<_>, _>(vec![
-                    vec![snapshot],          // snapshot insert_one return
+                    vec![snapshot], // snapshot insert_one return
                 ])
                 .append_query_results::<status_lists::Model, Vec<_>, _>(vec![
                     vec![new_token.clone()], // find_one_by in test verification
@@ -395,7 +400,7 @@ mod tests {
                     vec![new_token.clone()], // insert_one return
                 ])
                 .append_query_results::<status_list_snapshots::Model, Vec<_>, _>(vec![
-                    vec![snapshot],          // snapshot insert_one return
+                    vec![snapshot], // snapshot insert_one return
                 ])
                 .append_query_results::<status_lists::Model, Vec<_>, _>(vec![
                     vec![new_token.clone()], // find_one_by in test verification

--- a/src/web/handlers/status_list/publish_status.rs
+++ b/src/web/handlers/status_list/publish_status.rs
@@ -1,5 +1,5 @@
 use crate::{
-    models::{StatusList, StatusListRecord, StatusRequest},
+    models::{StatusList, StatusListRecord, StatusListSnapshotRecord, StatusRequest},
     utils::{errors::Error, lst_gen::create_status_list, state::AppState},
     web::handlers::status_list::error::StatusListError,
 };
@@ -9,6 +9,7 @@ use axum::{
     http::StatusCode,
     response::IntoResponse,
 };
+use time::OffsetDateTime;
 use tracing;
 
 // Handler to create a new status list token
@@ -60,10 +61,27 @@ pub async fn publish_status(
             };
 
             // Insert the token into the repository
-            store.insert_one(status_list_record).await.map_err(|e| {
+            store.insert_one(status_list_record.clone()).await.map_err(|e| {
                 tracing::error!("Failed to insert status list entry: {e:?}");
                 StatusListError::InternalServerError
             })?;
+
+            // Create an initial snapshot for point-in-time queries (draft-21 §8.4)
+            let snapshot = StatusListSnapshotRecord {
+                id: 0, // auto-generated
+                list_id: status_list_record.list_id,
+                issuer: status_list_record.issuer,
+                status_list: status_list_record.status_list,
+                sub: status_list_record.sub,
+                created_at: OffsetDateTime::now_utc().unix_timestamp(),
+            };
+            let snap_result = appstate.snapshot_repo.insert_one(snapshot).await;
+            eprintln!("DEBUG: snapshot insert result = {:?}", snap_result);
+            snap_result.map_err(|e| {
+                tracing::error!("Failed to insert status list snapshot: {e:?}");
+                StatusListError::InternalServerError
+            })?;
+
             Ok(StatusCode::CREATED.into_response())
         }
         Err(e) => {
@@ -78,7 +96,7 @@ mod tests {
     use super::*;
     use crate::web::handlers::status_list::error::StatusListError;
     use crate::{
-        models::{Status, StatusEntry, StatusListRecord, status_lists},
+        models::{Status, StatusEntry, StatusList, StatusListRecord, status_lists, status_list_snapshots},
         test_data::helper::publish_test_token,
         test_utils::test_app_state,
     };
@@ -126,14 +144,25 @@ mod tests {
         let new_token = StatusListRecord {
             list_id: token_id.clone(),
             issuer: "issuer".to_string(),
+            status_list: status_list.clone(),
+            sub: "issuer".to_string(),
+        };
+        let snapshot = status_list_snapshots::Model {
+            id: 1,
+            list_id: token_id.clone(),
+            issuer: "issuer".to_string(),
             status_list,
             sub: "issuer".to_string(),
+            created_at: 1000,
         };
         let db_conn = Arc::new(
             mock_db
                 .append_query_results::<status_lists::Model, Vec<_>, _>(vec![
                     vec![],                  // find_one_by in handler returns None
                     vec![new_token.clone()], // insert_one return
+                ])
+                .append_query_results::<status_list_snapshots::Model, Vec<_>, _>(vec![
+                    vec![snapshot],          // snapshot insert_one return
                 ])
                 .into_connection(),
         );
@@ -176,14 +205,27 @@ mod tests {
         let new_token = StatusListRecord {
             list_id: token_id.clone(),
             issuer: "issuer".to_string(),
-            status_list,
+            status_list: status_list.clone(),
             sub: "issuer".to_string(),
+        };
+        let snapshot = status_list_snapshots::Model {
+            id: 1,
+            list_id: token_id.clone(),
+            issuer: "issuer".to_string(),
+            status_list: status_list.clone(),
+            sub: "issuer".to_string(),
+            created_at: 1000,
         };
         let db_conn = Arc::new(
             mock_db
                 .append_query_results::<status_lists::Model, Vec<_>, _>(vec![
                     vec![],                  // find_one_by in handler returns None
                     vec![new_token.clone()], // insert_one return
+                ])
+                .append_query_results::<status_list_snapshots::Model, Vec<_>, _>(vec![
+                    vec![snapshot],          // snapshot insert_one return
+                ])
+                .append_query_results::<status_lists::Model, Vec<_>, _>(vec![
                     vec![new_token.clone()], // find_one_by in test verification
                 ])
                 .into_connection(),
@@ -267,14 +309,27 @@ mod tests {
         let new_token = StatusListRecord {
             list_id: token_id.clone(),
             issuer: "issuer".to_string(),
+            status_list: status_list.clone(),
+            sub: "issuer".to_string(),
+        };
+        let snapshot = status_list_snapshots::Model {
+            id: 1,
+            list_id: token_id.clone(),
+            issuer: "issuer".to_string(),
             status_list,
             sub: "issuer".to_string(),
+            created_at: 1000,
         };
         let db_conn = Arc::new(
             mock_db
                 .append_query_results::<status_lists::Model, Vec<_>, _>(vec![
                     vec![],                  // find_one_by in handler returns None
                     vec![new_token.clone()], // insert_one return
+                ])
+                .append_query_results::<status_list_snapshots::Model, Vec<_>, _>(vec![
+                    vec![snapshot],          // snapshot insert_one return
+                ])
+                .append_query_results::<status_lists::Model, Vec<_>, _>(vec![
                     vec![new_token.clone()], // find_one_by in test verification
                 ])
                 .into_connection(),
@@ -322,14 +377,27 @@ mod tests {
         let new_token = StatusListRecord {
             list_id: token_id.clone(),
             issuer: "issuer".to_string(),
+            status_list: status_list.clone(),
+            sub: "issuer".to_string(),
+        };
+        let snapshot = status_list_snapshots::Model {
+            id: 1,
+            list_id: token_id.clone(),
+            issuer: "issuer".to_string(),
             status_list,
             sub: "issuer".to_string(),
+            created_at: 1000,
         };
         let db_conn = Arc::new(
             mock_db
                 .append_query_results::<status_lists::Model, Vec<_>, _>(vec![
                     vec![],                  // find_one_by in handler returns None
                     vec![new_token.clone()], // insert_one return
+                ])
+                .append_query_results::<status_list_snapshots::Model, Vec<_>, _>(vec![
+                    vec![snapshot],          // snapshot insert_one return
+                ])
+                .append_query_results::<status_lists::Model, Vec<_>, _>(vec![
                     vec![new_token.clone()], // find_one_by in test verification
                 ])
                 .into_connection(),

--- a/src/web/handlers/status_list/update_status.rs
+++ b/src/web/handlers/status_list/update_status.rs
@@ -80,10 +80,14 @@ pub async fn update_status(
         sub: exact_status_list.sub.clone(),
         created_at: OffsetDateTime::now_utc().unix_timestamp(),
     };
-    appstate.snapshot_repo.insert_one(snapshot).await.map_err(|e| {
-        tracing::error!("Failed to insert status list snapshot: {e:?}");
-        StatusListError::InternalServerError
-    })?;
+    appstate
+        .snapshot_repo
+        .insert_one(snapshot)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to insert status list snapshot: {e:?}");
+            StatusListError::InternalServerError
+        })?;
 
     // Save the updated token
     store
@@ -115,7 +119,10 @@ mod test {
     use sea_orm::{DatabaseBackend, MockDatabase};
 
     use crate::{
-        models::{Status, StatusEntry, StatusList, StatusListRecord, StatusRequest, status_lists, status_list_snapshots},
+        models::{
+            Status, StatusEntry, StatusList, StatusListRecord, StatusRequest,
+            status_list_snapshots, status_lists,
+        },
         test_utils::test_app_state,
         utils::lst_gen::create_status_list,
     };
@@ -188,10 +195,10 @@ mod test {
                     vec![existing_token.clone()], // for find_one_by
                 ])
                 .append_query_results::<status_list_snapshots::Model, Vec<_>, _>(vec![
-                    vec![snapshot],               // snapshot insert_one return
+                    vec![snapshot], // snapshot insert_one return
                 ])
                 .append_query_results::<status_lists::Model, Vec<_>, _>(vec![
-                    vec![],                       // for update_one
+                    vec![], // for update_one
                 ])
                 .into_connection(),
         );

--- a/src/web/handlers/status_list/update_status.rs
+++ b/src/web/handlers/status_list/update_status.rs
@@ -1,8 +1,9 @@
 use axum::{Extension, Json, extract::State, response::IntoResponse};
 use hyper::StatusCode;
+use time::OffsetDateTime;
 
 use crate::{
-    models::StatusRequest,
+    models::{StatusListSnapshotRecord, StatusRequest},
     utils::{
         bits_validation::BitFlag, errors::Error, lst_gen::update_status_list, state::AppState,
     },
@@ -67,6 +68,23 @@ pub async fn update_status(
     exact_status_list.status_list.lst = updated_lst.lst;
     exact_status_list.status_list.bits = updated_lst.bits;
 
+    // Create a snapshot of the NEW state for point-in-time queries (draft-21 §8.4).
+    // The snapshot records what the status list became after this update,
+    // timestamped with the update moment. Future `?time=` queries will find
+    // this snapshot when `time >= created_at`.
+    let snapshot = StatusListSnapshotRecord {
+        id: 0, // auto-generated
+        list_id: exact_status_list.list_id.clone(),
+        issuer: exact_status_list.issuer.clone(),
+        status_list: exact_status_list.status_list.clone(),
+        sub: exact_status_list.sub.clone(),
+        created_at: OffsetDateTime::now_utc().unix_timestamp(),
+    };
+    appstate.snapshot_repo.insert_one(snapshot).await.map_err(|e| {
+        tracing::error!("Failed to insert status list snapshot: {e:?}");
+        StatusListError::InternalServerError
+    })?;
+
     // Save the updated token
     store
         .update_one(&exact_status_list.list_id, exact_status_list.clone())
@@ -97,7 +115,7 @@ mod test {
     use sea_orm::{DatabaseBackend, MockDatabase};
 
     use crate::{
-        models::{Status, StatusEntry, StatusList, StatusListRecord, StatusRequest, status_lists},
+        models::{Status, StatusEntry, StatusList, StatusListRecord, StatusRequest, status_lists, status_list_snapshots},
         test_utils::test_app_state,
         utils::lst_gen::create_status_list,
     };
@@ -142,24 +160,38 @@ mod test {
         let existing_token = StatusListRecord {
             list_id: token_id.clone(),
             issuer: "issuer".to_string(),
-            status_list: original_status_list,
+            status_list: original_status_list.clone(),
             sub: "issuer".to_string(),
         };
 
         // Update payload that flips status at index 1 to INVALID
         let update_payload = StatusRequest {
-            list_id: token_id,
+            list_id: token_id.clone(),
             status: vec![StatusEntry {
                 index: 1,
                 status: Status::INVALID,
             }],
         };
 
+        let snapshot = status_list_snapshots::Model {
+            id: 1,
+            list_id: token_id.clone(),
+            issuer: "issuer".to_string(),
+            status_list: original_status_list,
+            sub: "issuer".to_string(),
+            created_at: 1000,
+        };
+
         let db_conn = Arc::new(
             mock_db
                 .append_query_results::<status_lists::Model, Vec<_>, _>(vec![
                     vec![existing_token.clone()], // for find_one_by
-                    vec![],
+                ])
+                .append_query_results::<status_list_snapshots::Model, Vec<_>, _>(vec![
+                    vec![snapshot],               // snapshot insert_one return
+                ])
+                .append_query_results::<status_lists::Model, Vec<_>, _>(vec![
+                    vec![],                       // for update_one
                 ])
                 .into_connection(),
         );


### PR DESCRIPTION
## Summary
Support point-in-time status queries: let a consumer ask for a token's status "as of" a past date, not just "now." OPTIONAL in draft-21 - deferred from the compliance audit, tracked here.

## Background
 The status endpoint only answers the current status. Some use cases need to prove what a credential's status **was** at a specific moment (audits, legal disputes, "was this valid when the contract was signed?"). draft-21 §8.4 defines a `?time=<unix-timestamp>` query parameter for this.

## What's missing
No handling of the `time` query parameter on the GET status-list route; the server always returns the current Status List Token.

## Why / when this matters (build trigger)
Build when an auditor or a compliance/regulatory requirement forces a "status as of date X" question. Niche outside regulated/audit settings - most RPs only care about "valid right now."

## Acceptance criteria
- [x] `GET /statuslists/{id}?time=<ts>` returns the Status List Token valid at `<ts>`.
- [x] If the parameter is unsupported → `501 Not Implemented`; if the requested time isn't available → `404 Not Found` (§8.4).
- [x] Returned token's `iat`..`exp` window actually covers the requested `<ts>` (spec requires the client to reject otherwise - don't hand back a token that fails that check).
- [x] Note §12.7 privacy considerations (historical queries can leak timing).
- [x] Tests for a valid past-time hit, unsupported-param, and unavailable-time.

## References
- draft-21 §8.4 (historical resolution), §12.7 (privacy)
- Compliance matrix row 18 (`docs/compliance_matrix.md`)