### PR TITLE
Acme dns provider support

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -67,9 +67,13 @@ APP_SERVER__CERT__STORE__SOURCE=filesystem
 #
 # ACME-DNS (self-hosted, credentials from the /register response)
 # APP_SERVER__CERT__DNS__ACMEDNS__SERVER_URL=
+# Default account (used for domains without a per-domain entry below)
 # APP_SERVER__CERT__DNS__ACMEDNS__USERNAME=
 # APP_SERVER__CERT__DNS__ACMEDNS__PASSWORD=
 # APP_SERVER__CERT__DNS__ACMEDNS__SUBDOMAIN=
+# Optional per-domain accounts as a JSON object (one registration per domain),
+# e.g. {"a.example.com": {"username": "u", "password": "p", "subdomain": "s"}}
+# APP_SERVER__CERT__DNS__ACMEDNS__ACCOUNTS=
 
 # Postgres connection string
 APP_DATABASE__URL=postgres://postgres:postgres@db:5432/status-list

--- a/docs/dns-providers.md
+++ b/docs/dns-providers.md
@@ -82,6 +82,7 @@ needs no credentials for it.
 ```bash
 APP_SERVER__CERT__DNS__PROVIDER=acmedns
 APP_SERVER__CERT__DNS__ACMEDNS__SERVER_URL=https://auth.example.org
+# Default account, used for every domain without a per-domain entry:
 APP_SERVER__CERT__DNS__ACMEDNS__USERNAME=<username from registration>
 APP_SERVER__CERT__DNS__ACMEDNS__PASSWORD=<password from registration>
 APP_SERVER__CERT__DNS__ACMEDNS__SUBDOMAIN=<subdomain from registration>
@@ -94,11 +95,33 @@ Setup:
 2. Create a CNAME record at your primary DNS provider from
    `_acme-challenge.<domain>` to the returned `fulldomain`.
 
-Note: ACME-DNS keeps only the two most recent TXT values and has no delete
-endpoint, so record cleanup after a challenge is a no-op. Because all domains
-share the single configured ACME-DNS subdomain, certificates with more than
-two identifiers (e.g. more than two SANs) are not supported with this
-provider — earlier challenge values would be rotated out before validation.
+### Per-domain accounts
+
+ACME-DNS keeps only the two most recent TXT values per subdomain and has no
+delete endpoint, so record cleanup after a challenge is a no-op. With a single
+account, all identifiers of an order share that two-value window, which limits
+a certificate to two identifiers (an apex + wildcard pair fits, since both TXT
+values live at the same name). To lift the limit, register one account per
+domain and map them — the same model lego and acme.sh use:
+
+```bash
+APP_SERVER__CERT__DNS__ACMEDNS__ACCOUNTS='{
+  "a.example.com": {"username": "<u1>", "password": "<p1>", "subdomain": "<s1>"},
+  "b.example.com": {"username": "<u2>", "password": "<p2>", "subdomain": "<s2>"}
+}'
+```
+
+Each mapped domain needs its own registration (step 1) and its own
+`_acme-challenge.<domain>` CNAME to that account's `fulldomain` (step 2).
+Write keys as they appear in the certificate order — punycode (a-labels,
+e.g. `xn--mnchen-3ya.example.com`) for internationalized names — and write
+wildcard domains as their base domain (`example.com`, not `*.example.com`),
+since an apex and its wildcard share one CNAME and therefore one account.
+Keys are matched case-insensitively, ignoring any trailing dot; two entries
+that reduce to the same domain but hold different credentials are rejected
+at startup. Domains without an entry fall back to the default account; at
+least one of the two must be configured. The server fails at startup when
+the configured server domain is covered by neither.
 
 ## Pebble (`pebble`)
 

--- a/docs/dns-providers.md
+++ b/docs/dns-providers.md
@@ -121,7 +121,12 @@ Keys are matched case-insensitively, ignoring any trailing dot; two entries
 that reduce to the same domain but hold different credentials are rejected
 at startup. Domains without an entry fall back to the default account; at
 least one of the two must be configured. The server fails at startup when
-the configured server domain is covered by neither.
+a certificate domain is covered by neither, or when one account would have
+to serve more than two identifiers of the certificate at once.
+
+All accounts must be registered on the one ACME-DNS server named by
+`SERVER_URL`; spreading accounts across multiple ACME-DNS servers is not
+supported.
 
 ## Pebble (`pebble`)
 

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -77,8 +77,9 @@ statuslist:
     # DNS provider for ACME DNS-01 challenges: route53 | cloudflare | gcloud | azure | acmedns
     # (pebble also exists but is a development-only fake, not for deployments)
     # See docs/dns-providers.md for the settings each provider needs.
-    # Provider credentials (e.g. APP_SERVER__CERT__DNS__CLOUDFLARE__API_TOKEN) must come
-    # from a secret (see externalSecret below), not from plain env values.
+    # Provider credentials (e.g. APP_SERVER__CERT__DNS__CLOUDFLARE__API_TOKEN, or the
+    # APP_SERVER__CERT__DNS__ACMEDNS__ACCOUNTS JSON, which holds every account password)
+    # must come from a secret (see externalSecret below), not from plain env values.
     APP_SERVER__CERT__DNS__PROVIDER: "route53"
     APP_REDIS__REQUIRE_CLIENT_AUTH: "false"
     APP_AWS__SECRETS_CACHE_TTL: "300"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap, fmt, marker::PhantomData, time::Duration};
 
 use config::{Config as ConfigLib, ConfigError, Environment};
 use redis::{
@@ -243,6 +243,34 @@ impl AcmeDnsConfig {
                     .to_string(),
             ));
         }
+        // Reject unusable per-domain entries here instead of as an opaque
+        // HTTP 401 at the first renewal
+        for (domain, account) in &self.accounts {
+            let name = domain.trim();
+            let name = name.strip_prefix("*.").unwrap_or(name);
+            if name.trim_end_matches('.').is_empty() {
+                return Err(ConfigError::Message(format!(
+                    "ACME-DNS accounts entry {domain:?} does not name a domain"
+                )));
+            }
+            let empty: Vec<&str> = [
+                ("username", account.username.trim().is_empty()),
+                (
+                    "password",
+                    account.password.expose_secret().trim().is_empty(),
+                ),
+                ("subdomain", account.subdomain.trim().is_empty()),
+            ]
+            .into_iter()
+            .filter_map(|(field, is_empty)| is_empty.then_some(field))
+            .collect();
+            if !empty.is_empty() {
+                return Err(ConfigError::Message(format!(
+                    "ACME-DNS account for {domain} has empty required fields: {}",
+                    empty.join(", ")
+                )));
+            }
+        }
         Ok(())
     }
 }
@@ -257,18 +285,37 @@ where
     D: serde::Deserializer<'de>,
     V: serde::de::DeserializeOwned,
 {
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum MapOrString<V> {
-        Map(HashMap<String, V>),
-        String(String),
+    // A visitor (rather than an untagged enum) so errors inside a map value
+    // surface as-is instead of as "did not match any variant"
+    struct MapOrString<V>(PhantomData<V>);
+
+    impl<'de, V: serde::de::DeserializeOwned> serde::de::Visitor<'de> for MapOrString<V> {
+        type Value = HashMap<String, V>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("a map or a JSON object string")
+        }
+
+        fn visit_str<E: serde::de::Error>(self, raw: &str) -> Result<Self::Value, E> {
+            if raw.trim().is_empty() {
+                return Ok(HashMap::new());
+            }
+            serde_json::from_str(raw).map_err(E::custom)
+        }
+
+        fn visit_map<A: serde::de::MapAccess<'de>>(
+            self,
+            mut access: A,
+        ) -> Result<Self::Value, A::Error> {
+            let mut map = HashMap::with_capacity(access.size_hint().unwrap_or(0));
+            while let Some((key, value)) = access.next_entry()? {
+                map.insert(key, value);
+            }
+            Ok(map)
+        }
     }
 
-    match MapOrString::deserialize(deserializer)? {
-        MapOrString::Map(map) => Ok(map),
-        MapOrString::String(raw) if raw.trim().is_empty() => Ok(HashMap::new()),
-        MapOrString::String(raw) => serde_json::from_str(&raw).map_err(serde::de::Error::custom),
-    }
+    deserializer.deserialize_any(MapOrString(PhantomData))
 }
 
 impl AzureDnsConfig {
@@ -764,6 +811,45 @@ mod tests {
         };
         let err = dns.resolve("production").unwrap_err();
         assert!(err.to_string().contains("dns.gcloud"));
+    }
+
+    #[test]
+    fn test_acme_dns_rejects_unusable_account_entries() {
+        let acmedns = |accounts: HashMap<String, AcmeDnsAccount>| DnsConfig {
+            provider: Some(DnsProviderKind::Acmedns),
+            acmedns: Some(AcmeDnsConfig {
+                server_url: "https://auth.example.org".into(),
+                username: None,
+                password: None,
+                subdomain: None,
+                accounts,
+            }),
+            ..Default::default()
+        };
+        let account = |username: &str, subdomain: &str| AcmeDnsAccount {
+            username: username.into(),
+            password: "password".into(),
+            subdomain: subdomain.into(),
+        };
+
+        // An entry with empty fields is rejected, naming the domain and fields
+        let dns = acmedns([("status.example.com".to_string(), account("", " "))].into());
+        let err = dns.resolve("production").unwrap_err().to_string();
+        assert!(err.contains("status.example.com"));
+        assert!(err.contains("username"));
+        assert!(err.contains("subdomain"));
+        assert!(!err.contains("password"));
+
+        // A key that does not name a domain is rejected
+        for key in ["", "  ", "*.", "."] {
+            let dns = acmedns([(key.to_string(), account("user", "sub"))].into());
+            let err = dns.resolve("production").unwrap_err().to_string();
+            assert!(err.contains("does not name a domain"), "key {key:?}: {err}");
+        }
+
+        // A usable entry passes
+        let dns = acmedns([("status.example.com".to_string(), account("user", "sub"))].into());
+        assert_eq!(dns.resolve("production").unwrap(), DnsProviderKind::Acmedns);
     }
 
     #[sealed_test(env = [

--- a/src/config.rs
+++ b/src/config.rs
@@ -195,25 +195,39 @@ pub struct AcmeDnsAccount {
     pub subdomain: String,
 }
 
+/// Treat unset and empty (e.g. an env var set to an empty string) alike
+fn non_empty(value: &Option<String>) -> Option<&String> {
+    value.as_ref().filter(|v| !v.trim().is_empty())
+}
+
 impl AcmeDnsConfig {
     /// The default account, when username, password and subdomain are all set
+    /// (empty values count as unset)
     pub fn default_account(&self) -> Option<AcmeDnsAccount> {
-        match (&self.username, &self.password, &self.subdomain) {
-            (Some(username), Some(password), Some(subdomain)) => Some(AcmeDnsAccount {
-                username: username.clone(),
-                password: password.clone(),
-                subdomain: subdomain.clone(),
-            }),
-            _ => None,
-        }
+        let password = self
+            .password
+            .as_ref()
+            .filter(|p| !p.expose_secret().trim().is_empty())?;
+        Some(AcmeDnsAccount {
+            username: non_empty(&self.username)?.clone(),
+            password: password.clone(),
+            subdomain: non_empty(&self.subdomain)?.clone(),
+        })
     }
 
     /// Validate that the settings describe at least one usable account
     fn validate(&self) -> Result<(), ConfigError> {
+        if self.server_url.trim().is_empty() {
+            return Err(ConfigError::Message(
+                "ACME-DNS settings have an empty server_url".to_string(),
+            ));
+        }
         let set = [
-            self.username.is_some(),
-            self.password.is_some(),
-            self.subdomain.is_some(),
+            non_empty(&self.username).is_some(),
+            self.password
+                .as_ref()
+                .is_some_and(|p| !p.expose_secret().trim().is_empty()),
+            non_empty(&self.subdomain).is_some(),
         ];
         if set.iter().any(|&s| s) && !set.iter().all(|&s| s) {
             return Err(ConfigError::Message(
@@ -257,6 +271,44 @@ where
     }
 }
 
+impl AzureDnsConfig {
+    /// Reject empty required fields so misconfigurations fail at startup
+    /// instead of surfacing as opaque API errors at the first renewal
+    fn validate(&self) -> Result<(), ConfigError> {
+        let empty: Vec<&str> = [
+            ("tenant_id", self.tenant_id.trim().is_empty()),
+            ("client_id", self.client_id.trim().is_empty()),
+            (
+                "client_secret",
+                self.client_secret.expose_secret().trim().is_empty(),
+            ),
+            ("subscription_id", self.subscription_id.trim().is_empty()),
+            ("resource_group", self.resource_group.trim().is_empty()),
+        ]
+        .into_iter()
+        .filter_map(|(name, is_empty)| is_empty.then_some(name))
+        .collect();
+        if !empty.is_empty() {
+            return Err(ConfigError::Message(format!(
+                "Azure DNS settings have empty required fields: {}",
+                empty.join(", ")
+            )));
+        }
+        Ok(())
+    }
+}
+
+impl CloudflareDnsConfig {
+    fn validate(&self) -> Result<(), ConfigError> {
+        if self.api_token.expose_secret().trim().is_empty() {
+            return Err(ConfigError::Message(
+                "Cloudflare DNS settings have an empty api_token".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
 impl DnsConfig {
     /// Resolve the DNS provider to use and validate that its settings are present.
     pub fn resolve(&self, app_env: &str) -> Result<DnsProviderKind, ConfigError> {
@@ -270,7 +322,10 @@ impl DnsConfig {
             DnsProviderKind::Cloudflare if self.cloudflare.is_none() => Some("dns.cloudflare"),
             DnsProviderKind::Gcloud
                 if self.gcloud.as_ref().is_none_or(|g| {
-                    g.service_account_key.is_none() && g.service_account_key_path.is_none()
+                    g.service_account_key
+                        .as_ref()
+                        .is_none_or(|k| k.expose_secret().trim().is_empty())
+                        && non_empty(&g.service_account_key_path).is_none()
                 }) =>
             {
                 Some("dns.gcloud")
@@ -284,10 +339,23 @@ impl DnsConfig {
                 "DNS provider {kind:?} selected but the server.cert.{section} settings are missing"
             )));
         }
-        if kind == DnsProviderKind::Acmedns
-            && let Some(acmedns) = &self.acmedns
-        {
-            acmedns.validate()?;
+        match kind {
+            DnsProviderKind::Cloudflare => {
+                if let Some(cloudflare) = &self.cloudflare {
+                    cloudflare.validate()?;
+                }
+            }
+            DnsProviderKind::Azure => {
+                if let Some(azure) = &self.azure {
+                    azure.validate()?;
+                }
+            }
+            DnsProviderKind::Acmedns => {
+                if let Some(acmedns) = &self.acmedns {
+                    acmedns.validate()?;
+                }
+            }
+            _ => {}
         }
         Ok(kind)
     }
@@ -618,6 +686,84 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(dns.resolve("production").unwrap(), DnsProviderKind::Gcloud);
+    }
+
+    #[test]
+    fn test_dns_provider_rejects_empty_required_fields() {
+        // Azure names exactly the empty fields
+        let azure = |tenant_id: &str, subscription_id: &str| DnsConfig {
+            provider: Some(DnsProviderKind::Azure),
+            azure: Some(AzureDnsConfig {
+                tenant_id: tenant_id.into(),
+                client_id: "client".into(),
+                client_secret: "secret".into(),
+                subscription_id: subscription_id.into(),
+                resource_group: "rg".into(),
+            }),
+            ..Default::default()
+        };
+        let err = azure("", " ")
+            .resolve("production")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("tenant_id"));
+        assert!(err.contains("subscription_id"));
+        assert!(!err.contains("client_id"));
+        assert_eq!(
+            azure("tenant", "sub").resolve("production").unwrap(),
+            DnsProviderKind::Azure
+        );
+
+        // Cloudflare rejects an empty api_token
+        let dns = DnsConfig {
+            provider: Some(DnsProviderKind::Cloudflare),
+            cloudflare: Some(CloudflareDnsConfig {
+                api_token: "".into(),
+            }),
+            ..Default::default()
+        };
+        let err = dns.resolve("production").unwrap_err();
+        assert!(err.to_string().contains("api_token"));
+
+        // ACME-DNS rejects an empty server_url
+        let acmedns = |cfg: AcmeDnsConfig| DnsConfig {
+            provider: Some(DnsProviderKind::Acmedns),
+            acmedns: Some(cfg),
+            ..Default::default()
+        };
+        let dns = acmedns(AcmeDnsConfig {
+            server_url: " ".into(),
+            username: Some("user".into()),
+            password: Some("password".into()),
+            subdomain: Some("subdomain".into()),
+            accounts: Default::default(),
+        });
+        let err = dns.resolve("production").unwrap_err();
+        assert!(err.to_string().contains("server_url"));
+
+        // An empty default-account field counts as unset, so the account
+        // is partial rather than silently unusable
+        let dns = acmedns(AcmeDnsConfig {
+            server_url: "https://auth.example.org".into(),
+            username: Some("user".into()),
+            password: Some("password".into()),
+            subdomain: Some("".into()),
+            accounts: Default::default(),
+        });
+        let err = dns.resolve("production").unwrap_err();
+        assert!(err.to_string().contains("must be set together"));
+
+        // Gcloud with both key sources empty counts as missing
+        let dns = DnsConfig {
+            provider: Some(DnsProviderKind::Gcloud),
+            gcloud: Some(GcloudDnsConfig {
+                service_account_key: Some("".into()),
+                service_account_key_path: Some(" ".into()),
+            }),
+            ..Default::default()
+        };
+        let err = dns.resolve("production").unwrap_err();
+        assert!(err.to_string().contains("dns.gcloud"));
     }
 
     #[sealed_test(env = [

--- a/src/config.rs
+++ b/src/config.rs
@@ -244,7 +244,9 @@ impl AcmeDnsConfig {
             ));
         }
         // Reject unusable per-domain entries here instead of as an opaque
-        // HTTP 401 at the first renewal
+        // HTTP 401 at the first renewal. Key conflicts under normalization
+        // are the provider's own invariant and are rejected in
+        // AcmeDnsProvider::new, also at startup.
         for (domain, account) in &self.accounts {
             let name = domain.trim();
             let name = name.strip_prefix("*.").unwrap_or(name);

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
 use config::{Config as ConfigLib, ConfigError, Environment};
 use redis::{
@@ -174,67 +174,86 @@ pub struct CloudflareDnsConfig {
 pub struct AcmeDnsConfig {
     /// Base URL of the ACME-DNS server, e.g. <https://auth.example.org>
     pub server_url: String,
+    /// Default account, used for domains without an entry in `accounts`.
+    /// The three fields must be set together.
+    pub username: Option<String>,
+    pub password: Option<SecretString>,
+    /// Subdomain returned by the ACME-DNS registration
+    pub subdomain: Option<String>,
+    /// Per-domain accounts keyed by identifier (e.g. `status.example.com`),
+    /// so each identifier gets its own two-value TXT window. Accepts a map
+    /// or a JSON object string, allowing the whole map in one env var.
+    #[serde(default, deserialize_with = "deserialize_map_from_string_or_map")]
+    pub accounts: HashMap<String, AcmeDnsAccount>,
+}
+
+/// A single registered ACME-DNS account
+#[derive(Debug, Clone, Deserialize)]
+pub struct AcmeDnsAccount {
     pub username: String,
     pub password: SecretString,
-    /// Subdomain returned by the ACME-DNS registration
     pub subdomain: String,
 }
 
-/// Report the required fields whose value is empty, so misconfigurations
-/// (e.g. an env var set to an empty string) fail at startup instead of
-/// surfacing as opaque API errors at the first renewal
-fn empty_fields(fields: &[(&'static str, bool)]) -> Option<String> {
-    let empty: Vec<&str> = fields
-        .iter()
-        .filter_map(|&(name, is_empty)| is_empty.then_some(name))
-        .collect();
-    (!empty.is_empty()).then(|| empty.join(", "))
-}
-
-impl AzureDnsConfig {
-    fn validate(&self) -> Result<(), ConfigError> {
-        if let Some(fields) = empty_fields(&[
-            ("tenant_id", self.tenant_id.trim().is_empty()),
-            ("client_id", self.client_id.trim().is_empty()),
-            (
-                "client_secret",
-                self.client_secret.expose_secret().trim().is_empty(),
-            ),
-            ("subscription_id", self.subscription_id.trim().is_empty()),
-            ("resource_group", self.resource_group.trim().is_empty()),
-        ]) {
-            return Err(ConfigError::Message(format!(
-                "Azure DNS settings have empty required fields: {fields}"
-            )));
+impl AcmeDnsConfig {
+    /// The default account, when username, password and subdomain are all set
+    pub fn default_account(&self) -> Option<AcmeDnsAccount> {
+        match (&self.username, &self.password, &self.subdomain) {
+            (Some(username), Some(password), Some(subdomain)) => Some(AcmeDnsAccount {
+                username: username.clone(),
+                password: password.clone(),
+                subdomain: subdomain.clone(),
+            }),
+            _ => None,
         }
-        Ok(())
     }
-}
 
-impl CloudflareDnsConfig {
+    /// Validate that the settings describe at least one usable account
     fn validate(&self) -> Result<(), ConfigError> {
-        if self.api_token.expose_secret().trim().is_empty() {
+        let set = [
+            self.username.is_some(),
+            self.password.is_some(),
+            self.subdomain.is_some(),
+        ];
+        if set.iter().any(|&s| s) && !set.iter().all(|&s| s) {
             return Err(ConfigError::Message(
-                "Cloudflare DNS settings have an empty api_token".to_string(),
+                "Incomplete ACME-DNS default account: username, password and subdomain \
+                 must be set together"
+                    .to_string(),
+            ));
+        }
+        if self.default_account().is_none() && self.accounts.is_empty() {
+            return Err(ConfigError::Message(
+                "ACME-DNS settings need a default account (username/password/subdomain) \
+                 or a non-empty accounts map"
+                    .to_string(),
             ));
         }
         Ok(())
     }
 }
 
-impl AcmeDnsConfig {
-    fn validate(&self) -> Result<(), ConfigError> {
-        if let Some(fields) = empty_fields(&[
-            ("server_url", self.server_url.trim().is_empty()),
-            ("username", self.username.trim().is_empty()),
-            ("password", self.password.expose_secret().trim().is_empty()),
-            ("subdomain", self.subdomain.trim().is_empty()),
-        ]) {
-            return Err(ConfigError::Message(format!(
-                "ACME-DNS settings have empty required fields: {fields}"
-            )));
-        }
-        Ok(())
+/// Deserialize a map either directly or from a JSON object string, so it can
+/// be provided via a single environment variable (map keys such as domain
+/// names cannot be encoded in `__`-separated env var names).
+fn deserialize_map_from_string_or_map<'de, D, V>(
+    deserializer: D,
+) -> Result<HashMap<String, V>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    V: serde::de::DeserializeOwned,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum MapOrString<V> {
+        Map(HashMap<String, V>),
+        String(String),
+    }
+
+    match MapOrString::deserialize(deserializer)? {
+        MapOrString::Map(map) => Ok(map),
+        MapOrString::String(raw) if raw.trim().is_empty() => Ok(HashMap::new()),
+        MapOrString::String(raw) => serde_json::from_str(&raw).map_err(serde::de::Error::custom),
     }
 }
 
@@ -249,15 +268,9 @@ impl DnsConfig {
 
         let missing = match kind {
             DnsProviderKind::Cloudflare if self.cloudflare.is_none() => Some("dns.cloudflare"),
-            // Empty key sources count as unset
             DnsProviderKind::Gcloud
                 if self.gcloud.as_ref().is_none_or(|g| {
-                    g.service_account_key
-                        .as_ref()
-                        .is_none_or(|k| k.expose_secret().trim().is_empty())
-                        && g.service_account_key_path
-                            .as_ref()
-                            .is_none_or(|p| p.trim().is_empty())
+                    g.service_account_key.is_none() && g.service_account_key_path.is_none()
                 }) =>
             {
                 Some("dns.gcloud")
@@ -271,23 +284,10 @@ impl DnsConfig {
                 "DNS provider {kind:?} selected but the server.cert.{section} settings are missing"
             )));
         }
-        match kind {
-            DnsProviderKind::Cloudflare => {
-                if let Some(cloudflare) = &self.cloudflare {
-                    cloudflare.validate()?;
-                }
-            }
-            DnsProviderKind::Azure => {
-                if let Some(azure) = &self.azure {
-                    azure.validate()?;
-                }
-            }
-            DnsProviderKind::Acmedns => {
-                if let Some(acmedns) = &self.acmedns {
-                    acmedns.validate()?;
-                }
-            }
-            _ => {}
+        if kind == DnsProviderKind::Acmedns
+            && let Some(acmedns) = &self.acmedns
+        {
+            acmedns.validate()?;
         }
         Ok(kind)
     }
@@ -545,6 +545,58 @@ mod tests {
         let err = dns.resolve("production").unwrap_err();
         assert!(err.to_string().contains("dns.acmedns"));
 
+        // Legacy single-account config still resolves unchanged
+        let acmedns = |cfg: AcmeDnsConfig| DnsConfig {
+            provider: Some(DnsProviderKind::Acmedns),
+            acmedns: Some(cfg),
+            ..Default::default()
+        };
+        let dns = acmedns(AcmeDnsConfig {
+            server_url: "https://auth.example.org".into(),
+            username: Some("user".into()),
+            password: Some("password".into()),
+            subdomain: Some("subdomain".into()),
+            accounts: Default::default(),
+        });
+        assert_eq!(dns.resolve("production").unwrap(), DnsProviderKind::Acmedns);
+
+        // A per-domain accounts map alone is enough
+        let account = AcmeDnsAccount {
+            username: "user".into(),
+            password: "password".into(),
+            subdomain: "subdomain".into(),
+        };
+        let dns = acmedns(AcmeDnsConfig {
+            server_url: "https://auth.example.org".into(),
+            username: None,
+            password: None,
+            subdomain: None,
+            accounts: [("status.example.com".to_string(), account)].into(),
+        });
+        assert_eq!(dns.resolve("production").unwrap(), DnsProviderKind::Acmedns);
+
+        // A partial default account is rejected
+        let dns = acmedns(AcmeDnsConfig {
+            server_url: "https://auth.example.org".into(),
+            username: Some("user".into()),
+            password: None,
+            subdomain: None,
+            accounts: Default::default(),
+        });
+        let err = dns.resolve("production").unwrap_err();
+        assert!(err.to_string().contains("must be set together"));
+
+        // Neither a default account nor a map is rejected
+        let dns = acmedns(AcmeDnsConfig {
+            server_url: "https://auth.example.org".into(),
+            username: None,
+            password: None,
+            subdomain: None,
+            accounts: Default::default(),
+        });
+        let err = dns.resolve("production").unwrap_err();
+        assert!(err.to_string().contains("default account"));
+
         // Gcloud needs the key inline or as a file path
         let dns = DnsConfig {
             provider: Some(DnsProviderKind::Gcloud),
@@ -568,70 +620,43 @@ mod tests {
         assert_eq!(dns.resolve("production").unwrap(), DnsProviderKind::Gcloud);
     }
 
-    #[test]
-    fn test_dns_provider_rejects_empty_required_fields() {
-        // Azure names exactly the empty fields
-        let azure = |tenant_id: &str, subscription_id: &str| DnsConfig {
-            provider: Some(DnsProviderKind::Azure),
-            azure: Some(AzureDnsConfig {
-                tenant_id: tenant_id.into(),
-                client_id: "client".into(),
-                client_secret: "secret".into(),
-                subscription_id: subscription_id.into(),
-                resource_group: "rg".into(),
-            }),
-            ..Default::default()
-        };
-        let err = azure("", " ")
-            .resolve("production")
-            .unwrap_err()
-            .to_string();
-        assert!(err.contains("tenant_id"));
-        assert!(err.contains("subscription_id"));
-        assert!(!err.contains("client_id"));
-        assert_eq!(
-            azure("tenant", "sub").resolve("production").unwrap(),
-            DnsProviderKind::Azure
-        );
+    #[sealed_test(env = [
+        ("APP_SERVER__CERT__DNS__ACMEDNS__SERVER_URL", "https://auth.example.org"),
+        ("APP_SERVER__CERT__DNS__ACMEDNS__ACCOUNTS", r#"{
+            "a.example.com": {"username": "u1", "password": "p1", "subdomain": "s1"},
+            "b.example.com": {"username": "u2", "password": "p2", "subdomain": "s2"}
+        }"#),
+    ])]
+    fn test_acme_dns_accounts_parse_from_env_json() {
+        let config = Config::load().expect("Failed to load config");
 
-        // Cloudflare rejects an empty api_token
-        let dns = DnsConfig {
-            provider: Some(DnsProviderKind::Cloudflare),
-            cloudflare: Some(CloudflareDnsConfig {
-                api_token: "".into(),
-            }),
-            ..Default::default()
-        };
-        let err = dns.resolve("production").unwrap_err();
-        assert!(err.to_string().contains("api_token"));
+        let acmedns = config.server.cert.dns.acmedns.expect("acmedns settings");
+        assert_eq!(acmedns.server_url, "https://auth.example.org");
+        assert!(acmedns.default_account().is_none());
+        assert_eq!(acmedns.accounts.len(), 2);
+        let account = &acmedns.accounts["b.example.com"];
+        assert_eq!(account.username, "u2");
+        assert_eq!(account.password.expose_secret(), "p2");
+        assert_eq!(account.subdomain, "s2");
+    }
 
-        // ACME-DNS names exactly the empty fields
-        let dns = DnsConfig {
-            provider: Some(DnsProviderKind::Acmedns),
-            acmedns: Some(AcmeDnsConfig {
-                server_url: " ".into(),
-                username: "".into(),
-                password: "password".into(),
-                subdomain: "subdomain".into(),
-            }),
-            ..Default::default()
-        };
-        let err = dns.resolve("production").unwrap_err().to_string();
-        assert!(err.contains("server_url"));
-        assert!(err.contains("username"));
-        assert!(!err.contains("subdomain"));
+    #[sealed_test(env = [
+        ("APP_SERVER__CERT__DNS__ACMEDNS__SERVER_URL", "https://auth.example.org"),
+        ("APP_SERVER__CERT__DNS__ACMEDNS__ACCOUNTS", r#"{"a.example.com": not valid json"#),
+    ])]
+    fn test_acme_dns_accounts_reject_malformed_json() {
+        Config::load().expect_err("malformed accounts JSON must fail config loading");
+    }
 
-        // Gcloud with both key sources empty counts as missing
-        let dns = DnsConfig {
-            provider: Some(DnsProviderKind::Gcloud),
-            gcloud: Some(GcloudDnsConfig {
-                service_account_key: Some("".into()),
-                service_account_key_path: Some(" ".into()),
-            }),
-            ..Default::default()
-        };
-        let err = dns.resolve("production").unwrap_err();
-        assert!(err.to_string().contains("dns.gcloud"));
+    #[sealed_test(env = [
+        ("APP_SERVER__CERT__DNS__ACMEDNS__SERVER_URL", "https://auth.example.org"),
+        ("APP_SERVER__CERT__DNS__ACMEDNS__ACCOUNTS", ""),
+    ])]
+    fn test_acme_dns_accounts_empty_env_var_means_no_accounts() {
+        let config = Config::load().expect("Failed to load config");
+
+        let acmedns = config.server.cert.dns.acmedns.expect("acmedns settings");
+        assert!(acmedns.accounts.is_empty());
     }
 
     #[sealed_test(env = [

--- a/src/utils/cert_manager/challenge.rs
+++ b/src/utils/cert_manager/challenge.rs
@@ -2,8 +2,9 @@ mod dns01;
 mod http01;
 
 pub use dns01::{
-    AcmeDnsProvider, AwsRoute53DnsProvider, AzureDnsProvider, CloudflareDnsProvider, Dns01Handler,
-    DnsProvider, GoogleCloudDnsProvider, PebbleDnsProvider, ServicePrincipal,
+    AcmeDnsCredentials, AcmeDnsProvider, AwsRoute53DnsProvider, AzureDnsProvider,
+    CloudflareDnsProvider, Dns01Handler, DnsProvider, GoogleCloudDnsProvider, PebbleDnsProvider,
+    ServicePrincipal,
 };
 pub use http01::Http01Handler;
 

--- a/src/utils/cert_manager/challenge/dns01/acme_dns.rs
+++ b/src/utils/cert_manager/challenge/dns01/acme_dns.rs
@@ -106,6 +106,32 @@ impl AcmeDnsProvider {
         self.credentials_for(domain).is_ok()
     }
 
+    /// Validate that a certificate order for `domains` can succeed: every
+    /// domain must resolve to an account, and no account may serve more than
+    /// two of them, since a third digest would rotate the first out of the
+    /// account's two-value TXT window before the CA validates it. Meant to
+    /// run at startup, so the gap is caught before the first renewal.
+    pub fn check_order_domains(&self, domains: &[&str]) -> Result<(), ChallengeError> {
+        let mut by_account: HashMap<&str, Vec<&str>> = HashMap::new();
+        for domain in domains {
+            let account = self.credentials_for(domain)?;
+            by_account
+                .entry(account.subdomain.as_str())
+                .or_default()
+                .push(domain);
+        }
+        if let Some((subdomain, domains)) = by_account.iter().find(|(_, d)| d.len() > 2) {
+            return Err(dns_err(eyre!(
+                "The ACME-DNS account with subdomain {subdomain} would serve {} identifiers \
+                 ({}), but ACME-DNS keeps only the two most recent TXT values; register a \
+                 separate account per domain in the accounts map",
+                domains.len(),
+                domains.join(", "),
+            )));
+        }
+        Ok(())
+    }
+
     /// Select the account for a domain: per-domain entry first, then the default
     fn credentials_for(&self, domain: &str) -> Result<&AcmeDnsCredentials, ChallengeError> {
         self.accounts
@@ -144,7 +170,12 @@ impl DnsProvider for AcmeDnsProvider {
             )));
         }
 
-        info!("ACME-DNS TXT record updated for {domain}");
+        // Naming the subdomain makes a wrong account selection (e.g. a typoed
+        // map key silently falling back to the default) visible in the logs
+        info!(
+            "ACME-DNS TXT record updated for {domain} via subdomain {}",
+            account.subdomain
+        );
         Ok(())
     }
 
@@ -322,6 +353,92 @@ mod tests {
             .create_txt_record("other.example.com", "digest-value")
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn mapped_account_wins_over_the_default() {
+        let server = MockServer::start().await;
+        let (default, mapped) = (account("default"), account("mapped"));
+        // Only the mapped account may be used; a request authenticated as the
+        // default account would not match this mock and fail the test
+        expect_update(&server, &mapped, "digest-value").await;
+
+        let provider = AcmeDnsProvider::new(
+            server.uri(),
+            Some(default),
+            HashMap::from([("mapped.example.com".to_string(), mapped)]),
+        )
+        .unwrap();
+
+        provider
+            .create_txt_record("mapped.example.com", "digest-value")
+            .await
+            .unwrap();
+    }
+
+    #[test]
+    fn check_order_domains_rejects_three_identifiers_on_one_account() {
+        let provider = AcmeDnsProvider::new(
+            "https://auth.example.org",
+            Some(account("default")),
+            HashMap::new(),
+        )
+        .unwrap();
+
+        // An apex + wildcard pair fits the account's two-value TXT window
+        provider
+            .check_order_domains(&["example.com", "*.example.com"])
+            .unwrap();
+
+        // A third identifier on the same account would rotate a digest out
+        let err = provider
+            .check_order_domains(&["a.example.com", "b.example.com", "c.example.com"])
+            .unwrap_err();
+        match err {
+            ChallengeError::Dns { provider, source } => {
+                assert_eq!(provider, "acmedns");
+                let message = source.to_string();
+                assert!(message.contains("sub-default"));
+                assert!(message.contains("a.example.com, b.example.com, c.example.com"));
+            }
+            other => panic!("Unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn check_order_domains_passes_when_identifiers_spread_across_accounts() {
+        // Two identifiers on the default plus one mapped: every two-value
+        // window holds at most two digests
+        let provider = AcmeDnsProvider::new(
+            "https://auth.example.org",
+            Some(account("default")),
+            HashMap::from([("c.example.com".to_string(), account("c"))]),
+        )
+        .unwrap();
+
+        provider
+            .check_order_domains(&["a.example.com", "b.example.com", "c.example.com"])
+            .unwrap();
+    }
+
+    #[test]
+    fn check_order_domains_reports_the_uncovered_domain() {
+        let provider = AcmeDnsProvider::new(
+            "https://auth.example.org",
+            None,
+            HashMap::from([("mapped.example.com".to_string(), account("mapped"))]),
+        )
+        .unwrap();
+
+        let err = provider
+            .check_order_domains(&["other.example.com"])
+            .unwrap_err();
+        match err {
+            ChallengeError::Dns { source, .. } => {
+                assert!(source.to_string().contains("other.example.com"));
+            }
+            other => panic!("Unexpected error: {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/src/utils/cert_manager/challenge/dns01/acme_dns.rs
+++ b/src/utils/cert_manager/challenge/dns01/acme_dns.rs
@@ -1,3 +1,5 @@
+use std::collections::{HashMap, hash_map::Entry};
+
 use async_trait::async_trait;
 use color_eyre::eyre::{Report, eyre};
 use reqwest::Client;
@@ -10,17 +12,28 @@ use crate::cert_manager::challenge::ChallengeError;
 
 const PROVIDER: &str = "acmedns";
 
+/// Credentials of a single registered ACME-DNS account
+#[derive(Clone)]
+pub struct AcmeDnsCredentials {
+    pub username: String,
+    pub password: SecretString,
+    pub subdomain: String,
+}
+
 /// A DNS provider for a self-hosted ACME-DNS server (<https://github.com/joohoi/acme-dns>).
 ///
-/// Requires a pre-registered account and a CNAME from `_acme-challenge.<domain>`
-/// to the registered ACME-DNS subdomain. ACME-DNS serves updates immediately
-/// and keeps the two most recent TXT values, so deletion is a no-op.
+/// Requires pre-registered accounts and a CNAME from `_acme-challenge.<domain>`
+/// to each registered ACME-DNS subdomain. ACME-DNS serves updates immediately
+/// and keeps the two most recent TXT values per subdomain, so deletion is a
+/// no-op. Accounts are selected per domain from `accounts`, falling back to
+/// `default_account`; a dedicated account per identifier keeps orders with
+/// three or more identifiers from rotating digests out before validation.
 pub struct AcmeDnsProvider {
     client: Client,
     server_url: String,
-    username: String,
-    password: SecretString,
-    subdomain: String,
+    default_account: Option<AcmeDnsCredentials>,
+    /// Per-domain accounts keyed by normalized identifier
+    accounts: HashMap<String, AcmeDnsCredentials>,
 }
 
 fn dns_err(source: impl Into<Report>) -> ChallengeError {
@@ -30,34 +43,94 @@ fn dns_err(source: impl Into<Report>) -> ChallengeError {
     }
 }
 
+/// Normalize a domain for account lookup (lowercase, no trailing dot, no
+/// wildcard label) so config keys and ACME identifiers compare equal
+fn normalize_domain(domain: &str) -> String {
+    let domain = domain.trim().trim_end_matches('.');
+    domain
+        .strip_prefix("*.")
+        .unwrap_or(domain)
+        .to_ascii_lowercase()
+}
+
+/// Whether two entries hold the same registered account
+fn same_account(a: &AcmeDnsCredentials, b: &AcmeDnsCredentials) -> bool {
+    a.username == b.username
+        && a.subdomain == b.subdomain
+        && a.password.expose_secret() == b.password.expose_secret()
+}
+
 impl AcmeDnsProvider {
+    /// Fails when two account entries normalize to the same domain but hold
+    /// different credentials, since only one of them could ever be used
     pub fn new(
         server_url: impl Into<String>,
-        username: impl Into<String>,
-        password: SecretString,
-        subdomain: impl Into<String>,
-    ) -> Self {
-        Self {
+        default_account: Option<AcmeDnsCredentials>,
+        accounts: HashMap<String, AcmeDnsCredentials>,
+    ) -> Result<Self, ChallengeError> {
+        let mut normalized: HashMap<String, (String, AcmeDnsCredentials)> =
+            HashMap::with_capacity(accounts.len());
+        for (domain, account) in accounts {
+            match normalized.entry(normalize_domain(&domain)) {
+                Entry::Occupied(entry) => {
+                    let (other, existing) = entry.get();
+                    // Identical duplicates are fine (e.g. an apex and its
+                    // wildcard listed separately with the same account)
+                    if !same_account(existing, &account) {
+                        return Err(dns_err(eyre!(
+                            "Conflicting ACME-DNS accounts: entries {other} and {domain} \
+                             both normalize to {} but hold different credentials",
+                            entry.key(),
+                        )));
+                    }
+                }
+                Entry::Vacant(slot) => {
+                    slot.insert((domain, account));
+                }
+            }
+        }
+
+        Ok(Self {
             client: http_client(),
             server_url: server_url.into().trim_end_matches('/').to_string(),
-            username: username.into(),
-            password,
-            subdomain: subdomain.into(),
-        }
+            default_account,
+            accounts: normalized
+                .into_iter()
+                .map(|(key, (_, account))| (key, account))
+                .collect(),
+        })
+    }
+
+    /// Whether an account is configured for the given domain
+    pub fn has_credentials_for(&self, domain: &str) -> bool {
+        self.credentials_for(domain).is_ok()
+    }
+
+    /// Select the account for a domain: per-domain entry first, then the default
+    fn credentials_for(&self, domain: &str) -> Result<&AcmeDnsCredentials, ChallengeError> {
+        self.accounts
+            .get(&normalize_domain(domain))
+            .or(self.default_account.as_ref())
+            .ok_or_else(|| {
+                dns_err(eyre!(
+                    "No ACME-DNS account configured for {domain} and no default account is set"
+                ))
+            })
     }
 }
 
 #[async_trait]
 impl DnsProvider for AcmeDnsProvider {
     async fn create_txt_record(&self, domain: &str, value: &str) -> Result<(), ChallengeError> {
+        let account = self.credentials_for(domain)?;
         let url = format!("{}/update", self.server_url);
-        let body = json!({"subdomain": self.subdomain, "txt": value});
+        let body = json!({"subdomain": account.subdomain, "txt": value});
 
         let response = self
             .client
             .post(&url)
-            .header("X-Api-User", &self.username)
-            .header("X-Api-Key", self.password.expose_secret())
+            .header("X-Api-User", &account.username)
+            .header("X-Api-Key", account.password.expose_secret())
             .json(&body)
             .send()
             .await
@@ -87,13 +160,41 @@ mod tests {
     use wiremock::matchers::{body_json, header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    fn provider(server: &MockServer) -> AcmeDnsProvider {
+    fn account(name: &str) -> AcmeDnsCredentials {
+        AcmeDnsCredentials {
+            username: format!("user-{name}"),
+            password: format!("key-{name}").into(),
+            subdomain: format!("sub-{name}"),
+        }
+    }
+
+    fn single_account_provider(server: &MockServer) -> AcmeDnsProvider {
         AcmeDnsProvider::new(
             server.uri(),
-            "user-uuid",
-            "api-key".into(),
-            "subdomain-uuid",
+            Some(AcmeDnsCredentials {
+                username: "user-uuid".into(),
+                password: "api-key".into(),
+                subdomain: "subdomain-uuid".into(),
+            }),
+            HashMap::new(),
         )
+        .expect("no account entries to conflict")
+    }
+
+    /// Mount a mock expecting one `/update` authenticated as the given account
+    async fn expect_update(server: &MockServer, account: &AcmeDnsCredentials, txt: &str) {
+        Mock::given(method("POST"))
+            .and(path("/update"))
+            .and(header("x-api-user", account.username.as_str()))
+            .and(header("x-api-key", account.password.expose_secret()))
+            .and(body_json(json!({
+                "subdomain": account.subdomain,
+                "txt": txt,
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"txt": txt})))
+            .expect(1)
+            .mount(server)
+            .await;
     }
 
     #[tokio::test]
@@ -114,7 +215,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        provider(&server)
+        single_account_provider(&server)
             .create_txt_record("status.example.com", "digest-value")
             .await
             .unwrap();
@@ -131,7 +232,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let err = provider(&server)
+        let err = single_account_provider(&server)
             .create_txt_record("status.example.com", "digest-value")
             .await
             .unwrap_err();
@@ -149,9 +250,177 @@ mod tests {
         let server = MockServer::start().await;
         // No mocks mounted: any request would fail the test
 
-        provider(&server)
+        single_account_provider(&server)
             .delete_txt_record("status.example.com", "digest-value")
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn selects_account_by_identifier() {
+        let server = MockServer::start().await;
+        let (a, b) = (account("a"), account("b"));
+        expect_update(&server, &a, "digest-a").await;
+        expect_update(&server, &b, "digest-b").await;
+
+        let provider = AcmeDnsProvider::new(
+            server.uri(),
+            None,
+            HashMap::from([
+                ("a.example.com".to_string(), a),
+                ("b.example.com".to_string(), b),
+            ]),
+        )
+        .unwrap();
+
+        provider
+            .create_txt_record("a.example.com", "digest-a")
+            .await
+            .unwrap();
+        provider
+            .create_txt_record("b.example.com", "digest-b")
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn three_identifiers_update_three_distinct_subdomains() {
+        let server = MockServer::start().await;
+        let domains = ["a.example.com", "b.example.com", "c.example.com"];
+        let mut accounts = HashMap::new();
+        for domain in domains {
+            let acct = account(domain);
+            // Each digest must land exactly once on its own subdomain, so no
+            // account's two-value TXT window ever holds more than one digest
+            expect_update(&server, &acct, &format!("digest-{domain}")).await;
+            accounts.insert(domain.to_string(), acct);
+        }
+
+        let provider = AcmeDnsProvider::new(server.uri(), None, accounts).unwrap();
+        for domain in domains {
+            provider
+                .create_txt_record(domain, &format!("digest-{domain}"))
+                .await
+                .unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn falls_back_to_default_account_for_unmapped_domain() {
+        let server = MockServer::start().await;
+        let default = account("default");
+        expect_update(&server, &default, "digest-value").await;
+
+        let provider = AcmeDnsProvider::new(
+            server.uri(),
+            Some(default),
+            HashMap::from([("mapped.example.com".to_string(), account("mapped"))]),
+        )
+        .unwrap();
+
+        provider
+            .create_txt_record("other.example.com", "digest-value")
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn errors_when_domain_has_no_account_and_no_default() {
+        let server = MockServer::start().await;
+        // No mocks mounted: the lookup must fail before any request is sent
+
+        let provider = AcmeDnsProvider::new(
+            server.uri(),
+            None,
+            HashMap::from([("mapped.example.com".to_string(), account("mapped"))]),
+        )
+        .unwrap();
+
+        let err = provider
+            .create_txt_record("other.example.com", "digest-value")
+            .await
+            .unwrap_err();
+        match err {
+            ChallengeError::Dns { provider, source } => {
+                assert_eq!(provider, "acmedns");
+                assert!(source.to_string().contains("other.example.com"));
+            }
+            other => panic!("Unexpected error: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn normalizes_domains_for_account_lookup() {
+        let server = MockServer::start().await;
+        let acct = account("norm");
+        Mock::given(method("POST"))
+            .and(path("/update"))
+            .and(header("x-api-user", acct.username.as_str()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"txt": "digest-value"})))
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        // Config key differs cosmetically; wildcard identifiers share the
+        // base domain's account (apex + wildcard fit one two-value window)
+        let provider = AcmeDnsProvider::new(
+            server.uri(),
+            None,
+            HashMap::from([("Status.Example.COM.".to_string(), acct)]),
+        )
+        .unwrap();
+
+        provider
+            .create_txt_record("status.example.com", "digest-value")
+            .await
+            .unwrap();
+        provider
+            .create_txt_record("*.status.example.com", "digest-value")
+            .await
+            .unwrap();
+    }
+
+    #[test]
+    fn rejects_conflicting_accounts_for_the_same_normalized_domain() {
+        let err = AcmeDnsProvider::new(
+            "https://auth.example.org",
+            None,
+            HashMap::from([
+                ("A.Example.com".to_string(), account("first")),
+                ("a.example.com.".to_string(), account("second")),
+            ]),
+        )
+        .err()
+        .expect("conflicting entries must be rejected");
+
+        match err {
+            ChallengeError::Dns { provider, source } => {
+                assert_eq!(provider, "acmedns");
+                // Both offending config keys are named in the error
+                let message = source.to_string();
+                assert!(message.contains("A.Example.com"));
+                assert!(message.contains("a.example.com."));
+            }
+            other => panic!("Unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn allows_duplicate_entries_with_identical_accounts() {
+        // An apex and its wildcard listed separately are the legitimate
+        // duplicate: they share one CNAME target, hence one account
+        let acct = account("shared");
+        let provider = AcmeDnsProvider::new(
+            "https://auth.example.org",
+            None,
+            HashMap::from([
+                ("example.com".to_string(), acct.clone()),
+                ("*.example.com".to_string(), acct),
+            ]),
+        )
+        .unwrap();
+
+        assert!(provider.has_credentials_for("example.com"));
+        assert!(provider.has_credentials_for("*.example.com"));
     }
 }

--- a/src/utils/cert_manager/challenge/dns01/acme_dns.rs
+++ b/src/utils/cert_manager/challenge/dns01/acme_dns.rs
@@ -44,7 +44,10 @@ fn dns_err(source: impl Into<Report>) -> ChallengeError {
 }
 
 /// Normalize a domain for account lookup (lowercase, no trailing dot, no
-/// wildcard label) so config keys and ACME identifiers compare equal
+/// wildcard label) so config keys and ACME identifiers compare equal.
+/// No IDNA mapping is done: ACME identifiers arrive as punycode A-labels,
+/// so a config key written as a U-label (e.g. `münchen.example.com`) never
+/// matches and the domain falls back to the default account or "no account".
 fn normalize_domain(domain: &str) -> String {
     let domain = domain.trim().trim_end_matches('.');
     domain
@@ -109,8 +112,11 @@ impl AcmeDnsProvider {
     /// Validate that a certificate order for `domains` can succeed: every
     /// domain must resolve to an account, and no account may serve more than
     /// two of them, since a third digest would rotate the first out of the
-    /// account's two-value TXT window before the CA validates it. Meant to
-    /// run at startup, so the gap is caught before the first renewal.
+    /// account's two-value TXT window before the CA validates it.
+    ///
+    /// A startup sanity check over the configured domains only: it is not
+    /// invoked on the order path, so it cannot protect orders whose
+    /// identifiers diverge from the domains checked here.
     pub fn check_order_domains(&self, domains: &[&str]) -> Result<(), ChallengeError> {
         let mut by_account: HashMap<&str, Vec<&str>> = HashMap::new();
         for domain in domains {
@@ -376,14 +382,13 @@ mod tests {
             .unwrap();
     }
 
-    #[test]
-    fn check_order_domains_rejects_three_identifiers_on_one_account() {
-        let provider = AcmeDnsProvider::new(
-            "https://auth.example.org",
-            Some(account("default")),
-            HashMap::new(),
-        )
-        .unwrap();
+    #[tokio::test]
+    async fn check_order_domains_rejects_three_identifiers_on_one_account() {
+        // No mocks mounted: the check must reject the overloaded account
+        // before any request is sent
+        let server = MockServer::start().await;
+        let provider =
+            AcmeDnsProvider::new(server.uri(), Some(account("default")), HashMap::new()).unwrap();
 
         // An apex + wildcard pair fits the account's two-value TXT window
         provider

--- a/src/utils/cert_manager/challenge/dns01/mod.rs
+++ b/src/utils/cert_manager/challenge/dns01/mod.rs
@@ -6,7 +6,7 @@ mod pebble;
 mod route53;
 mod token;
 
-pub use acme_dns::AcmeDnsProvider;
+pub use acme_dns::{AcmeDnsCredentials, AcmeDnsProvider};
 pub use azure::{AzureDnsProvider, ServicePrincipal};
 pub use cloudflare::CloudflareDnsProvider;
 pub use gcloud::GoogleCloudDnsProvider;

--- a/src/utils/state.rs
+++ b/src/utils/state.rs
@@ -2,8 +2,9 @@ use crate::{
     cert_manager::{
         CertManager, StoreProvisioningStrategy,
         challenge::{
-            AcmeDnsProvider, AwsRoute53DnsProvider, AzureDnsProvider, CloudflareDnsProvider,
-            Dns01Handler, GoogleCloudDnsProvider, PebbleDnsProvider, ServicePrincipal,
+            AcmeDnsCredentials, AcmeDnsProvider, AwsRoute53DnsProvider, AzureDnsProvider,
+            CloudflareDnsProvider, Dns01Handler, GoogleCloudDnsProvider, PebbleDnsProvider,
+            ServicePrincipal,
         },
         storage::{AwsS3, AwsSecretsManager, Redis},
     },
@@ -23,6 +24,15 @@ use super::{cache::StatusListCache, cert_manager::http_client::DefaultHttpClient
 
 fn empty_to_none(value: Option<String>) -> Option<String> {
     value.filter(|v| !v.trim().is_empty())
+}
+
+/// Map an ACME-DNS account from the config layer to provider credentials
+fn acme_dns_credentials(account: &crate::config::AcmeDnsAccount) -> AcmeDnsCredentials {
+    AcmeDnsCredentials {
+        username: account.username.clone(),
+        password: account.password.clone(),
+        subdomain: account.subdomain.clone(),
+    }
 }
 
 #[derive(Clone)]
@@ -94,7 +104,11 @@ pub async fn build_state(config: &AppConfig) -> EyeResult<AppState> {
              but APP_ENV=production; ACME challenges will not succeed against a real CA"
         );
     }
-    let challenge_handler = build_dns_challenge_handler(dns_provider, config, &aws_config).await?;
+    // Domains certificates are ordered for; the single source for both the
+    // ACME order and the challenge handler's startup coverage checks
+    let cert_domains = [config.server.domain.as_str()];
+    let challenge_handler =
+        build_dns_challenge_handler(dns_provider, config, &aws_config, &cert_domains)?;
 
     // Initialize the storage backends for the certificate manager
     let cache = Redis::new(redis_conn.clone()).with_ttl(config.redis.cert_cache_ttl);
@@ -119,7 +133,7 @@ pub async fn build_state(config: &AppConfig) -> EyeResult<AppState> {
         .eq_ignore_ascii_case("acme");
 
     let mut cert_manager_builder = CertManager::builder()
-        .domains([config.server.domain.as_str()])
+        .domains(cert_domains)
         .email(&config.server.cert.email)
         .organization(config.server.cert.organization.as_deref())
         .acme_directory_url(&config.server.cert.acme_directory_url)
@@ -246,11 +260,15 @@ fn store_certificate_strategy(config: &AppConfig) -> EyeResult<Option<StoreProvi
     }
 }
 
-/// Build the DNS-01 challenge handler for the resolved DNS provider
-async fn build_dns_challenge_handler(
+/// Build the DNS-01 challenge handler for the resolved DNS provider.
+///
+/// `cert_domains` are the domains certificates will be ordered for, used to
+/// validate at startup that the provider can serve challenges for them.
+fn build_dns_challenge_handler(
     provider: DnsProviderKind,
     config: &AppConfig,
     aws_config: &SdkConfig,
+    cert_domains: &[&str],
 ) -> EyeResult<Dns01Handler> {
     let dns = &config.server.cert.dns;
     let handler = match provider {
@@ -267,19 +285,9 @@ async fn build_dns_challenge_handler(
                 .gcloud
                 .as_ref()
                 .ok_or_else(|| eyre!("Missing Google Cloud DNS settings"))?;
-            // Empty values count as unset, matching DnsConfig::resolve
-            let inline = cfg
-                .service_account_key
-                .as_ref()
-                .filter(|k| !k.expose_secret().trim().is_empty());
-            let path = cfg
-                .service_account_key_path
-                .as_deref()
-                .filter(|p| !p.trim().is_empty());
-            let key_json = match (inline, path) {
+            let key_json = match (&cfg.service_account_key, &cfg.service_account_key_path) {
                 (Some(key), _) => key.expose_secret().to_string(),
-                (None, Some(path)) => tokio::fs::read_to_string(path)
-                    .await
+                (None, Some(path)) => std::fs::read_to_string(path)
                     .wrap_err_with(|| format!("Failed to read service account key at {path}"))?,
                 (None, None) => return Err(eyre!("Missing Google Cloud service account key")),
             };
@@ -305,12 +313,28 @@ async fn build_dns_challenge_handler(
                 .acmedns
                 .as_ref()
                 .ok_or_else(|| eyre!("Missing ACME-DNS settings"))?;
-            Dns01Handler::new(AcmeDnsProvider::new(
+            let accounts = cfg
+                .accounts
+                .iter()
+                .map(|(domain, account)| (domain.clone(), acme_dns_credentials(account)))
+                .collect();
+            let provider = AcmeDnsProvider::new(
                 &cfg.server_url,
-                &cfg.username,
-                cfg.password.clone(),
-                &cfg.subdomain,
-            ))
+                cfg.default_account().as_ref().map(acme_dns_credentials),
+                accounts,
+            )?;
+            // Catch a credentials gap for any ordered domain at startup
+            // instead of at the first renewal
+            if let Some(domain) = cert_domains
+                .iter()
+                .find(|domain| !provider.has_credentials_for(domain))
+            {
+                return Err(eyre!(
+                    "ACME-DNS settings provide no account for domain {domain} \
+                     and no default account"
+                ));
+            }
+            Dns01Handler::new(provider)
         }
         DnsProviderKind::Pebble => {
             // The DNS challenge server URL is optional and only used in dev mode;
@@ -345,33 +369,28 @@ mod tests {
             .build()
     }
 
-    // Sync wrapper shadowing the async builder: sealed tests fork the
-    // process and run without an async runtime
-    fn build_dns_challenge_handler(
-        provider: DnsProviderKind,
-        config: &AppConfig,
-        aws_config: &SdkConfig,
-    ) -> EyeResult<Dns01Handler> {
-        tokio::runtime::Runtime::new()
-            .expect("failed to build test runtime")
-            .block_on(super::build_dns_challenge_handler(
-                provider, config, aws_config,
-            ))
-    }
-
     #[sealed_test]
     fn builds_handler_for_each_configured_provider() {
         let sdk = test_sdk_config();
         let mut config = AppConfig::load().expect("Failed to load config");
+        let domain = config.server.domain.clone();
+        let domains = [domain.as_str()];
 
         // Route53 and Pebble need no provider-specific settings
-        assert!(build_dns_challenge_handler(DnsProviderKind::Route53, &config, &sdk).is_ok());
-        assert!(build_dns_challenge_handler(DnsProviderKind::Pebble, &config, &sdk).is_ok());
+        assert!(
+            build_dns_challenge_handler(DnsProviderKind::Route53, &config, &sdk, &domains).is_ok()
+        );
+        assert!(
+            build_dns_challenge_handler(DnsProviderKind::Pebble, &config, &sdk, &domains).is_ok()
+        );
 
         config.server.cert.dns.cloudflare = Some(CloudflareDnsConfig {
             api_token: "token".into(),
         });
-        assert!(build_dns_challenge_handler(DnsProviderKind::Cloudflare, &config, &sdk).is_ok());
+        assert!(
+            build_dns_challenge_handler(DnsProviderKind::Cloudflare, &config, &sdk, &domains)
+                .is_ok()
+        );
 
         config.server.cert.dns.azure = Some(AzureDnsConfig {
             tenant_id: "tenant".into(),
@@ -380,15 +399,20 @@ mod tests {
             subscription_id: "sub".into(),
             resource_group: "rg".into(),
         });
-        assert!(build_dns_challenge_handler(DnsProviderKind::Azure, &config, &sdk).is_ok());
+        assert!(
+            build_dns_challenge_handler(DnsProviderKind::Azure, &config, &sdk, &domains).is_ok()
+        );
 
         config.server.cert.dns.acmedns = Some(AcmeDnsConfig {
             server_url: "https://auth.example.org".into(),
-            username: "user".into(),
-            password: "password".into(),
-            subdomain: "subdomain".into(),
+            username: Some("user".into()),
+            password: Some("password".into()),
+            subdomain: Some("subdomain".into()),
+            accounts: Default::default(),
         });
-        assert!(build_dns_challenge_handler(DnsProviderKind::Acmedns, &config, &sdk).is_ok());
+        assert!(
+            build_dns_challenge_handler(DnsProviderKind::Acmedns, &config, &sdk, &domains).is_ok()
+        );
 
         let key_json = serde_json::json!({
             "client_email": "acme@test-project.iam.gserviceaccount.com",
@@ -400,18 +424,92 @@ mod tests {
             service_account_key: Some(key_json.to_string().into()),
             service_account_key_path: None,
         });
-        assert!(build_dns_challenge_handler(DnsProviderKind::Gcloud, &config, &sdk).is_ok());
+        assert!(
+            build_dns_challenge_handler(DnsProviderKind::Gcloud, &config, &sdk, &domains).is_ok()
+        );
     }
 
     #[sealed_test]
     fn fails_when_provider_settings_are_missing() {
         let sdk = test_sdk_config();
         let config = AppConfig::load().expect("Failed to load config");
+        let domains = [config.server.domain.as_str()];
 
-        assert!(build_dns_challenge_handler(DnsProviderKind::Cloudflare, &config, &sdk).is_err());
-        assert!(build_dns_challenge_handler(DnsProviderKind::Gcloud, &config, &sdk).is_err());
-        assert!(build_dns_challenge_handler(DnsProviderKind::Azure, &config, &sdk).is_err());
-        assert!(build_dns_challenge_handler(DnsProviderKind::Acmedns, &config, &sdk).is_err());
+        for kind in [
+            DnsProviderKind::Cloudflare,
+            DnsProviderKind::Gcloud,
+            DnsProviderKind::Azure,
+            DnsProviderKind::Acmedns,
+        ] {
+            assert!(build_dns_challenge_handler(kind, &config, &sdk, &domains).is_err());
+        }
+    }
+
+    #[sealed_test]
+    fn acme_dns_must_cover_the_server_domain_at_startup() {
+        let sdk = test_sdk_config();
+        let mut config = AppConfig::load().expect("Failed to load config");
+        let domain = config.server.domain.clone();
+        let domains = [domain.as_str()];
+
+        let account = crate::config::AcmeDnsAccount {
+            username: "user".into(),
+            password: "password".into(),
+            subdomain: "subdomain".into(),
+        };
+        let mut acmedns = AcmeDnsConfig {
+            server_url: "https://auth.example.org".into(),
+            username: None,
+            password: None,
+            subdomain: None,
+            accounts: [("other.example.com".to_string(), account.clone())].into(),
+        };
+
+        // Map-only config not covering the server domain fails at startup
+        config.server.cert.dns.acmedns = Some(acmedns.clone());
+        let err = build_dns_challenge_handler(DnsProviderKind::Acmedns, &config, &sdk, &domains)
+            .err()
+            .expect("startup must fail without an account for the server domain");
+        assert!(err.to_string().contains(&domain));
+
+        // An entry for the server domain (any cosmetic form) makes it build
+        acmedns.accounts.insert(domain.to_uppercase(), account);
+        config.server.cert.dns.acmedns = Some(acmedns);
+        assert!(
+            build_dns_challenge_handler(DnsProviderKind::Acmedns, &config, &sdk, &domains).is_ok()
+        );
+    }
+
+    #[sealed_test]
+    fn acme_dns_account_conflicts_fail_at_boot() {
+        let sdk = test_sdk_config();
+        let mut config = AppConfig::load().expect("Failed to load config");
+        let domain = config.server.domain.clone();
+        let domains = [domain.as_str()];
+
+        // Two entries normalizing to the server domain, different credentials:
+        // the provider is built eagerly at boot, so this must fail here
+        let account = |subdomain: &str| crate::config::AcmeDnsAccount {
+            username: "user".into(),
+            password: "password".into(),
+            subdomain: subdomain.into(),
+        };
+        config.server.cert.dns.acmedns = Some(AcmeDnsConfig {
+            server_url: "https://auth.example.org".into(),
+            username: None,
+            password: None,
+            subdomain: None,
+            accounts: [
+                (domain.clone(), account("first")),
+                (domain.to_uppercase(), account("second")),
+            ]
+            .into(),
+        });
+
+        let err = build_dns_challenge_handler(DnsProviderKind::Acmedns, &config, &sdk, &domains)
+            .err()
+            .expect("conflicting account entries must fail the boot-path builder");
+        assert!(err.to_string().contains("Conflicting ACME-DNS accounts"));
     }
 
     #[test]

--- a/src/utils/state.rs
+++ b/src/utils/state.rs
@@ -108,7 +108,7 @@ pub async fn build_state(config: &AppConfig) -> EyeResult<AppState> {
     // ACME order and the challenge handler's startup coverage checks
     let cert_domains = [config.server.domain.as_str()];
     let challenge_handler =
-        build_dns_challenge_handler(dns_provider, config, &aws_config, &cert_domains)?;
+        build_dns_challenge_handler(dns_provider, config, &aws_config, &cert_domains).await?;
 
     // Initialize the storage backends for the certificate manager
     let cache = Redis::new(redis_conn.clone()).with_ttl(config.redis.cert_cache_ttl);
@@ -264,7 +264,7 @@ fn store_certificate_strategy(config: &AppConfig) -> EyeResult<Option<StoreProvi
 ///
 /// `cert_domains` are the domains certificates will be ordered for, used to
 /// validate at startup that the provider can serve challenges for them.
-fn build_dns_challenge_handler(
+async fn build_dns_challenge_handler(
     provider: DnsProviderKind,
     config: &AppConfig,
     aws_config: &SdkConfig,
@@ -285,9 +285,19 @@ fn build_dns_challenge_handler(
                 .gcloud
                 .as_ref()
                 .ok_or_else(|| eyre!("Missing Google Cloud DNS settings"))?;
-            let key_json = match (&cfg.service_account_key, &cfg.service_account_key_path) {
+            // Empty values count as unset, matching DnsConfig::resolve
+            let inline = cfg
+                .service_account_key
+                .as_ref()
+                .filter(|k| !k.expose_secret().trim().is_empty());
+            let path = cfg
+                .service_account_key_path
+                .as_deref()
+                .filter(|p| !p.trim().is_empty());
+            let key_json = match (inline, path) {
                 (Some(key), _) => key.expose_secret().to_string(),
-                (None, Some(path)) => std::fs::read_to_string(path)
+                (None, Some(path)) => tokio::fs::read_to_string(path)
+                    .await
                     .wrap_err_with(|| format!("Failed to read service account key at {path}"))?,
                 (None, None) => return Err(eyre!("Missing Google Cloud service account key")),
             };
@@ -367,6 +377,24 @@ mod tests {
         SdkConfig::builder()
             .behavior_version(BehaviorVersion::latest())
             .build()
+    }
+
+    // Sync wrapper shadowing the async builder: sealed tests fork the
+    // process and run without an async runtime
+    fn build_dns_challenge_handler(
+        provider: DnsProviderKind,
+        config: &AppConfig,
+        aws_config: &SdkConfig,
+        cert_domains: &[&str],
+    ) -> EyeResult<Dns01Handler> {
+        tokio::runtime::Runtime::new()
+            .expect("failed to build test runtime")
+            .block_on(super::build_dns_challenge_handler(
+                provider,
+                config,
+                aws_config,
+                cert_domains,
+            ))
     }
 
     #[sealed_test]

--- a/src/utils/state.rs
+++ b/src/utils/state.rs
@@ -333,17 +333,9 @@ async fn build_dns_challenge_handler(
                 cfg.default_account().as_ref().map(acme_dns_credentials),
                 accounts,
             )?;
-            // Catch a credentials gap for any ordered domain at startup
-            // instead of at the first renewal
-            if let Some(domain) = cert_domains
-                .iter()
-                .find(|domain| !provider.has_credentials_for(domain))
-            {
-                return Err(eyre!(
-                    "ACME-DNS settings provide no account for domain {domain} \
-                     and no default account"
-                ));
-            }
+            // Catch a credentials gap or an overloaded two-value TXT window
+            // for the ordered domains at startup instead of at the first renewal
+            provider.check_order_domains(cert_domains)?;
             Dns01Handler::new(provider)
         }
         DnsProviderKind::Pebble => {
@@ -538,6 +530,43 @@ mod tests {
             .err()
             .expect("conflicting account entries must fail the boot-path builder");
         assert!(err.to_string().contains("Conflicting ACME-DNS accounts"));
+    }
+
+    #[sealed_test]
+    fn acme_dns_rejects_three_cert_domains_on_one_account() {
+        let sdk = test_sdk_config();
+        let mut config = AppConfig::load().expect("Failed to load config");
+        let domains = ["a.example.com", "b.example.com", "c.example.com"];
+
+        // All three fall back to the default account, whose two-value TXT
+        // window cannot hold three digests at once
+        config.server.cert.dns.acmedns = Some(AcmeDnsConfig {
+            server_url: "https://auth.example.org".into(),
+            username: Some("user".into()),
+            password: Some("password".into()),
+            subdomain: Some("subdomain".into()),
+            accounts: Default::default(),
+        });
+
+        let err = build_dns_challenge_handler(DnsProviderKind::Acmedns, &config, &sdk, &domains)
+            .err()
+            .expect("three identifiers on one account must fail the boot-path builder");
+        assert!(err.to_string().contains("two most recent TXT values"));
+
+        // Mapping one of them to its own account restores a valid setup
+        if let Some(acmedns) = &mut config.server.cert.dns.acmedns {
+            acmedns.accounts.insert(
+                "c.example.com".to_string(),
+                crate::config::AcmeDnsAccount {
+                    username: "user-c".into(),
+                    password: "password-c".into(),
+                    subdomain: "subdomain-c".into(),
+                },
+            );
+        }
+        assert!(
+            build_dns_challenge_handler(DnsProviderKind::Acmedns, &config, &sdk, &domains).is_ok()
+        );
     }
 
     #[test]


### PR DESCRIPTION

The ACME-DNS provider holds a single account (one server URL / username /password / subdomain). Because acme-dns keeps only the **two most recent TXT values** per record by design, every domain's `_acme challenge` CNAME points at the same acme-dns record, and only the last two written digests survive.

## Acceptance criteria

- [ ] Per-domain credential selection implemented and config-driven.
- [ ] Backward compatible: existing single-account config works unchanged.
- [ ] wiremock tests cover per-domain selection and the 3-identifier case that currently fails.
- [ ] Docs updated to describe the map and remove the ≤2-identifier caveat once lifted.
