### PR TITLE
Guard update_status against concurrent lost updates with optimistic u…

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -271,6 +271,8 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/UpdateConflict"
         "413":
           $ref: "#/components/responses/PayloadTooLarge"
         "422":
@@ -747,6 +749,23 @@ components:
           schema:
             type: string
           example: "Too Many Requests! Wait for 42s"
+
+    UpdateConflict:
+      description: |
+        The status list was modified concurrently between the client's read and
+        this write (optimistic-concurrency conflict): another writer's update
+        landed first, so this request was rejected rather than silently
+        overwriting it. The client should re-read the current state and retry.
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: "about:blank"
+            title: "Conflict"
+            status: 409
+            detail: "the status list was modified concurrently; re-read the current state and retry"
+            instance: "/api/v1/status-lists/477121aa-b598-419e-916f-1e74654ff38b/statuses"
 
     ServiceUnavailable:
       description: Service temporarily unavailable

--- a/src/database/queries.rs
+++ b/src/database/queries.rs
@@ -1,6 +1,6 @@
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder,
-    QuerySelect, Set,
+    QuerySelect, Set, sea_query::Expr,
 };
 use std::sync::Arc;
 
@@ -63,30 +63,58 @@ impl SeaOrmStore<StatusListRecord> {
             .map_err(|e| RepositoryError::FindError(e.to_string()))
     }
 
+    /// Optimistic-concurrency update guarded on `updated_at`.
+    ///
+    /// Executes a single atomic `UPDATE ... WHERE list_id = ? AND updated_at = ?`.
+    /// `list_id` is the primary key, so this touches at most one row and
+    /// `rows_affected` is exactly 0 or 1. A return of `Ok(false)` means the guard
+    /// did not match — another writer changed the row (or it was deleted) since
+    /// the caller read `expected_updated_at`, i.e. a lost-update was prevented.
+    ///
+    /// `rows_affected` is used deliberately: its semantics are identical across
+    /// the Postgres/MySQL/SQLite sea-orm backends, unlike `SELECT ... FOR UPDATE`
+    /// row locking (see #143).
+    ///
+    /// # Caller contract
+    ///
+    /// `entity.updated_at` MUST be strictly greater than `expected_updated_at`.
+    /// The guard only prevents a lost update if the write *advances* the stamp:
+    /// with a non-advancing value (`new == expected`) two same-second writers
+    /// would both match `WHERE updated_at = expected` and both succeed, silently
+    /// losing a flip. This invariant is enforced below rather than trusted, so a
+    /// future caller that forgets to advance the stamp fails loudly instead of
+    /// reintroducing the race.
     pub async fn update_one(
         &self,
         list_id: &str,
         entity: StatusListRecord,
+        expected_updated_at: i64,
     ) -> Result<bool, RepositoryError> {
-        let existing = status_lists::Entity::find_by_id(list_id)
-            .one(&*self.db)
-            .await
-            .map_err(|e| RepositoryError::FindError(e.to_string()))?;
-        if existing.is_none() {
-            return Ok(false);
+        if entity.updated_at <= expected_updated_at {
+            return Err(RepositoryError::UpdateError(format!(
+                "guarded update requires a strictly newer updated_at \
+                 (new={}, expected-guard={}); a non-advancing stamp would \
+                 silently reintroduce the same-second lost update",
+                entity.updated_at, expected_updated_at
+            )));
         }
-        let active = status_lists::ActiveModel {
-            list_id: Set(entity.list_id),
-            issuer: Set(entity.issuer),
-            status_list: Set(entity.status_list),
-            sub: Set(entity.sub),
-            updated_at: Set(entity.updated_at),
-        };
-        active
-            .update(&*self.db)
+        let result = status_lists::Entity::update_many()
+            .col_expr(status_lists::Column::Issuer, Expr::value(entity.issuer))
+            .col_expr(
+                status_lists::Column::StatusList,
+                Expr::value(entity.status_list),
+            )
+            .col_expr(status_lists::Column::Sub, Expr::value(entity.sub))
+            .col_expr(
+                status_lists::Column::UpdatedAt,
+                Expr::value(entity.updated_at),
+            )
+            .filter(status_lists::Column::ListId.eq(list_id))
+            .filter(status_lists::Column::UpdatedAt.eq(expected_updated_at))
+            .exec(&*self.db)
             .await
             .map_err(|e| RepositoryError::UpdateError(e.to_string()))?;
-        Ok(true)
+        Ok(result.rows_affected > 0)
     }
 
     pub async fn delete_by(&self, value: &str) -> Result<bool, RepositoryError> {
@@ -406,8 +434,10 @@ mod test {
                 "list-sqlite-test",
                 StatusListRecord {
                     sub: "sub-2-sqlite-test".to_string(),
-                    ..record
+                    updated_at: record.updated_at + 1, // guarded write must advance the stamp
+                    ..record.clone()
                 },
+                record.updated_at,
             )
             .await
             .unwrap();
@@ -419,6 +449,7 @@ mod test {
             .unwrap()
             .unwrap();
         assert_eq!(updated_found.sub, "sub-2-sqlite-test");
+        assert_eq!(updated_found.updated_at, record.updated_at + 1);
 
         let by_issuer = store.find_by_issuer("sub-2-sqlite-test").await.unwrap();
         assert!(!by_issuer.is_empty());
@@ -632,14 +663,190 @@ mod test {
                         lst: "compressed".to_string(),
                     },
                     sub: "sub-neg-sqlite".to_string(),
-                    updated_at: 0,
+                    updated_at: 1, // must advance past the guard value below
                 },
+                0,
             )
             .await
             .unwrap();
         assert!(!missing, "update on missing row should report no rows");
 
         cred_store.delete_by("issuer-neg-sqlite").await.unwrap();
+    }
+
+    /// The real proof for the lost-update fix: two writers that both read the
+    /// same `updated_at` cannot both win. This deterministically models the race
+    /// (no threads) — both capture the same guard value, the first guarded write
+    /// lands, the second's guard misses and is rejected — and asserts the
+    /// loser's flip did not overwrite the winner's.
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn test_update_one_optimistic_guard_rejects_stale_write() {
+        let db = sqlite_connection().await;
+        let cred_store = SeaOrmStore::<Credentials>::new(db.clone());
+        let store = SeaOrmStore::<StatusListRecord>::new(db);
+
+        let key: Jwk = serde_json::from_str(
+            r#"{
+                "kty": "EC",
+                "crv": "P-256",
+                "x": "NeyFv_2L67OEplNbJpR02IFis4_lFW9HYmhfF5Or6m8",
+                "y": "eAH2qe8Pg3GQ28uxA8-qNAqdwQ_zfV2uKAvJ2sLpY9M"
+            }"#,
+        )
+        .unwrap();
+        let issuer = "issuer-guard-sqlite";
+        cred_store
+            .insert_one(Credentials::new(issuer.to_string(), key))
+            .await
+            .unwrap();
+
+        // Seed a row at a known guard value V.
+        let v = 1000;
+        let base = StatusListRecord {
+            list_id: "list-guard-sqlite".to_string(),
+            issuer: issuer.to_string(),
+            status_list: StatusList {
+                bits: 1,
+                lst: "initial".to_string(),
+            },
+            sub: "sub-guard-sqlite".to_string(),
+            updated_at: v,
+        };
+        store.insert_one(base.clone()).await.unwrap();
+
+        // Both writers read the same state, so both guard on V.
+        let writer_a = StatusListRecord {
+            status_list: StatusList {
+                bits: 1,
+                lst: "flip-A".to_string(),
+            },
+            updated_at: v + 1,
+            ..base.clone()
+        };
+        let writer_b = StatusListRecord {
+            status_list: StatusList {
+                bits: 1,
+                lst: "flip-B".to_string(),
+            },
+            updated_at: v + 1,
+            ..base.clone()
+        };
+
+        // First writer wins.
+        let a_won = store.update_one(&base.list_id, writer_a, v).await.unwrap();
+        assert!(a_won, "first guarded write should land");
+
+        // Second writer guarded on the now-stale V: rejected, not silently applied.
+        let b_won = store.update_one(&base.list_id, writer_b, v).await.unwrap();
+        assert!(!b_won, "stale guarded write must be rejected");
+
+        // A's flip survived; B's did not overwrite it.
+        let stored = store.find_one_by(&base.list_id).await.unwrap().unwrap();
+        assert_eq!(stored.status_list.lst, "flip-A");
+        assert_eq!(stored.updated_at, v + 1);
+    }
+
+    /// Cross-backend proof (#143): the optimistic guard must behave identically
+    /// on a real non-sqlite backend. This exercises the JSON `col_expr` write and
+    /// `rows_affected` semantics against MySQL — the two things most likely to
+    /// diverge from sqlite — and asserts the same win/reject outcome as the
+    /// sqlite guard test.
+    #[cfg(feature = "mysql")]
+    #[tokio::test]
+    async fn test_mysql_update_one_optimistic_guard_rejects_stale_write() {
+        let test_db = mysql_helpers::mysql_connection().await;
+        let cred_store = SeaOrmStore::<Credentials>::new(test_db.db.clone());
+        let store = SeaOrmStore::<StatusListRecord>::new(test_db.db.clone());
+
+        let key: Jwk = serde_json::from_str(
+            r#"{
+                "kty": "EC",
+                "crv": "P-256",
+                "x": "NeyFv_2L67OEplNbJpR02IFis4_lFW9HYmhfF5Or6m8",
+                "y": "eAH2qe8Pg3GQ28uxA8-qNAqdwQ_zfV2uKAvJ2sLpY9M"
+            }"#,
+        )
+        .unwrap();
+        let issuer = "issuer-guard-mysql";
+        cred_store
+            .insert_one(Credentials::new(issuer.to_string(), key))
+            .await
+            .unwrap();
+
+        let v = 1000;
+        let base = StatusListRecord {
+            list_id: "list-guard-mysql".to_string(),
+            issuer: issuer.to_string(),
+            status_list: StatusList {
+                bits: 1,
+                lst: "initial".to_string(),
+            },
+            sub: "sub-guard-mysql".to_string(),
+            updated_at: v,
+        };
+        store.insert_one(base.clone()).await.unwrap();
+
+        let writer_a = StatusListRecord {
+            status_list: StatusList {
+                bits: 1,
+                lst: "flip-A".to_string(),
+            },
+            updated_at: v + 1,
+            ..base.clone()
+        };
+        let writer_b = StatusListRecord {
+            status_list: StatusList {
+                bits: 1,
+                lst: "flip-B".to_string(),
+            },
+            updated_at: v + 1,
+            ..base.clone()
+        };
+
+        // First writer wins.
+        let a_won = store.update_one(&base.list_id, writer_a, v).await.unwrap();
+        assert!(a_won, "first guarded write should land on MySQL");
+
+        // Second writer guarded on the now-stale V: rejected.
+        let b_won = store.update_one(&base.list_id, writer_b, v).await.unwrap();
+        assert!(!b_won, "stale guarded write must be rejected on MySQL");
+
+        // A's flip survived and round-tripped through the JSON column.
+        let stored = store.find_one_by(&base.list_id).await.unwrap().unwrap();
+        assert_eq!(stored.status_list.lst, "flip-A");
+        assert_eq!(stored.updated_at, v + 1);
+    }
+
+    /// Pins the store-level caller contract: a guarded write whose new
+    /// `updated_at` does not strictly advance past the guard value is rejected
+    /// outright (before touching the DB), so a future caller that forgets to
+    /// advance the stamp fails loudly instead of silently reintroducing the
+    /// same-second lost update. No DB round-trip is needed — the check precedes
+    /// the query — so this runs on the mock backend.
+    #[tokio::test]
+    async fn test_update_one_rejects_non_advancing_stamp() {
+        let db_conn = Arc::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection());
+        let store = SeaOrmStore::<StatusListRecord>::new(db_conn);
+
+        let entity = StatusListRecord {
+            list_id: "list-x".to_string(),
+            issuer: "issuer".to_string(),
+            status_list: StatusList {
+                bits: 1,
+                lst: "x".to_string(),
+            },
+            sub: "sub".to_string(),
+            updated_at: 1000,
+        };
+
+        // new == expected: not advancing.
+        let equal = store.update_one("list-x", entity.clone(), 1000).await;
+        assert!(matches!(equal, Err(RepositoryError::UpdateError(_))));
+
+        // new < expected: going backwards.
+        let backwards = store.update_one("list-x", entity, 1001).await;
+        assert!(matches!(backwards, Err(RepositoryError::UpdateError(_))));
     }
 
     #[cfg(feature = "sqlite")]

--- a/src/web/handlers/status_list/error.rs
+++ b/src/web/handlers/status_list/error.rs
@@ -17,6 +17,8 @@ pub enum StatusListError {
     Generic(String),
     #[error("failed to update status")]
     UpdateFailed,
+    #[error("the status list was modified concurrently; re-read the current state and retry")]
+    UpdateConflict,
     #[error("Malformed body: {0}")]
     MalformedBody(String),
     #[error("Status list not found")]
@@ -61,6 +63,7 @@ impl StatusListError {
             InvalidIndex => StatusCode::BAD_REQUEST,
             Generic(_) => StatusCode::BAD_REQUEST,
             UpdateFailed => StatusCode::INTERNAL_SERVER_ERROR,
+            UpdateConflict => StatusCode::CONFLICT,
             MalformedBody(_) => StatusCode::BAD_REQUEST,
             StatusListNotFound => StatusCode::NOT_FOUND,
             HistoricalStatusListNotFound => StatusCode::NOT_FOUND,
@@ -89,6 +92,7 @@ impl StatusListError {
             InvalidIndex => Cow::Borrowed("invalid_index"),
             Generic(_) => Cow::Borrowed("invalid_input"),
             UpdateFailed => Cow::Borrowed("update_failed"),
+            UpdateConflict => Cow::Borrowed("update_conflict"),
             MalformedBody(_) => Cow::Borrowed("malformed_body"),
             StatusListNotFound => Cow::Borrowed("status_list_not_found"),
             HistoricalStatusListNotFound => Cow::Borrowed("historical_status_list_not_found"),

--- a/src/web/handlers/status_list/update_status.rs
+++ b/src/web/handlers/status_list/update_status.rs
@@ -20,6 +20,23 @@ use crate::{
 use super::error::StatusListError;
 use super::publish_status::persist_historical_snapshot;
 
+/// Computes the next `updated_at` for an optimistic-concurrency write.
+///
+/// Two distinct concerns, both required — do not drop either:
+///   * the `WHERE updated_at = previous` guard in `update_one` handles
+///     *concurrency* (a racing writer loses the race);
+///   * the `.max(previous + 1)` here handles *clock granularity*.
+///
+/// `updated_at` is unix seconds, so two writers in the same second both read the
+/// same `previous` and both see `now == previous`. If the stamp did not advance,
+/// the first write would leave `updated_at` unchanged and the second writer's
+/// guard would still match — both would succeed, silently losing a flip. Forcing
+/// the value to strictly increase guarantees the guard moves, so the loser's
+/// `WHERE` misses. Dropping the `+ 1` reintroduces the same-second lost update.
+fn next_updated_at(previous: i64, now: i64) -> i64 {
+    now.max(previous + 1)
+}
+
 /// Update status entries in an existing status list.
 pub async fn update_status(
     State(appstate): State<AppState>,
@@ -92,15 +109,43 @@ pub async fn update_status(
         }
     })?;
 
+    // The timestamp read here is the optimistic-concurrency guard: the write
+    // below only lands if `updated_at` is still this value, so a racing writer
+    // that already moved it is rejected instead of silently overwritten.
+    let previous_updated_at = record.updated_at;
+
     let mut exact_status_list = record;
     exact_status_list.status_list.lst = updated_lst.lst;
     exact_status_list.status_list.bits = updated_lst.bits;
-    exact_status_list.updated_at = OffsetDateTime::now_utc().unix_timestamp();
+    // Strictly-advancing stamp so the optimistic guard always moves; see
+    // `next_updated_at` for why the `+ 1` is load-bearing.
+    let now = OffsetDateTime::now_utc().unix_timestamp();
+    exact_status_list.updated_at = next_updated_at(previous_updated_at, now);
 
-    // Save the updated token
-    store
-        .update_one(&exact_status_list.list_id, exact_status_list.clone())
+    // Save the updated token under the optimistic guard.
+    let updated = store
+        .update_one(
+            &exact_status_list.list_id,
+            exact_status_list.clone(),
+            previous_updated_at,
+        )
         .await?;
+
+    if !updated {
+        // Guard did not match: a concurrent writer won the race (or the row was
+        // deleted). Return 409 *before* recording a snapshot or invalidating the
+        // cache, so nothing is persisted for a write that never landed.
+        //
+        // Logged at info, not warn: under contention an optimistic conflict is
+        // the expected, correct outcome, not an anomaly — warn would pollute
+        // dashboards and trip alerting during exactly the high-load bursts where
+        // conflicts are normal.
+        tracing::info!(
+            list_id = ?exact_status_list.list_id,
+            "Concurrent update conflict; write rejected"
+        );
+        return Err(StatusListError::UpdateConflict.into());
+    }
 
     persist_historical_snapshot(&appstate, &exact_status_list).await?;
 
@@ -205,12 +250,17 @@ mod test {
             mock_db
                 .append_query_results::<status_lists::Model, Vec<_>, _>(vec![
                     vec![existing_token.clone()], // for find_one_by
-                    vec![],
                 ])
-                .append_exec_results(vec![MockExecResult {
-                    rows_affected: 1,
-                    last_insert_id: 0,
-                }])
+                .append_exec_results(vec![
+                    MockExecResult {
+                        rows_affected: 1,
+                        last_insert_id: 0,
+                    }, // guarded update_many
+                    MockExecResult {
+                        rows_affected: 1,
+                        last_insert_id: 0,
+                    }, // status_list_history insert
+                ])
                 .into_connection(),
         );
 
@@ -374,5 +424,80 @@ mod test {
             Err(err) => err.into_response(),
         };
         assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    /// Pins the load-bearing monotonicity of the optimistic stamp. If someone
+    /// "simplifies" `next_updated_at` down to `now` (dropping the `+ 1`), the
+    /// same-second case below fails here instead of silently reintroducing the
+    /// lost-update bug in production.
+    #[test]
+    fn test_next_updated_at_strictly_advances_within_same_second() {
+        // Same wall-clock second as the previous write: must still advance.
+        assert_eq!(next_updated_at(1000, 1000), 1001);
+        // Clock went backwards / equal: never emit a stale-or-equal stamp.
+        assert_eq!(next_updated_at(1000, 999), 1001);
+        // Clock advanced normally: use the real time.
+        assert_eq!(next_updated_at(1000, 2000), 2000);
+    }
+
+    #[tokio::test]
+    async fn test_update_status_conflict_returns_409() {
+        let mock_db = MockDatabase::new(DatabaseBackend::Postgres);
+        let token_id = uuid::Uuid::new_v4().to_string();
+
+        let existing_token = StatusListRecord {
+            list_id: token_id.clone(),
+            issuer: "issuer".to_string(),
+            status_list: StatusList {
+                bits: 2,
+                lst: create_status_list(
+                    vec![StatusEntry {
+                        index: 0,
+                        status: Status::VALID,
+                    }],
+                    &LIMITS,
+                )
+                .unwrap()
+                .lst,
+            },
+            sub: "issuer".to_string(),
+            updated_at: 0,
+        };
+
+        let update_payload = StatusesRequest {
+            statuses: vec![StatusEntry {
+                index: 0,
+                status: Status::INVALID,
+            }],
+        };
+
+        // find_one_by sees the row, but the guarded UPDATE affects 0 rows: a
+        // concurrent writer already moved `updated_at`.
+        let db_conn = Arc::new(
+            mock_db
+                .append_query_results::<status_lists::Model, Vec<_>, _>(vec![vec![
+                    existing_token.clone(),
+                ]])
+                .append_exec_results(vec![MockExecResult {
+                    rows_affected: 0,
+                    last_insert_id: 0,
+                }])
+                .into_connection(),
+        );
+
+        let app_state = test_app_state(Some(db_conn.clone())).await;
+        let response = match update_status(
+            State(app_state),
+            Extension("issuer".to_string()),
+            Path(token_id),
+            Json(update_payload),
+        )
+        .await
+        {
+            Ok(_) => panic!("conflicting write must not report success"),
+            Err(err) => err.into_response(),
+        };
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
     }
 }


### PR DESCRIPTION
`update_status` performs a plain read-modify-write with no concurrency guard. Two concurrent `PATCH` requests to the same status list can each read the same list state, each recompute it in memory, and each write
back  with the last writer silently erasing the first writer's changes.

## Acceptance criteria

- [ ] Concurrent `PATCH`es to the same list can no longer silently lose a flip.
- [ ] A conflicting write returns `409` (with retry guidance), not a false success.
- [ ] Behavior is identical on Postgres, MySQL, and SQLite (rows-affected-based, no backend-specific locking).
- [ ] A regression test drives two interleaved updates and asserts neither flip is lost (or the loser gets a 409).