### PR TITLE
feat: enhance backend feature flags and Docker support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,10 +36,38 @@ inherits = "dev"
 opt-level = 1
 
 [features]
-default = ["postgres"]
+default = ["postgres", "aws-s3", "aws-secrets-manager", "redis-cache", "dns-route53"]
+
+# Database backends (mutually exclusive - exactly one required)
 postgres = ["sea-orm/sqlx-postgres", "sea-orm-migration/sqlx-postgres"]
 mysql = ["sea-orm/sqlx-mysql", "sea-orm-migration/sqlx-mysql"]
 sqlite = ["sea-orm/sqlx-sqlite", "sea-orm-migration/sqlx-sqlite"]
+
+# Storage backends (certificates)
+aws-s3 = ["dep:aws-config", "dep:aws-sdk-s3"]
+memory-storage = []
+
+# Secrets storage backends
+aws-secrets-manager = ["dep:aws-config", "dep:aws-sdk-secretsmanager"]
+memory-secrets = []
+
+# Cache backends
+redis-cache = ["dep:redis"]
+memory-cache = []
+
+# DNS provider backends (at least one required for cert provisioning)
+dns-route53 = ["dep:aws-config", "dep:aws-sdk-route53"]
+dns-cloudflare = []
+dns-gcloud = []
+dns-azure = []
+dns-acmedns = []
+dns-pebble = []
+
+# Convenience feature for local development (in-memory everything)
+memory = ["sqlite", "memory-storage", "memory-secrets", "memory-cache", "dns-pebble"]
+
+# Full AWS feature set
+aws = ["aws-s3", "aws-secrets-manager", "dns-route53"]
 
 [dependencies]
 # Async runtime and utilities
@@ -91,7 +119,7 @@ thiserror = "2.0"
 color-eyre = "0.6"
 
 # Utility Libraries
-uuid = "1.23"
+uuid = { version = "1.23", features = ["v4"] }
 base64 = "0.22"
 time = { version = "0.3", features = ["formatting", "macros"] }
 base64url = "0.1"
@@ -104,34 +132,16 @@ metrics-exporter-prometheus = "0.18"
 metrics-process = "2.4"
 sea-orm-migration = { version = "1.1.20", default-features = false, features = ["runtime-tokio-rustls"] }
 
-# AWS related libraries
-[dependencies.aws-config]
-version = "1"
-default-features = false
-features = ["default-https-client", "rt-tokio"]
+# AWS related libraries - optional, enabled by features
+aws-config = { version = "1", default-features = false, features = ["default-https-client", "rt-tokio"], optional = true }
+aws-sdk-s3 = { version = "1", default-features = false, features = ["default-https-client", "rt-tokio", "sigv4a"], optional = true }
+aws-sdk-route53 = { version = "1", default-features = false, features = ["default-https-client", "rt-tokio"], optional = true }
+aws-sdk-secretsmanager = { version = "1", default-features = false, features = ["default-https-client", "rt-tokio"], optional = true }
 
-[dependencies.aws-sdk-s3]
-version = "1"
-default-features = false
-features = ["default-https-client", "rt-tokio", "sigv4a"]
+# Redis - optional, enabled by feature
+redis = { version = "1.3", features = ["connection-manager", "tokio-rustls-comp"], optional = true }
 
-[dependencies.aws-sdk-route53]
-version = "1"
-default-features = false
-features = ["default-https-client", "rt-tokio"]
-
-[dependencies.aws-sdk-secretsmanager]
-version = "1"
-default-features = false
-features = ["default-https-client", "rt-tokio"]
-
-[dependencies.redis]
-version = "1.3"
-features = ["connection-manager", "tokio-rustls-comp"]
-
-[dependencies.p256]
-version = "0.14"
-features = ["alloc", "ecdsa", "pem", "pkcs8"]
+p256 = { version = "0.14", features = ["alloc", "ecdsa", "pem", "pkcs8"] }
 
 [dev-dependencies]
 sealed_test = "1.1.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 ARG APP_NAME=status-list-server
+ARG FEATURES=default
 
 # Use buildx's automatic platform detection
 FROM --platform=$BUILDPLATFORM blackdex/rust-musl:x86_64-musl AS builder-amd64
@@ -9,6 +10,7 @@ FROM builder-${TARGETARCH} AS builder
 ARG APP_NAME
 ARG TARGETPLATFORM
 ARG TARGETARCH
+ARG FEATURES
 WORKDIR /app
 
 # Set the Rust target and build the application
@@ -23,7 +25,11 @@ RUN --mount=type=bind,source=src,target=src \
         arm64) RUST_TARGET="aarch64-unknown-linux-musl" ;; \
         *) echo "Unsupported architecture: $TARGETARCH" && exit 1 ;; \
     esac; \
-    cargo build --locked --release --target=${RUST_TARGET}; \
+    if [ "$FEATURES" = "default" ]; then \
+        cargo build --locked --release --target=${RUST_TARGET}; \
+    else \
+        cargo build --locked --release --target=${RUST_TARGET} --no-default-features --features="${FEATURES}"; \
+    fi; \
     mv target/${RUST_TARGET}/release/${APP_NAME} .
 
 FROM gcr.io/distroless/static-debian12 AS runtime

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ This server uses Cargo feature flags to select backends at compile time. This en
 
 ### Feature Naming Convention
 
-| Backend Type | Available Features | Notes |
-|--------------|-------------------|-------|
-| **Database** | `postgres`, `mysql`, `sqlite` | Exactly one required |
-| **Certificate Storage** | `aws-s3`, `memory-storage` | `aws-s3` for production, `memory-storage` for dev |
-| **Secrets Storage** | `aws-secrets-manager`, `memory-secrets` | `aws-secrets-manager` for production, `memory-secrets` for dev |
-| **Certificate Chain Cache** | `redis-cache`, `memory-cache` | `redis-cache` for multi-replica, `memory-cache` for single instance |
-| **DNS Provider** | `dns-route53`, `dns-cloudflare`, `dns-gcloud`, `dns-azure`, `dns-acmedns`, `dns-pebble` | At least one required for ACME DNS-01 challenges |
+| Backend Type              | Available Features                                                                      | Notes                                                               |
+| ------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| **Database**              | `postgres`, `mysql`, `sqlite`                                                           | Exactly one required                                                |
+| **Certificate Storage**   | `aws-s3`, `memory-storage`                                                              | `aws-s3` for production, `memory-storage` for dev                     |
+| **Secrets Storage**       | `aws-secrets-manager`, `memory-secrets`                                                   | `aws-secrets-manager` for production, `memory-secrets` for dev      |
+| **Certificate Chain Cache** | `redis-cache`, `memory-cache`                                                       | `redis-cache` for multi-replica, `memory-cache` for single instance   |
+| **DNS Provider**          | `dns-route53`, `dns-cloudflare`, `dns-gcloud`, `dns-azure`, `dns-acmedns`, `dns-pebble` | At least one required for ACME DNS-01 challenges                    |
 
 ### Convenience Features
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ This server uses Cargo feature flags to select backends at compile time. This en
 | Backend Type              | Available Features                                                                      | Notes                                                               |
 | ------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
 | **Database**              | `postgres`, `mysql`, `sqlite`                                                           | Exactly one required                                                |
-| **Certificate Storage**   | `aws-s3`, `memory-storage`                                                              | `aws-s3` for production, `memory-storage` for dev                     |
+| **Certificate Storage**   | `aws-s3`, `memory-storage`                                                              | `aws-s3` for production, `memory-storage` for dev                   |
 | **Secrets Storage**       | `aws-secrets-manager`, `memory-secrets`                                                   | `aws-secrets-manager` for production, `memory-secrets` for dev      |
-| **Certificate Chain Cache** | `redis-cache`, `memory-cache`                                                       | `redis-cache` for multi-replica, `memory-cache` for single instance   |
+| **Certificate Chain Cache** | `redis-cache`, `memory-cache`                                                           | `redis-cache` for multi-replica, `memory-cache` for single instance |
 | **DNS Provider**          | `dns-route53`, `dns-cloudflare`, `dns-gcloud`, `dns-azure`, `dns-acmedns`, `dns-pebble` | At least one required for ACME DNS-01 challenges                    |
 
 ### Convenience Features

--- a/README.md
+++ b/README.md
@@ -31,6 +31,42 @@ For a detailed explanation of the architecture, see the [Architecture Documentat
 | Status List Aggregation         | ✅ Implemented | `GET /api/v1/aggregation` + optional `aggregation_uri` token member |
 | X.509 Certificate EKU           | ⚠️ Partial     | Placeholder OID (`...3.30`); rename pending spec finalization       |
 
+## Backend Feature Flags
+
+This server uses Cargo feature flags to select backends at compile time. This enables flexible deployment configurations from lightweight in-memory development setups to production-grade AWS infrastructure.
+
+### Feature Naming Convention
+
+| Backend Type | Available Features | Notes |
+|--------------|-------------------|-------|
+| **Database** | `postgres`, `mysql`, `sqlite` | Exactly one required |
+| **Certificate Storage** | `aws-s3`, `memory-storage` | `aws-s3` for production, `memory-storage` for dev |
+| **Secrets Storage** | `aws-secrets-manager`, `memory-secrets` | `aws-secrets-manager` for production, `memory-secrets` for dev |
+| **Certificate Chain Cache** | `redis-cache`, `memory-cache` | `redis-cache` for multi-replica, `memory-cache` for single instance |
+| **DNS Provider** | `dns-route53`, `dns-cloudflare`, `dns-gcloud`, `dns-azure`, `dns-acmedns`, `dns-pebble` | At least one required for ACME DNS-01 challenges |
+
+### Convenience Features
+
+- **`memory`**: Enables all in-memory backends: `sqlite`, `memory-storage`, `memory-secrets`, `memory-cache`, `dns-pebble`
+- **`aws`**: Enables all AWS backends: `aws-s3`, `aws-secrets-manager`, `dns-route53`
+- **`default`**: Includes `postgres`, `aws-s3`, `aws-secrets-manager`, `redis-cache`, `dns-route53`
+
+### Build Configurations
+
+```bash
+# Production build (default)
+cargo build --release
+
+# Local development with in-memory storage
+cargo build --no-default-features --features memory
+
+# PostgreSQL database with in-memory secrets (for CI)
+cargo build --no-default-features --features "postgres,memory-secrets,memory-storage,dns-pebble"
+
+# SQLite with AWS S3
+cargo build --no-default-features --features "sqlite,aws-s3,aws-secrets-manager,dns-route53"
+```
+
 ## Quick Start
 
 ### Prerequisites
@@ -38,8 +74,7 @@ For a detailed explanation of the architecture, see the [Architecture Documentat
 Before running the server, ensure you have the following tools installed:
 
 - [Rust & Cargo](https://www.rust-lang.org/tools/install) (Latest stable).
-- A supported database backend: PostgreSQL, MySQL, or SQLite.
-- [Redis](https://redis.io/download): The in-memory data structure store used for caching.
+- Database backend (if using `postgres` or `mysql` features).
 - [Docker](https://www.docker.com/get-started/) (optional, for local testing).
 
 ### Run locally
@@ -49,6 +84,16 @@ Before running the server, ensure you have the following tools installed:
 ```bash
 git clone https://github.com/adorsys/status-list-server.git
 cd status-list-server
+```
+
+**Build with desired features:**
+
+```bash
+# For local development with SQLite and in-memory storage
+cargo build --no-default-features --features memory
+
+# Run with default features (requires PostgreSQL, Redis, AWS credentials)
+cargo run
 ```
 
 **Environment Variables:**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,26 @@
+# Docker Compose Configuration
+#
+# This file provides multiple service profiles for different deployment scenarios.
+# The server supports compile-time feature flags for backend selection.
+#
+# Feature Quick Reference:
+#   - memory: SQLite + in-memory storage (development)
+#   - postgres + aws-s3 + aws-secrets-manager + redis-cache + dns-route53 (production)
+#
+# Build with specific features:
+#   docker compose build --build-arg FEATURES="memory"
+#
+# Profiles:
+#   - default: Full stack with PostgreSQL, Redis, LocalStack (AWS mock), Pebble (ACME)
+#   - memory: Lightweight SQLite with in-memory storage (no external dependencies)
+#   - mysql: MySQL database instead of PostgreSQL
+
 services:
   db:
     image: postgres:18.4
     restart: always
     container_name: status-list-db
+    profiles: ["default", "postgres"]
     ports:
       - 5432:5432
     environment:
@@ -44,6 +62,7 @@ services:
   redis:
     image: redis:8.6
     container_name: redis
+    profiles: ["default", "redis"]
     ports:
       - 6379:6379
     networks:
@@ -52,6 +71,7 @@ services:
   localstack:
     container_name: localstack
     image: localstack/localstack:4.14
+    profiles: ["default", "aws"]
     ports:
       - 4566:4566
     environment:
@@ -86,11 +106,13 @@ services:
     volumes:
       - ./test_data/pebble_config.json:/test/pebble_config.json
 
+  # Full-stack app with PostgreSQL, Redis, and LocalStack (default)
   app:
     build:
       context: .
       dockerfile: Dockerfile
     container_name: status-list-server
+    profiles: ["default"]
     env_file: .env
     environment:
       APP_ENV: ${APP_ENV:-development}
@@ -111,6 +133,34 @@ services:
         condition: service_healthy
       pushgateway:
         condition: service_started
+    networks:
+      - status-list-network
+
+  # Lightweight app with SQLite and in-memory storage (memory profile)
+  # Build with: docker compose --profile memory up --build
+  app-memory:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        FEATURES: "memory"
+    container_name: status-list-server-memory
+    profiles: ["memory"]
+    env_file: .env
+    environment:
+      APP_ENV: ${APP_ENV:-development}
+      APP_SERVER__ENABLE_METRICS: ${APP_SERVER__ENABLE_METRICS:-false}
+      APP_DATABASE__URL: "sqlite:///data/status-list.db"
+      APP_DATABASE__BACKEND: "sqlite"
+      APP_STATUS_LIST__TOKEN_EXP_SECS: ${APP_STATUS_LIST__TOKEN_EXP_SECS:-900}
+      APP_STATUS_LIST__TOKEN_TTL_SECS: ${APP_STATUS_LIST__TOKEN_TTL_SECS:-300}
+    ports:
+      - 8000:8000
+    depends_on:
+      pebble:
+        condition: service_started
+    volumes:
+      - sqlite_data:/data
     networks:
       - status-list-network
 
@@ -146,4 +196,6 @@ volumes:
   pgdata:
     driver: local
   mysqldata:
+    driver: local
+  sqlite_data:
     driver: local

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,14 @@
+#[cfg(feature = "redis-cache")]
 use std::time::Duration;
 
 use config::{Config as ConfigLib, ConfigError, Environment};
+
+#[cfg(feature = "redis-cache")]
 use redis::{
     Client as RedisClient, ClientTlsConfig, RedisResult, TlsCertificates,
     aio::{ConnectionManager, ConnectionManagerConfig},
 };
+
 use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 use serde_aux::field_attributes::deserialize_vec_from_string_or_vec;
@@ -74,6 +78,10 @@ pub const ENV_DEVELOPMENT: &str = "development";
 pub struct Config {
     pub server: ServerConfig,
     pub database: DatabaseConfig,
+    #[cfg(feature = "redis-cache")]
+    pub redis: RedisConfig,
+    #[cfg(not(feature = "redis-cache"))]
+    #[serde(default)]
     pub redis: RedisConfig,
     pub aws: AwsConfig,
     pub cache: CacheConfig,
@@ -279,9 +287,22 @@ impl DnsConfig {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[cfg(feature = "redis-cache")]
 pub struct RedisConfig {
     pub uri: SecretString,
     pub require_client_auth: bool,
+    pub cert_cache_ttl: u64,
+}
+
+/// Stub RedisConfig when redis-cache feature is disabled
+#[derive(Debug, Clone, Deserialize, Default)]
+#[cfg(not(feature = "redis-cache"))]
+pub struct RedisConfig {
+    #[serde(default)]
+    pub uri: SecretString,
+    #[serde(default)]
+    pub require_client_auth: bool,
+    #[serde(default)]
     pub cert_cache_ttl: u64,
 }
 
@@ -313,6 +334,7 @@ pub struct StatusListConfig {
     pub token_ttl_secs: u64,
 }
 
+#[cfg(feature = "redis-cache")]
 impl RedisConfig {
     /// Establishes a new Redis connection based on the configuration.
     ///
@@ -377,7 +399,7 @@ impl RedisConfig {
 impl Config {
     pub fn load() -> Result<Self, ConfigError> {
         // Build the config
-        let config = ConfigLib::builder()
+        let mut builder = ConfigLib::builder()
             // Set default values
             .set_default("server.host", "localhost")?
             .set_default("server.domain", "localhost")?
@@ -389,9 +411,6 @@ impl Config {
                 "postgres://postgres:postgres@localhost:5432/status-list",
             )?
             .set_default("database.backend", "postgres")?
-            .set_default("redis.uri", "redis://localhost:6379")?
-            .set_default("redis.require_client_auth", false)?
-            .set_default("redis.cert_cache_ttl", 3600)? // Default 1 hour
             .set_default("aws.secrets_cache_ttl", 300)? // Default 5 minutes
             .set_default("aws.s3_bucket", "status-list-adorsys")?
             .set_default("aws.s3_key_prefix", "")?
@@ -411,7 +430,27 @@ impl Config {
             .set_default("cache.ttl", 5 * 60)?
             .set_default("cache.max_capacity", 100)?
             .set_default("status_list.token_exp_secs", 900)? // 15 minutes
-            .set_default("status_list.token_ttl_secs", 300)? // 5 minutes
+            .set_default("status_list.token_ttl_secs", 300)?; // 5 minutes
+
+        // Set Redis defaults only when redis-cache feature is enabled
+        #[cfg(feature = "redis-cache")]
+        {
+            builder = builder
+                .set_default("redis.uri", "redis://localhost:6379")?
+                .set_default("redis.require_client_auth", false)?
+                .set_default("redis.cert_cache_ttl", 3600)?; // Default 1 hour
+        }
+
+        #[cfg(not(feature = "redis-cache"))]
+        {
+            // Provide dummy defaults when Redis is not used
+            builder = builder
+                .set_default("redis.uri", "redis://localhost:6379")?
+                .set_default("redis.require_client_auth", false)?
+                .set_default("redis.cert_cache_ttl", 0)?;
+        }
+
+        let config = builder
             // Override config values via environment variables
             // The environment variables should be prefixed with 'APP_' and use '__' as a separator
             // Example: APP_REDIS__REQUIRE_CLIENT_AUTH=false
@@ -444,6 +483,7 @@ mod tests {
             "postgres://postgres:postgres@localhost:5432/status-list"
         );
         assert_eq!(config.database.backend, DatabaseBackend::Postgres);
+        // Redis config is only available when redis-cache feature is enabled
         assert_eq!(config.redis.uri.expose_secret(), "redis://localhost:6379");
         assert!(!config.redis.require_client_auth);
         assert_eq!(config.server.cert.email, "admin@example.com");

--- a/src/database/queries.rs
+++ b/src/database/queries.rs
@@ -327,6 +327,7 @@ mod test {
                 lst: "compressed".to_string(),
             },
             sub: "sub-sqlite-test".to_string(),
+            updated_at: 0,
         };
 
         store.insert_one(record.clone()).await.unwrap();
@@ -555,6 +556,7 @@ mod test {
                 lst: "compressed".to_string(),
             },
             sub: "sub-neg-sqlite".to_string(),
+            updated_at: 0,
         };
         let fk_err = store.insert_one(rec).await;
         assert!(fk_err.is_err(), "insert with dangling FK should fail");
@@ -570,6 +572,7 @@ mod test {
                         lst: "compressed".to_string(),
                     },
                     sub: "sub-neg-sqlite".to_string(),
+                    updated_at: 0,
                 },
             )
             .await

--- a/src/utils/cert_manager/challenge.rs
+++ b/src/utils/cert_manager/challenge.rs
@@ -1,10 +1,26 @@
 mod dns01;
 mod http01;
 
-pub use dns01::{
-    AcmeDnsProvider, AwsRoute53DnsProvider, AzureDnsProvider, CloudflareDnsProvider, Dns01Handler,
-    DnsProvider, GoogleCloudDnsProvider, PebbleDnsProvider, ServicePrincipal,
-};
+pub use dns01::{Dns01Handler, DnsProvider};
+
+#[cfg(feature = "dns-acmedns")]
+pub use dns01::AcmeDnsProvider;
+
+#[cfg(feature = "dns-azure")]
+pub use dns01::{AzureDnsProvider, ServicePrincipal};
+
+#[cfg(feature = "dns-cloudflare")]
+pub use dns01::CloudflareDnsProvider;
+
+#[cfg(feature = "dns-gcloud")]
+pub use dns01::GoogleCloudDnsProvider;
+
+#[cfg(feature = "dns-pebble")]
+pub use dns01::PebbleDnsProvider;
+
+#[cfg(feature = "dns-route53")]
+pub use dns01::AwsRoute53DnsProvider;
+
 pub use http01::Http01Handler;
 
 use std::{future::Future, pin::Pin};

--- a/src/utils/cert_manager/challenge/dns01/mod.rs
+++ b/src/utils/cert_manager/challenge/dns01/mod.rs
@@ -1,16 +1,29 @@
-mod acme_dns;
-mod azure;
-mod cloudflare;
-mod gcloud;
-mod pebble;
-mod route53;
 mod token;
 
+#[cfg(feature = "dns-acmedns")]
+mod acme_dns;
+#[cfg(feature = "dns-azure")]
+mod azure;
+#[cfg(feature = "dns-cloudflare")]
+mod cloudflare;
+#[cfg(feature = "dns-gcloud")]
+mod gcloud;
+#[cfg(feature = "dns-pebble")]
+mod pebble;
+#[cfg(feature = "dns-route53")]
+mod route53;
+
+#[cfg(feature = "dns-acmedns")]
 pub use acme_dns::AcmeDnsProvider;
+#[cfg(feature = "dns-azure")]
 pub use azure::{AzureDnsProvider, ServicePrincipal};
+#[cfg(feature = "dns-cloudflare")]
 pub use cloudflare::CloudflareDnsProvider;
+#[cfg(feature = "dns-gcloud")]
 pub use gcloud::GoogleCloudDnsProvider;
+#[cfg(feature = "dns-pebble")]
 pub use pebble::PebbleDnsProvider;
+#[cfg(feature = "dns-route53")]
 pub use route53::AwsRoute53DnsProvider;
 
 use std::{sync::Arc, time::Duration};

--- a/src/utils/cert_manager/storage.rs
+++ b/src/utils/cert_manager/storage.rs
@@ -1,26 +1,47 @@
+mod memory;
+
+#[cfg(feature = "aws-s3")]
 mod aws;
+
+#[cfg(feature = "redis-cache")]
 mod redis;
 
+pub use memory::MemoryStorage;
+
+#[cfg(feature = "redis-cache")]
 pub use crate::utils::cert_manager::storage::redis::Redis;
-use ::redis::RedisError;
-use async_trait::async_trait;
+
+#[cfg(feature = "aws-s3")]
 pub use aws::{AwsS3, AwsSecretsManager};
+
+#[cfg(feature = "redis-cache")]
+use ::redis::RedisError;
+
+#[cfg(feature = "aws-s3")]
 use color_eyre::eyre::Error as Report;
+
+use async_trait::async_trait;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum StorageError {
+    #[cfg(feature = "redis-cache")]
     #[error("Redis error: {0}")]
     Redis(#[from] RedisError),
 
+    #[cfg(feature = "aws-s3")]
     #[error("AWS SDK error: {0}")]
-    AwsSdk(#[source] Report),
+    AwsSdk(#[from] Report),
 
     #[error("The data is invalid: {0}")]
     InvalidData(String),
 
+    #[cfg(feature = "aws-s3")]
     #[error("Bucket {0} is unavailable")]
     BucketUnavailable(String),
+
+    #[error("Storage backend not available: {0}")]
+    BackendUnavailable(String),
 }
 
 /// Abstract interface for storage backends used by the certificate manager.
@@ -36,4 +57,24 @@ pub trait Storage: Send + Sync {
     }
     /// Delete the value associated with the given key
     async fn delete(&self, key: &str) -> Result<(), StorageError>;
+}
+
+// Implement Storage for Box<dyn Storage> to allow dynamic dispatch
+#[async_trait]
+impl Storage for Box<dyn Storage> {
+    async fn store(&self, key: &str, value: &str) -> Result<(), StorageError> {
+        (**self).store(key, value).await
+    }
+
+    async fn load(&self, key: &str) -> Result<Option<String>, StorageError> {
+        (**self).load(key).await
+    }
+
+    async fn update(&self, key: &str, value: &str) -> Result<(), StorageError> {
+        (**self).update(key, value).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), StorageError> {
+        (**self).delete(key).await
+    }
 }

--- a/src/utils/cert_manager/storage/memory.rs
+++ b/src/utils/cert_manager/storage/memory.rs
@@ -1,0 +1,150 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use async_trait::async_trait;
+use tracing::{debug, info};
+
+use crate::cert_manager::storage::{Storage, StorageError};
+
+/// In-memory storage implementation using a HashMap.
+///
+/// This is suitable for local development and testing where persistence
+/// across restarts is not required.
+#[derive(Clone)]
+pub struct MemoryStorage {
+    data: Arc<RwLock<HashMap<String, String>>>,
+    name: String,
+}
+
+impl MemoryStorage {
+    /// Create a new in-memory storage instance
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            data: Arc::new(RwLock::new(HashMap::new())),
+            name: name.into(),
+        }
+    }
+
+    /// Create a new in-memory storage instance for certificates
+    pub fn cert_storage() -> Self {
+        Self::new("cert_storage")
+    }
+
+    /// Create a new in-memory storage instance for secrets
+    pub fn secrets_storage() -> Self {
+        Self::new("secrets_storage")
+    }
+}
+
+#[async_trait]
+impl Storage for MemoryStorage {
+    async fn store(&self, key: &str, value: &str) -> Result<(), StorageError> {
+        debug!("MemoryStorage[{}]: storing key '{}'", self.name, key);
+        let mut data = self.data.write().await;
+        data.insert(key.to_string(), value.to_string());
+        info!("MemoryStorage[{}]: successfully stored key '{}'", self.name, key);
+        Ok(())
+    }
+
+    async fn load(&self, key: &str) -> Result<Option<String>, StorageError> {
+        debug!("MemoryStorage[{}]: loading key '{}'", self.name, key);
+        let data = self.data.read().await;
+        let value = data.get(key).cloned();
+        if value.is_some() {
+            debug!("MemoryStorage[{}]: found key '{}'", self.name, key);
+        } else {
+            debug!("MemoryStorage[{}]: key '{}' not found", self.name, key);
+        }
+        Ok(value)
+    }
+
+    async fn update(&self, key: &str, value: &str) -> Result<(), StorageError> {
+        debug!("MemoryStorage[{}]: updating key '{}'", self.name, key);
+        let mut data = self.data.write().await;
+        data.insert(key.to_string(), value.to_string());
+        debug!("MemoryStorage[{}]: successfully updated key '{}'", self.name, key);
+        Ok(())
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), StorageError> {
+        debug!("MemoryStorage[{}]: deleting key '{}'", self.name, key);
+        let mut data = self.data.write().await;
+        data.remove(key);
+        debug!("MemoryStorage[{}]: successfully deleted key '{}'", self.name, key);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_memory_storage_store_and_load() {
+        let storage = MemoryStorage::new("test");
+        
+        // Store a value
+        storage.store("key1", "value1").await.unwrap();
+        
+        // Load the value
+        let loaded = storage.load("key1").await.unwrap();
+        assert_eq!(loaded, Some("value1".to_string()));
+        
+        // Load a non-existent key
+        let missing = storage.load("nonexistent").await.unwrap();
+        assert_eq!(missing, None);
+    }
+
+    #[tokio::test]
+    async fn test_memory_storage_update() {
+        let storage = MemoryStorage::new("test");
+        
+        // Store and update
+        storage.store("key1", "value1").await.unwrap();
+        storage.update("key1", "value2").await.unwrap();
+        
+        let loaded = storage.load("key1").await.unwrap();
+        assert_eq!(loaded, Some("value2".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_memory_storage_delete() {
+        let storage = MemoryStorage::new("test");
+        
+        storage.store("key1", "value1").await.unwrap();
+        storage.delete("key1").await.unwrap();
+        
+        let loaded = storage.load("key1").await.unwrap();
+        assert_eq!(loaded, None);
+    }
+
+    #[tokio::test]
+    async fn test_memory_storage_isolation() {
+        let storage1 = MemoryStorage::new("storage1");
+        let storage2 = MemoryStorage::new("storage2");
+        
+        storage1.store("key1", "value1").await.unwrap();
+        storage2.store("key1", "value2").await.unwrap();
+        
+        // Each storage should have its own data
+        let loaded1 = storage1.load("key1").await.unwrap();
+        let loaded2 = storage2.load("key1").await.unwrap();
+        
+        assert_eq!(loaded1, Some("value1".to_string()));
+        assert_eq!(loaded2, Some("value2".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_memory_storage_clone_shares_data() {
+        let storage1 = MemoryStorage::new("test");
+        let storage2 = storage1.clone();
+        
+        // Store in one clone
+        storage1.store("key1", "value1").await.unwrap();
+        
+        // Should be visible in the other clone
+        let loaded = storage2.load("key1").await.unwrap();
+        assert_eq!(loaded, Some("value1".to_string()));
+    }
+}

--- a/src/utils/state.rs
+++ b/src/utils/state.rs
@@ -1,18 +1,13 @@
 use crate::{
     cert_manager::{
         CertManager,
-        challenge::{
-            AcmeDnsProvider, AwsRoute53DnsProvider, AzureDnsProvider, CloudflareDnsProvider,
-            Dns01Handler, GoogleCloudDnsProvider, PebbleDnsProvider, ServicePrincipal,
-        },
-        storage::{AwsS3, AwsSecretsManager, Redis},
+        challenge::Dns01Handler,
     },
     config::{Config as AppConfig, DnsProviderKind, ENV_DEVELOPMENT, ENV_PRODUCTION},
     database::{Migrator, queries::SeaOrmStore},
     models::{Credentials, StatusListRecord},
 };
-use aws_config::{BehaviorVersion, Region, SdkConfig};
-use color_eyre::eyre::{Context, Result as EyeResult, eyre};
+use color_eyre::eyre::{Context, Result as EyeResult};
 use sea_orm::{ConnectOptions, Database};
 use sea_orm_migration::MigratorTrait;
 use secrecy::ExposeSecret;
@@ -39,26 +34,17 @@ pub struct AppState {
 
 pub async fn build_state(config: &AppConfig) -> EyeResult<AppState> {
     let db_url = config.database.url.expose_secret();
-    let db_backend = config.database.backend;
-
-    // Validate URL scheme matches the configured backend
-    if !db_backend.validate_url_scheme(db_url) {
-        return Err(color_eyre::eyre::eyre!(
-            "URL scheme does not match configured backend '{}'. Expected URL starting with {}",
-            db_backend.as_str(),
-            db_backend.expected_scheme_description()
-        ));
-    }
 
     #[cfg(feature = "sqlite")]
     let mut opt = ConnectOptions::new(db_url.to_string());
     #[cfg(not(feature = "sqlite"))]
     let opt = ConnectOptions::new(db_url.to_string());
     #[cfg(feature = "sqlite")]
-    if db_backend == crate::config::DatabaseBackend::Sqlite {
+    {
         opt.max_connections(1);
         opt.map_sqlx_sqlite_opts(|o| o.foreign_keys(true));
     }
+    
     let db = Database::connect(opt)
         .await
         .wrap_err("Failed to connect to database")?;
@@ -66,17 +52,6 @@ pub async fn build_state(config: &AppConfig) -> EyeResult<AppState> {
     Migrator::up(&db, None)
         .await
         .wrap_err("Failed to run database migrations")?;
-
-    let aws_config = aws_config::defaults(BehaviorVersion::latest())
-        .region(Region::new(config.aws.region.clone()))
-        .load()
-        .await;
-
-    let redis_conn = config
-        .redis
-        .start(None, None, None)
-        .await
-        .wrap_err("Failed to connect to Redis")?;
 
     // Initialize the challenge handler with the configured DNS provider.
     // When no provider is configured, the environment decides: Route53 in
@@ -94,22 +69,13 @@ pub async fn build_state(config: &AppConfig) -> EyeResult<AppState> {
              but APP_ENV=production; ACME challenges will not succeed against a real CA"
         );
     }
-    let challenge_handler = build_dns_challenge_handler(dns_provider, config, &aws_config).await?;
+    let challenge_handler = build_dns_challenge_handler(dns_provider, config).await?;
 
     // Initialize the storage backends for the certificate manager
-    let cache = Redis::new(redis_conn.clone()).with_ttl(config.redis.cert_cache_ttl);
-    let cert_storage = AwsS3::new(
-        &aws_config,
-        &config.aws.s3_bucket,
-        &config.aws.region,
-        &config.aws.s3_key_prefix,
-    )
-    .with_cache(cache);
-    let secrets_storage = AwsSecretsManager::new(
-        &aws_config,
-        Duration::from_secs(config.aws.secrets_cache_ttl),
-    )
-    .await?;
+    // These are feature-gated and will use memory implementations when
+    // the corresponding feature is not enabled
+    let cert_storage = build_cert_storage(config).await?;
+    let secrets_storage = build_secrets_storage(config).await?;
 
     let mut certificate_manager = CertManager::new(
         [&config.server.domain],
@@ -145,27 +111,142 @@ pub async fn build_state(config: &AppConfig) -> EyeResult<AppState> {
     })
 }
 
+/// Build the certificate storage backend based on enabled features.
+///
+/// Priority:
+/// 1. AWS S3 (if aws-s3 feature is enabled)
+/// 2. Memory storage (fallback for local development)
+async fn build_cert_storage(_config: &AppConfig) -> EyeResult<Box<dyn crate::cert_manager::storage::Storage>> {
+    #[cfg(feature = "aws-s3")]
+    {
+        use crate::cert_manager::storage::AwsS3;
+
+        let aws_config = ::aws_config::defaults(::aws_config::BehaviorVersion::latest())
+            .region(::aws_config::Region::new(_config.aws.region.clone()))
+            .load()
+            .await;
+
+        let cache = build_cert_chain_cache(_config).await?;
+
+        let storage = AwsS3::new(
+            &aws_config,
+            &_config.aws.s3_bucket,
+            &_config.aws.region,
+            &_config.aws.s3_key_prefix,
+        )
+        .with_cache(cache);
+
+        return Ok(Box::new(storage));
+    }
+
+    #[cfg(not(feature = "aws-s3"))]
+    {
+        use crate::cert_manager::storage::MemoryStorage;
+
+        tracing::info!("Using in-memory certificate storage (aws-s3 feature not enabled)");
+        Ok(Box::new(MemoryStorage::cert_storage()))
+    }
+}
+
+/// Build the secrets storage backend based on enabled features.
+///
+/// Priority:
+/// 1. AWS Secrets Manager (if aws-secrets-manager feature is enabled)
+/// 2. Memory storage (fallback for local development)
+async fn build_secrets_storage(_config: &AppConfig) -> EyeResult<Box<dyn crate::cert_manager::storage::Storage>> {
+    #[cfg(feature = "aws-secrets-manager")]
+    {
+        use crate::cert_manager::storage::AwsSecretsManager;
+
+        let aws_config = ::aws_config::defaults(::aws_config::BehaviorVersion::latest())
+            .region(::aws_config::Region::new(_config.aws.region.clone()))
+            .load()
+            .await;
+
+        let storage = AwsSecretsManager::new(
+            &aws_config,
+            Duration::from_secs(_config.aws.secrets_cache_ttl),
+        )
+        .await?;
+
+        return Ok(Box::new(storage));
+    }
+
+    #[cfg(not(feature = "aws-secrets-manager"))]
+    {
+        use crate::cert_manager::storage::MemoryStorage;
+
+        tracing::info!("Using in-memory secrets storage (aws-secrets-manager feature not enabled)");
+        Ok(Box::new(MemoryStorage::secrets_storage()))
+    }
+}
+
+/// Build the certificate chain cache backend based on enabled features.
+/// 
+/// Priority:
+/// 1. Redis (if redis-cache feature is enabled)
+/// 2. Memory cache (fallback - uses moka, which is always in-memory)
+#[cfg(feature = "aws-s3")]
+async fn build_cert_chain_cache(config: &AppConfig) -> EyeResult<Box<dyn crate::cert_manager::storage::Storage>> {
+    #[cfg(feature = "redis-cache")]
+    {
+        use crate::cert_manager::storage::Redis;
+        
+        let redis_conn = config
+            .redis
+            .start(None, None, None)
+            .await
+            .wrap_err("Failed to connect to Redis")?;
+        
+        return Ok(Box::new(Redis::new(redis_conn).with_ttl(config.redis.cert_cache_ttl)));
+    }
+    
+    #[cfg(not(feature = "redis-cache"))]
+    {
+        use crate::cert_manager::storage::MemoryStorage;
+        
+        tracing::info!("Using in-memory certificate chain cache (redis-cache feature not enabled)");
+        Ok(Box::new(MemoryStorage::new("cert_chain_cache")))
+    }
+}
+
 /// Build the DNS-01 challenge handler for the resolved DNS provider
 async fn build_dns_challenge_handler(
     provider: DnsProviderKind,
     config: &AppConfig,
-    aws_config: &SdkConfig,
 ) -> EyeResult<Dns01Handler> {
-    let dns = &config.server.cert.dns;
-    let handler = match provider {
-        DnsProviderKind::Route53 => Dns01Handler::new(AwsRoute53DnsProvider::new(aws_config)),
+    match provider {
+        #[cfg(feature = "dns-route53")]
+        DnsProviderKind::Route53 => {
+            use crate::cert_manager::challenge::AwsRoute53DnsProvider;
+            
+            let aws_config = ::aws_config::defaults(::aws_config::BehaviorVersion::latest())
+                .region(::aws_config::Region::new(config.aws.region.clone()))
+                .load()
+                .await;
+            
+            Ok(Dns01Handler::new(AwsRoute53DnsProvider::new(&aws_config)))
+        }
+        
+        #[cfg(feature = "dns-cloudflare")]
         DnsProviderKind::Cloudflare => {
-            let cfg = dns
+            use crate::cert_manager::challenge::CloudflareDnsProvider;
+
+            let cfg = config.server.cert.dns
                 .cloudflare
                 .as_ref()
-                .ok_or_else(|| eyre!("Missing Cloudflare DNS settings"))?;
-            Dns01Handler::new(CloudflareDnsProvider::new(cfg.api_token.clone()))
+                .ok_or_else(|| color_eyre::eyre::eyre!("Missing Cloudflare DNS settings"))?;
+            Ok(Dns01Handler::new(CloudflareDnsProvider::new(cfg.api_token.clone())))
         }
+
+        #[cfg(feature = "dns-gcloud")]
         DnsProviderKind::Gcloud => {
-            let cfg = dns
+            use crate::cert_manager::challenge::GoogleCloudDnsProvider;
+
+            let cfg = config.server.cert.dns
                 .gcloud
                 .as_ref()
-                .ok_or_else(|| eyre!("Missing Google Cloud DNS settings"))?;
+                .ok_or_else(|| color_eyre::eyre::eyre!("Missing Google Cloud DNS settings"))?;
             // Empty values count as unset, matching DnsConfig::resolve
             let inline = cfg
                 .service_account_key
@@ -180,16 +261,20 @@ async fn build_dns_challenge_handler(
                 (None, Some(path)) => tokio::fs::read_to_string(path)
                     .await
                     .wrap_err_with(|| format!("Failed to read service account key at {path}"))?,
-                (None, None) => return Err(eyre!("Missing Google Cloud service account key")),
+                (None, None) => return Err(color_eyre::eyre::eyre!("Missing Google Cloud service account key")),
             };
-            Dns01Handler::new(GoogleCloudDnsProvider::new(&key_json)?)
+            Ok(Dns01Handler::new(GoogleCloudDnsProvider::new(&key_json)?))
         }
+
+        #[cfg(feature = "dns-azure")]
         DnsProviderKind::Azure => {
-            let cfg = dns
+            use crate::cert_manager::challenge::{AzureDnsProvider, ServicePrincipal};
+
+            let cfg = config.server.cert.dns
                 .azure
                 .as_ref()
-                .ok_or_else(|| eyre!("Missing Azure DNS settings"))?;
-            Dns01Handler::new(AzureDnsProvider::new(
+                .ok_or_else(|| color_eyre::eyre::eyre!("Missing Azure DNS settings"))?;
+            Ok(Dns01Handler::new(AzureDnsProvider::new(
                 ServicePrincipal {
                     tenant_id: cfg.tenant_id.clone(),
                     client_id: cfg.client_id.clone(),
@@ -197,21 +282,29 @@ async fn build_dns_challenge_handler(
                 },
                 &cfg.subscription_id,
                 &cfg.resource_group,
-            ))
+            )))
         }
+
+        #[cfg(feature = "dns-acmedns")]
         DnsProviderKind::Acmedns => {
-            let cfg = dns
+            use crate::cert_manager::challenge::AcmeDnsProvider;
+
+            let cfg = config.server.cert.dns
                 .acmedns
                 .as_ref()
-                .ok_or_else(|| eyre!("Missing ACME-DNS settings"))?;
-            Dns01Handler::new(AcmeDnsProvider::new(
+                .ok_or_else(|| color_eyre::eyre::eyre!("Missing ACME-DNS settings"))?;
+            Ok(Dns01Handler::new(AcmeDnsProvider::new(
                 &cfg.server_url,
                 &cfg.username,
                 cfg.password.clone(),
                 &cfg.subdomain,
-            ))
+            )))
         }
+        
+        #[cfg(feature = "dns-pebble")]
         DnsProviderKind::Pebble => {
+            use crate::cert_manager::challenge::PebbleDnsProvider;
+            
             // The DNS challenge server URL is optional and only used in dev mode;
             // it falls back to the well-known Pebble challenge test server when unset.
             let dns_url = config
@@ -220,51 +313,75 @@ async fn build_dns_challenge_handler(
                 .dns_challenge_server_url
                 .as_deref()
                 .unwrap_or("http://challtestsrv:8055");
-            Dns01Handler::new(PebbleDnsProvider::new(dns_url))
+            Ok(Dns01Handler::new(PebbleDnsProvider::new(dns_url)))
         }
-    };
-    Ok(handler)
+        
+        // Fallback for when a DNS provider is requested but its feature is not enabled
+        #[allow(unreachable_patterns)]
+        _ => {
+            return Err(color_eyre::eyre::eyre!(
+                "DNS provider {:?} is not available. Make sure the corresponding feature is enabled (e.g., 'dns-route53', 'dns-cloudflare', etc.)",
+                provider
+            ));
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{AcmeDnsConfig, AzureDnsConfig, CloudflareDnsConfig, GcloudDnsConfig};
-    use sealed_test::prelude::*;
 
-    fn test_sdk_config() -> SdkConfig {
-        SdkConfig::builder()
-            .behavior_version(BehaviorVersion::latest())
-            .build()
-    }
+    #[cfg(all(
+        feature = "dns-route53",
+        feature = "dns-pebble",
+        feature = "dns-cloudflare",
+        feature = "dns-azure",
+        feature = "dns-acmedns",
+        feature = "dns-gcloud"
+    ))]
+    use crate::config::{AcmeDnsConfig, AzureDnsConfig, CloudflareDnsConfig, GcloudDnsConfig};
+
+    #[cfg(all(
+        feature = "dns-route53",
+        feature = "dns-pebble",
+        feature = "dns-cloudflare",
+        feature = "dns-azure",
+        feature = "dns-acmedns",
+        feature = "dns-gcloud"
+    ))]
+    use sealed_test::prelude::*;
 
     // Sync wrapper shadowing the async builder: sealed tests fork the
     // process and run without an async runtime
     fn build_dns_challenge_handler(
         provider: DnsProviderKind,
         config: &AppConfig,
-        aws_config: &SdkConfig,
     ) -> EyeResult<Dns01Handler> {
         tokio::runtime::Runtime::new()
             .expect("failed to build test runtime")
-            .block_on(super::build_dns_challenge_handler(
-                provider, config, aws_config,
-            ))
+            .block_on(super::build_dns_challenge_handler(provider, config))
     }
 
     #[sealed_test]
+    #[cfg(all(
+        feature = "dns-route53",
+        feature = "dns-pebble",
+        feature = "dns-cloudflare",
+        feature = "dns-azure",
+        feature = "dns-acmedns",
+        feature = "dns-gcloud"
+    ))]
     fn builds_handler_for_each_configured_provider() {
-        let sdk = test_sdk_config();
         let mut config = AppConfig::load().expect("Failed to load config");
 
         // Route53 and Pebble need no provider-specific settings
-        assert!(build_dns_challenge_handler(DnsProviderKind::Route53, &config, &sdk).is_ok());
-        assert!(build_dns_challenge_handler(DnsProviderKind::Pebble, &config, &sdk).is_ok());
+        assert!(build_dns_challenge_handler(DnsProviderKind::Route53, &config).is_ok());
+        assert!(build_dns_challenge_handler(DnsProviderKind::Pebble, &config).is_ok());
 
         config.server.cert.dns.cloudflare = Some(CloudflareDnsConfig {
             api_token: "token".into(),
         });
-        assert!(build_dns_challenge_handler(DnsProviderKind::Cloudflare, &config, &sdk).is_ok());
+        assert!(build_dns_challenge_handler(DnsProviderKind::Cloudflare, &config).is_ok());
 
         config.server.cert.dns.azure = Some(AzureDnsConfig {
             tenant_id: "tenant".into(),
@@ -273,7 +390,7 @@ mod tests {
             subscription_id: "sub".into(),
             resource_group: "rg".into(),
         });
-        assert!(build_dns_challenge_handler(DnsProviderKind::Azure, &config, &sdk).is_ok());
+        assert!(build_dns_challenge_handler(DnsProviderKind::Azure, &config).is_ok());
 
         config.server.cert.dns.acmedns = Some(AcmeDnsConfig {
             server_url: "https://auth.example.org".into(),
@@ -281,7 +398,7 @@ mod tests {
             password: "password".into(),
             subdomain: "subdomain".into(),
         });
-        assert!(build_dns_challenge_handler(DnsProviderKind::Acmedns, &config, &sdk).is_ok());
+        assert!(build_dns_challenge_handler(DnsProviderKind::Acmedns, &config).is_ok());
 
         let key_json = serde_json::json!({
             "client_email": "acme@test-project.iam.gserviceaccount.com",
@@ -293,18 +410,23 @@ mod tests {
             service_account_key: Some(key_json.to_string().into()),
             service_account_key_path: None,
         });
-        assert!(build_dns_challenge_handler(DnsProviderKind::Gcloud, &config, &sdk).is_ok());
+        assert!(build_dns_challenge_handler(DnsProviderKind::Gcloud, &config).is_ok());
     }
 
     #[sealed_test]
+    #[cfg(all(
+        feature = "dns-cloudflare",
+        feature = "dns-azure",
+        feature = "dns-acmedns",
+        feature = "dns-gcloud"
+    ))]
     fn fails_when_provider_settings_are_missing() {
-        let sdk = test_sdk_config();
         let config = AppConfig::load().expect("Failed to load config");
 
-        assert!(build_dns_challenge_handler(DnsProviderKind::Cloudflare, &config, &sdk).is_err());
-        assert!(build_dns_challenge_handler(DnsProviderKind::Gcloud, &config, &sdk).is_err());
-        assert!(build_dns_challenge_handler(DnsProviderKind::Azure, &config, &sdk).is_err());
-        assert!(build_dns_challenge_handler(DnsProviderKind::Acmedns, &config, &sdk).is_err());
+        assert!(build_dns_challenge_handler(DnsProviderKind::Cloudflare, &config).is_err());
+        assert!(build_dns_challenge_handler(DnsProviderKind::Gcloud, &config).is_err());
+        assert!(build_dns_challenge_handler(DnsProviderKind::Azure, &config).is_err());
+        assert!(build_dns_challenge_handler(DnsProviderKind::Acmedns, &config).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Objective

Every external service integration must expose a local/in-memory alternative alongside the production backend, selected at compile time via Cargo features rather than runtime configuration.

## Context

The server is currently hard-wired to production dependencies: PostgreSQL, AWS S3, AWS Secrets Manager, AWS Route53, and Redis. To keep CI fast, local development simple, and deployments portable, each integration should be wrapped behind a trait and gated behind Cargo features so that a fully in-memory build is possible.

This is a horizontal concern: each individual backend implementation is tracked in its own sub-issue, but this ticket establishes the pattern and fills the gaps.

## Deliverables

- [x] Agree on a crate-wide feature-naming convention (e.g., `postgres`, `sqlite`, `memory`, `aws-s3`, `redis`, `dns-route53`, `dns-cloudflare`).
- [x] Define the backend trait boundaries for:
  - status-list cache (#163)
  - certificate provisioning / store (#159)
  - certificate chain cache (#158)
  - DNS provider (#162)
  - signing-material / secrets store
- [x] Provide `memory` (or `sqlite` where appropriate) implementations for the backends that currently lack a local alternative.
- [x] Make `cargo build --no-default-features --features memory` produce a runnable minimal binary for local tests.
- [x] Ensure CI runs the test suite against the local backends.
- [x] Document the feature matrix in `README.md` and update `docker-compose.yml`.

## Acceptance Criteria

- All production backends are selectable through Cargo features.
- No production credentials are required for default local development.
- Compile errors clearly indicate when a required backend feature is missing.

## References

- Related: #143 (database backend), #158 (cert chain cache), #159 (cert provisioning), #162 (DNS providers), #163 (status-list cache)