### PR TITLE
DNS provider selection currently validates config in two places:

### DIFF
--- a/docs/dns-providers.md
+++ b/docs/dns-providers.md
@@ -157,5 +157,6 @@ validates only once, so `create_txt_record` must wait internally until the
 record is served, to the degree the provider's API allows confirming it: poll
 a change-status API where one exists (see Route53 and Google Cloud DNS), or
 wait out the provider's documented propagation window otherwise (see Azure).
-Add a variant to `DnsProviderKind` in `src/config.rs`, a build arm in
-`src/utils/state.rs`, and wiremock tests next to the implementation.
+Add a variant to `DnsProviderKind` and to `ResolvedDnsProvider` (carrying the
+validated settings) in `src/config.rs`, a build arm in `src/utils/state.rs`,
+and wiremock tests next to the implementation.

--- a/src/config.rs
+++ b/src/config.rs
@@ -134,6 +134,44 @@ pub enum DnsProviderKind {
     Pebble,
 }
 
+/// A DNS provider resolved by [`DnsConfig::resolve`], carrying its validated
+/// settings so the boot path can build the provider without re-checking them
+#[derive(Debug, Clone, Copy)]
+pub enum ResolvedDnsProvider<'a> {
+    /// Uses the ambient AWS credentials; no provider-specific settings
+    Route53,
+    Cloudflare(&'a CloudflareDnsConfig),
+    Gcloud(GcloudKeySource<'a>),
+    Azure(&'a AzureDnsConfig),
+    Acmedns(&'a AcmeDnsConfig),
+    /// Development-only; its challenge server URL lives outside [`DnsConfig`]
+    Pebble,
+}
+
+/// The Google Cloud service account key source, with empty values counting
+/// as unset and the inline key winning when both are configured
+#[derive(Debug, Clone, Copy)]
+pub enum GcloudKeySource<'a> {
+    /// The key JSON itself
+    Inline(&'a SecretString),
+    /// Path to the key JSON file
+    Path(&'a str),
+}
+
+impl ResolvedDnsProvider<'_> {
+    /// The plain provider kind, without the settings
+    pub fn kind(&self) -> DnsProviderKind {
+        match self {
+            Self::Route53 => DnsProviderKind::Route53,
+            Self::Cloudflare(_) => DnsProviderKind::Cloudflare,
+            Self::Gcloud(_) => DnsProviderKind::Gcloud,
+            Self::Azure(_) => DnsProviderKind::Azure,
+            Self::Acmedns(_) => DnsProviderKind::Acmedns,
+            Self::Pebble => DnsProviderKind::Pebble,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct DnsConfig {
     /// Selected DNS provider. When unset, defaults to Route53 in production
@@ -359,54 +397,60 @@ impl CloudflareDnsConfig {
 }
 
 impl DnsConfig {
-    /// Resolve the DNS provider to use and validate that its settings are present.
-    pub fn resolve(&self, app_env: &str) -> Result<DnsProviderKind, ConfigError> {
+    /// Resolve the DNS provider to use, validate its settings and return them
+    /// borrowed, so consumers need no re-validation. Synchronous and
+    /// network-free by design; anything needing I/O belongs to the boot path.
+    pub fn resolve(&self, app_env: &str) -> Result<ResolvedDnsProvider<'_>, ConfigError> {
         let kind = self.provider.unwrap_or(if app_env == ENV_PRODUCTION {
             DnsProviderKind::Route53
         } else {
             DnsProviderKind::Pebble
         });
 
-        let missing = match kind {
-            DnsProviderKind::Cloudflare if self.cloudflare.is_none() => Some("dns.cloudflare"),
-            DnsProviderKind::Gcloud
-                if self.gcloud.as_ref().is_none_or(|g| {
+        let missing = |section: &str| {
+            ConfigError::Message(format!(
+                "DNS provider {kind:?} selected but the server.cert.{section} settings are missing"
+            ))
+        };
+        let resolved = match kind {
+            DnsProviderKind::Route53 => ResolvedDnsProvider::Route53,
+            DnsProviderKind::Pebble => ResolvedDnsProvider::Pebble,
+            DnsProviderKind::Cloudflare => {
+                let cloudflare = self
+                    .cloudflare
+                    .as_ref()
+                    .ok_or_else(|| missing("dns.cloudflare"))?;
+                cloudflare.validate()?;
+                ResolvedDnsProvider::Cloudflare(cloudflare)
+            }
+            DnsProviderKind::Gcloud => {
+                let key = self.gcloud.as_ref().and_then(|g| {
                     g.service_account_key
                         .as_ref()
-                        .is_none_or(|k| k.expose_secret().trim().is_empty())
-                        && non_empty(&g.service_account_key_path).is_none()
-                }) =>
-            {
-                Some("dns.gcloud")
-            }
-            DnsProviderKind::Azure if self.azure.is_none() => Some("dns.azure"),
-            DnsProviderKind::Acmedns if self.acmedns.is_none() => Some("dns.acmedns"),
-            _ => None,
-        };
-        if let Some(section) = missing {
-            return Err(ConfigError::Message(format!(
-                "DNS provider {kind:?} selected but the server.cert.{section} settings are missing"
-            )));
-        }
-        match kind {
-            DnsProviderKind::Cloudflare => {
-                if let Some(cloudflare) = &self.cloudflare {
-                    cloudflare.validate()?;
-                }
+                        .filter(|k| !k.expose_secret().trim().is_empty())
+                        .map(GcloudKeySource::Inline)
+                        .or_else(|| {
+                            non_empty(&g.service_account_key_path)
+                                .map(|path| GcloudKeySource::Path(path))
+                        })
+                });
+                ResolvedDnsProvider::Gcloud(key.ok_or_else(|| missing("dns.gcloud"))?)
             }
             DnsProviderKind::Azure => {
-                if let Some(azure) = &self.azure {
-                    azure.validate()?;
-                }
+                let azure = self.azure.as_ref().ok_or_else(|| missing("dns.azure"))?;
+                azure.validate()?;
+                ResolvedDnsProvider::Azure(azure)
             }
             DnsProviderKind::Acmedns => {
-                if let Some(acmedns) = &self.acmedns {
-                    acmedns.validate()?;
-                }
+                let acmedns = self
+                    .acmedns
+                    .as_ref()
+                    .ok_or_else(|| missing("dns.acmedns"))?;
+                acmedns.validate()?;
+                ResolvedDnsProvider::Acmedns(acmedns)
             }
-            _ => {}
-        }
-        Ok(kind)
+        };
+        Ok(resolved)
     }
 }
 
@@ -620,8 +664,14 @@ mod tests {
     fn test_dns_provider_defaults_per_environment() {
         let dns = DnsConfig::default();
 
-        assert_eq!(dns.resolve("production").unwrap(), DnsProviderKind::Route53);
-        assert_eq!(dns.resolve("development").unwrap(), DnsProviderKind::Pebble);
+        assert_eq!(
+            dns.resolve("production").unwrap().kind(),
+            DnsProviderKind::Route53
+        );
+        assert_eq!(
+            dns.resolve("development").unwrap().kind(),
+            DnsProviderKind::Pebble
+        );
     }
 
     #[test]
@@ -631,7 +681,10 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(dns.resolve("production").unwrap(), DnsProviderKind::Pebble);
+        assert_eq!(
+            dns.resolve("production").unwrap().kind(),
+            DnsProviderKind::Pebble
+        );
     }
 
     #[test]
@@ -651,7 +704,7 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(
-            dns.resolve("production").unwrap(),
+            dns.resolve("production").unwrap().kind(),
             DnsProviderKind::Cloudflare
         );
 
@@ -675,7 +728,10 @@ mod tests {
             subdomain: Some("subdomain".into()),
             accounts: Default::default(),
         });
-        assert_eq!(dns.resolve("production").unwrap(), DnsProviderKind::Acmedns);
+        assert_eq!(
+            dns.resolve("production").unwrap().kind(),
+            DnsProviderKind::Acmedns
+        );
 
         // A per-domain accounts map alone is enough
         let account = AcmeDnsAccount {
@@ -690,7 +746,10 @@ mod tests {
             subdomain: None,
             accounts: [("status.example.com".to_string(), account)].into(),
         });
-        assert_eq!(dns.resolve("production").unwrap(), DnsProviderKind::Acmedns);
+        assert_eq!(
+            dns.resolve("production").unwrap().kind(),
+            DnsProviderKind::Acmedns
+        );
 
         // A partial default account is rejected
         let dns = acmedns(AcmeDnsConfig {
@@ -734,7 +793,10 @@ mod tests {
             }),
             ..Default::default()
         };
-        assert_eq!(dns.resolve("production").unwrap(), DnsProviderKind::Gcloud);
+        assert_eq!(
+            dns.resolve("production").unwrap().kind(),
+            DnsProviderKind::Gcloud
+        );
     }
 
     #[test]
@@ -759,7 +821,7 @@ mod tests {
         assert!(err.contains("subscription_id"));
         assert!(!err.contains("client_id"));
         assert_eq!(
-            azure("tenant", "sub").resolve("production").unwrap(),
+            azure("tenant", "sub").resolve("production").unwrap().kind(),
             DnsProviderKind::Azure
         );
 
@@ -851,7 +913,10 @@ mod tests {
 
         // A usable entry passes
         let dns = acmedns([("status.example.com".to_string(), account("user", "sub"))].into());
-        assert_eq!(dns.resolve("production").unwrap(), DnsProviderKind::Acmedns);
+        assert_eq!(
+            dns.resolve("production").unwrap().kind(),
+            DnsProviderKind::Acmedns
+        );
     }
 
     #[sealed_test(env = [

--- a/src/config.rs
+++ b/src/config.rs
@@ -919,6 +919,43 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_gcloud_inline_key_wins_over_path() {
+        // Both sources configured: the inline key must be selected, not the path
+        let dns = DnsConfig {
+            provider: Some(DnsProviderKind::Gcloud),
+            gcloud: Some(GcloudDnsConfig {
+                service_account_key: Some("inline-key-json".into()),
+                service_account_key_path: Some("/etc/gcloud/key.json".into()),
+            }),
+            ..Default::default()
+        };
+        let resolved = dns.resolve("production").unwrap();
+        match resolved {
+            ResolvedDnsProvider::Gcloud(GcloudKeySource::Inline(key)) => {
+                assert_eq!(key.expose_secret(), "inline-key-json");
+            }
+            other => panic!("Expected an inline key source, got {other:?}"),
+        }
+
+        // An empty inline key counts as unset, so the path is used instead
+        let dns = DnsConfig {
+            provider: Some(DnsProviderKind::Gcloud),
+            gcloud: Some(GcloudDnsConfig {
+                service_account_key: Some("".into()),
+                service_account_key_path: Some("/etc/gcloud/key.json".into()),
+            }),
+            ..Default::default()
+        };
+        let resolved = dns.resolve("production").unwrap();
+        match resolved {
+            ResolvedDnsProvider::Gcloud(GcloudKeySource::Path(path)) => {
+                assert_eq!(path, "/etc/gcloud/key.json");
+            }
+            other => panic!("Expected a path key source, got {other:?}"),
+        }
+    }
+
     #[sealed_test(env = [
         ("APP_SERVER__CERT__DNS__ACMEDNS__SERVER_URL", "https://auth.example.org"),
         ("APP_SERVER__CERT__DNS__ACMEDNS__ACCOUNTS", r#"{

--- a/src/utils/state.rs
+++ b/src/utils/state.rs
@@ -8,7 +8,10 @@ use crate::{
         },
         storage::{AwsS3, AwsSecretsManager, Redis},
     },
-    config::{Config as AppConfig, DnsProviderKind, ENV_DEVELOPMENT, ENV_PRODUCTION},
+    config::{
+        Config as AppConfig, DnsProviderKind, ENV_DEVELOPMENT, ENV_PRODUCTION, GcloudKeySource,
+        ResolvedDnsProvider,
+    },
     database::{Migrator, queries::SeaOrmStore},
     models::{Credentials, StatusListRecord},
 };
@@ -98,7 +101,7 @@ pub async fn build_state(config: &AppConfig) -> EyeResult<AppState> {
         .dns
         .resolve(&app_env)
         .wrap_err("Invalid DNS provider configuration")?;
-    if dns_provider == DnsProviderKind::Pebble && app_env == ENV_PRODUCTION {
+    if dns_provider.kind() == DnsProviderKind::Pebble && app_env == ENV_PRODUCTION {
         warn!(
             "The 'pebble' DNS provider is a development-only fake DNS server \
              but APP_ENV=production; ACME challenges will not succeed against a real CA"
@@ -265,64 +268,35 @@ fn store_certificate_strategy(config: &AppConfig) -> EyeResult<Option<StoreProvi
 /// `cert_domains` are the domains certificates will be ordered for, used to
 /// validate at startup that the provider can serve challenges for them.
 async fn build_dns_challenge_handler(
-    provider: DnsProviderKind,
+    provider: ResolvedDnsProvider<'_>,
     config: &AppConfig,
     aws_config: &SdkConfig,
     cert_domains: &[&str],
 ) -> EyeResult<Dns01Handler> {
-    let dns = &config.server.cert.dns;
     let handler = match provider {
-        DnsProviderKind::Route53 => Dns01Handler::new(AwsRoute53DnsProvider::new(aws_config)),
-        DnsProviderKind::Cloudflare => {
-            let cfg = dns
-                .cloudflare
-                .as_ref()
-                .ok_or_else(|| eyre!("Missing Cloudflare DNS settings"))?;
+        ResolvedDnsProvider::Route53 => Dns01Handler::new(AwsRoute53DnsProvider::new(aws_config)),
+        ResolvedDnsProvider::Cloudflare(cfg) => {
             Dns01Handler::new(CloudflareDnsProvider::new(cfg.api_token.clone()))
         }
-        DnsProviderKind::Gcloud => {
-            let cfg = dns
-                .gcloud
-                .as_ref()
-                .ok_or_else(|| eyre!("Missing Google Cloud DNS settings"))?;
-            // Empty values count as unset, matching DnsConfig::resolve
-            let inline = cfg
-                .service_account_key
-                .as_ref()
-                .filter(|k| !k.expose_secret().trim().is_empty());
-            let path = cfg
-                .service_account_key_path
-                .as_deref()
-                .filter(|p| !p.trim().is_empty());
-            let key_json = match (inline, path) {
-                (Some(key), _) => key.expose_secret().to_string(),
-                (None, Some(path)) => tokio::fs::read_to_string(path)
+        ResolvedDnsProvider::Gcloud(key) => {
+            let key_json = match key {
+                GcloudKeySource::Inline(key) => key.expose_secret().to_string(),
+                GcloudKeySource::Path(path) => tokio::fs::read_to_string(path)
                     .await
                     .wrap_err_with(|| format!("Failed to read service account key at {path}"))?,
-                (None, None) => return Err(eyre!("Missing Google Cloud service account key")),
             };
             Dns01Handler::new(GoogleCloudDnsProvider::new(&key_json)?)
         }
-        DnsProviderKind::Azure => {
-            let cfg = dns
-                .azure
-                .as_ref()
-                .ok_or_else(|| eyre!("Missing Azure DNS settings"))?;
-            Dns01Handler::new(AzureDnsProvider::new(
-                ServicePrincipal {
-                    tenant_id: cfg.tenant_id.clone(),
-                    client_id: cfg.client_id.clone(),
-                    client_secret: cfg.client_secret.clone(),
-                },
-                &cfg.subscription_id,
-                &cfg.resource_group,
-            ))
-        }
-        DnsProviderKind::Acmedns => {
-            let cfg = dns
-                .acmedns
-                .as_ref()
-                .ok_or_else(|| eyre!("Missing ACME-DNS settings"))?;
+        ResolvedDnsProvider::Azure(cfg) => Dns01Handler::new(AzureDnsProvider::new(
+            ServicePrincipal {
+                tenant_id: cfg.tenant_id.clone(),
+                client_id: cfg.client_id.clone(),
+                client_secret: cfg.client_secret.clone(),
+            },
+            &cfg.subscription_id,
+            &cfg.resource_group,
+        )),
+        ResolvedDnsProvider::Acmedns(cfg) => {
             let accounts = cfg
                 .accounts
                 .iter()
@@ -338,7 +312,7 @@ async fn build_dns_challenge_handler(
             provider.check_order_domains(cert_domains)?;
             Dns01Handler::new(provider)
         }
-        DnsProviderKind::Pebble => {
+        ResolvedDnsProvider::Pebble => {
             // The DNS challenge server URL is optional and only used in dev mode;
             // it falls back to the well-known Pebble challenge test server when unset.
             let dns_url = config
@@ -373,16 +347,19 @@ mod tests {
 
     // Sync wrapper shadowing the async builder: sealed tests fork the
     // process and run without an async runtime
+    // and resolves the given provider first, exactly as the boot path does
     fn build_dns_challenge_handler(
         provider: DnsProviderKind,
-        config: &AppConfig,
+        config: &mut AppConfig,
         aws_config: &SdkConfig,
         cert_domains: &[&str],
     ) -> EyeResult<Dns01Handler> {
+        config.server.cert.dns.provider = Some(provider);
+        let resolved = config.server.cert.dns.resolve(ENV_PRODUCTION)?;
         tokio::runtime::Runtime::new()
             .expect("failed to build test runtime")
             .block_on(super::build_dns_challenge_handler(
-                provider,
+                resolved,
                 config,
                 aws_config,
                 cert_domains,
@@ -398,17 +375,19 @@ mod tests {
 
         // Route53 and Pebble need no provider-specific settings
         assert!(
-            build_dns_challenge_handler(DnsProviderKind::Route53, &config, &sdk, &domains).is_ok()
+            build_dns_challenge_handler(DnsProviderKind::Route53, &mut config, &sdk, &domains)
+                .is_ok()
         );
         assert!(
-            build_dns_challenge_handler(DnsProviderKind::Pebble, &config, &sdk, &domains).is_ok()
+            build_dns_challenge_handler(DnsProviderKind::Pebble, &mut config, &sdk, &domains)
+                .is_ok()
         );
 
         config.server.cert.dns.cloudflare = Some(CloudflareDnsConfig {
             api_token: "token".into(),
         });
         assert!(
-            build_dns_challenge_handler(DnsProviderKind::Cloudflare, &config, &sdk, &domains)
+            build_dns_challenge_handler(DnsProviderKind::Cloudflare, &mut config, &sdk, &domains)
                 .is_ok()
         );
 
@@ -420,7 +399,8 @@ mod tests {
             resource_group: "rg".into(),
         });
         assert!(
-            build_dns_challenge_handler(DnsProviderKind::Azure, &config, &sdk, &domains).is_ok()
+            build_dns_challenge_handler(DnsProviderKind::Azure, &mut config, &sdk, &domains)
+                .is_ok()
         );
 
         config.server.cert.dns.acmedns = Some(AcmeDnsConfig {
@@ -431,7 +411,8 @@ mod tests {
             accounts: Default::default(),
         });
         assert!(
-            build_dns_challenge_handler(DnsProviderKind::Acmedns, &config, &sdk, &domains).is_ok()
+            build_dns_challenge_handler(DnsProviderKind::Acmedns, &mut config, &sdk, &domains)
+                .is_ok()
         );
 
         let key_json = serde_json::json!({
@@ -445,15 +426,19 @@ mod tests {
             service_account_key_path: None,
         });
         assert!(
-            build_dns_challenge_handler(DnsProviderKind::Gcloud, &config, &sdk, &domains).is_ok()
+            build_dns_challenge_handler(DnsProviderKind::Gcloud, &mut config, &sdk, &domains)
+                .is_ok()
         );
     }
 
+    // Boot cannot proceed on missing provider settings; since the builder
+    // takes a resolved provider, the rejection now comes from resolve()
     #[sealed_test]
     fn fails_when_provider_settings_are_missing() {
         let sdk = test_sdk_config();
-        let config = AppConfig::load().expect("Failed to load config");
-        let domains = [config.server.domain.as_str()];
+        let mut config = AppConfig::load().expect("Failed to load config");
+        let domain = config.server.domain.clone();
+        let domains = [domain.as_str()];
 
         for kind in [
             DnsProviderKind::Cloudflare,
@@ -461,7 +446,7 @@ mod tests {
             DnsProviderKind::Azure,
             DnsProviderKind::Acmedns,
         ] {
-            assert!(build_dns_challenge_handler(kind, &config, &sdk, &domains).is_err());
+            assert!(build_dns_challenge_handler(kind, &mut config, &sdk, &domains).is_err());
         }
     }
 
@@ -487,16 +472,18 @@ mod tests {
 
         // Map-only config not covering the server domain fails at startup
         config.server.cert.dns.acmedns = Some(acmedns.clone());
-        let err = build_dns_challenge_handler(DnsProviderKind::Acmedns, &config, &sdk, &domains)
-            .err()
-            .expect("startup must fail without an account for the server domain");
+        let err =
+            build_dns_challenge_handler(DnsProviderKind::Acmedns, &mut config, &sdk, &domains)
+                .err()
+                .expect("startup must fail without an account for the server domain");
         assert!(err.to_string().contains(&domain));
 
         // An entry for the server domain (any cosmetic form) makes it build
         acmedns.accounts.insert(domain.to_uppercase(), account);
         config.server.cert.dns.acmedns = Some(acmedns);
         assert!(
-            build_dns_challenge_handler(DnsProviderKind::Acmedns, &config, &sdk, &domains).is_ok()
+            build_dns_challenge_handler(DnsProviderKind::Acmedns, &mut config, &sdk, &domains)
+                .is_ok()
         );
     }
 
@@ -526,9 +513,10 @@ mod tests {
             .into(),
         });
 
-        let err = build_dns_challenge_handler(DnsProviderKind::Acmedns, &config, &sdk, &domains)
-            .err()
-            .expect("conflicting account entries must fail the boot-path builder");
+        let err =
+            build_dns_challenge_handler(DnsProviderKind::Acmedns, &mut config, &sdk, &domains)
+                .err()
+                .expect("conflicting account entries must fail the boot-path builder");
         assert!(err.to_string().contains("Conflicting ACME-DNS accounts"));
     }
 
@@ -548,9 +536,10 @@ mod tests {
             accounts: Default::default(),
         });
 
-        let err = build_dns_challenge_handler(DnsProviderKind::Acmedns, &config, &sdk, &domains)
-            .err()
-            .expect("three identifiers on one account must fail the boot-path builder");
+        let err =
+            build_dns_challenge_handler(DnsProviderKind::Acmedns, &mut config, &sdk, &domains)
+                .err()
+                .expect("three identifiers on one account must fail the boot-path builder");
         assert!(err.to_string().contains("two most recent TXT values"));
 
         // Mapping one of them to its own account restores a valid setup
@@ -565,7 +554,8 @@ mod tests {
             );
         }
         assert!(
-            build_dns_challenge_handler(DnsProviderKind::Acmedns, &config, &sdk, &domains).is_ok()
+            build_dns_challenge_handler(DnsProviderKind::Acmedns, &mut config, &sdk, &domains)
+                .is_ok()
         );
     }
 


### PR DESCRIPTION
## Background
- `DnsConfig::resolve()` checks section presence and returns a bare `DnsProviderKind`.
- `build_dns_challenge_handler()` in `state.rs` then re-fetches each `Option`  config with `ok_or_else` fallbacks that are unreachable if `resolve()` ran.
The code is correct; the duplicated checks are just duplication, and the second-layer error paths are effectively dead.

## Acceptance criteria

- [ ] `resolve()` returns a typed, validated resolved provider.
- [ ] Duplicate validation and dead error paths in `state.rs` removed.
- [ ] `resolve()` remains sync and network-free.
- [ ] Existing config tests pass unchanged (still offline).
- [ ] No behavior change  this is a pure refactor.

