### PR TITLE
Wrap status list update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,10 @@ http = [
 postgres = ["dep:jsonwebtoken", "dep:sea-orm", "dep:sea-orm-migration", "sea-orm?/sqlx-postgres"]
 sqlite = ["dep:jsonwebtoken", "dep:sea-orm", "dep:sea-orm-migration", "sea-orm?/sqlx-sqlite"]
 mysql = ["dep:jsonwebtoken", "dep:sea-orm", "dep:sea-orm-migration", "sea-orm?/sqlx-mysql"]
+# Opt-in gate for the Postgres container test. `postgres` is default-on, so its
+# real-backend test needs a separate non-default feature to stay out of plain
+# `cargo test`; `--all-features` enables it in CI.
+postgres-tests = ["postgres"]
 cache-moka = ["dep:moka", "dep:tracing"]
 aws = [
     "certificate-acme",
@@ -178,7 +182,7 @@ optional = true
 sealed_test = "1.1.0"
 wiremock = "0.6"
 sea-orm = { version = "1.1", features = ["mock"] }
-testcontainers-modules = { version = "0.15", features = ["localstack", "mysql", "redis"] }
+testcontainers-modules = { version = "0.15", features = ["localstack", "mysql", "postgres", "redis"] }
 metrics-util = "0.20"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [features]
 default = ["server"]
 memory-only = []
+tracing = ["dep:tracing"]
 server = [
     "aws",
     "cache-moka",
@@ -19,7 +20,7 @@ server = [
 ]
 http = [
     "dep:axum", "dep:hyper", "dep:hyper-util", "dep:reqwest", "dep:tower",
-    "dep:tower-http", "dep:tower_governor", "dep:governor", "dep:tracing", "dep:tracing-subscriber",
+    "dep:tower-http", "dep:tower_governor", "dep:governor", "tracing", "dep:tracing-subscriber",
 ]
 postgres = ["dep:jsonwebtoken", "dep:sea-orm", "dep:sea-orm-migration", "sea-orm?/sqlx-postgres"]
 sqlite = ["dep:jsonwebtoken", "dep:sea-orm", "dep:sea-orm-migration", "sea-orm?/sqlx-sqlite"]
@@ -28,12 +29,12 @@ mysql = ["dep:jsonwebtoken", "dep:sea-orm", "dep:sea-orm-migration", "sea-orm?/s
 # real-backend test needs a separate non-default feature to stay out of plain
 # `cargo test`; `--all-features` enables it in CI.
 postgres-tests = ["postgres"]
-cache-moka = ["dep:moka", "dep:tracing"]
+cache-moka = ["dep:moka", "tracing"]
 aws = [
     "certificate-acme",
     "dep:aws-config", "dep:aws-sdk-route53", "dep:aws-sdk-s3",
     "dep:aws-sdk-secretsmanager", "dep:color-eyre", "dep:moka", "dep:reqwest",
-    "dep:tracing",
+    "tracing",
 ]
 redis = ["certificate-acme", "dep:redis"]
 metrics-prometheus = ["dep:color-eyre", "dep:metrics-exporter-prometheus", "dep:metrics-process"]
@@ -42,7 +43,7 @@ certificate-acme = [
     "dep:hyper-util", "dep:instant-acme", "dep:jsonwebtoken", "dep:p256",
     "dep:pem", "dep:public-suffix", "dep:rand", "dep:rcgen", "dep:reqwest",
     "dep:rustls", "dep:rustls-pki-types", "dep:time", "dep:tokio-cron-scheduler",
-    "dep:tracing", "dep:uuid", "dep:webpki-roots", "dep:x509-parser",
+    "tracing", "dep:uuid", "dep:webpki-roots", "dep:x509-parser",
 ]
 config-file = ["dep:config", "dep:dotenvy", "dep:secrecy", "dep:serde-aux"]
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -280,7 +280,7 @@ paths:
         "429":
           $ref: "#/components/responses/TooManyRequests"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/UpdateInternalServerError"
 
   /api/v1/status-lists/{list_id}:
     get:
@@ -765,6 +765,28 @@ components:
             title: "Conflict"
             status: 409
             detail: "the status list was modified concurrently; re-read the current state and retry"
+            instance: "/api/v1/status-lists/477121aa-b598-419e-916f-1e74654ff38b/statuses"
+
+    UpdateInternalServerError:
+      description: |
+        Internal server error. The status list row and the historical snapshot
+        recording the change are written in a single database transaction, so a
+        500 from this endpoint means **no partial write occurred**: the list is
+        unchanged, no snapshot was recorded, and the previous state remains
+        authoritative. The request is therefore safe to retry as-is.
+
+        This differs from a `409`, which means the write was rejected because
+        another writer got there first. A `409` requires re-reading the current
+        state before retrying; a `500` does not.
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: "about:blank"
+            title: "Internal Server Error"
+            status: 500
+            detail: "Internal server error"
             instance: "/api/v1/status-lists/477121aa-b598-419e-916f-1e74654ff38b/statuses"
 
     ServiceUnavailable:

--- a/src/adapters/memory.rs
+++ b/src/adapters/memory.rs
@@ -24,7 +24,36 @@ use tokio::sync::RwLock;
 #[derive(Clone, Default)]
 pub struct MemoryStatusLists {
     values: Arc<RwLock<HashMap<String, StatusListRecord>>>,
+    // Shared snapshot storage so `update_with_snapshot` can write the row and
+    // its snapshot under one held lock — the memory mirror of the SQL adapter's
+    // single transaction. `None` when history is disabled (memory-only builds do
+    // not compile the history port at all).
+    #[cfg(any(
+        feature = "server",
+        feature = "postgres",
+        feature = "sqlite",
+        feature = "mysql"
+    ))]
+    history: Option<Arc<RwLock<HashMap<String, StatusListSnapshot>>>>,
 }
+
+#[cfg(any(
+    feature = "server",
+    feature = "postgres",
+    feature = "sqlite",
+    feature = "mysql"
+))]
+impl MemoryStatusLists {
+    /// Share `history`'s underlying storage so the atomic
+    /// [`update_with_snapshot`](StatusListRepository::update_with_snapshot)
+    /// writes the row and its snapshot together. Without this, the memory repo
+    /// has nowhere to record snapshots and would silently drop them.
+    pub fn with_history(mut self, history: &MemoryStatusListHistory) -> Self {
+        self.history = Some(history.values.clone());
+        self
+    }
+}
+
 #[async_trait]
 impl StatusListRepository for MemoryStatusLists {
     async fn find(&self, id: &str) -> Result<Option<Arc<StatusListRecord>>, PortError> {
@@ -49,6 +78,38 @@ impl StatusListRepository for MemoryStatusLists {
         match values.get(&record.list_id) {
             Some(current) if current.updated_at == expected_updated_at => {}
             _ => return Ok(false),
+        }
+        values.insert(record.list_id.clone(), record);
+        Ok(true)
+    }
+    /// Atomic mirror of the SQL adapter's transactional update: the row CAS and
+    /// the snapshot insert happen while the row-map write lock is held, so a
+    /// reader can never observe the row advanced without its snapshot. A guard
+    /// miss returns `false` before either write, so nothing is recorded. Lock
+    /// order is always row-map then history-map, and no other path takes them in
+    /// the opposite order, so this cannot deadlock.
+    #[cfg(any(
+        feature = "server",
+        feature = "postgres",
+        feature = "sqlite",
+        feature = "mysql"
+    ))]
+    async fn update_with_snapshot(
+        &self,
+        record: StatusListRecord,
+        expected_updated_at: i64,
+        snapshot: StatusListSnapshot,
+    ) -> Result<bool, PortError> {
+        let mut values = self.values.write().await;
+        match values.get(&record.list_id) {
+            Some(current) if current.updated_at == expected_updated_at => {}
+            _ => return Ok(false),
+        }
+        if let Some(history) = &self.history {
+            history
+                .write()
+                .await
+                .insert(snapshot.snapshot_id.clone(), snapshot);
         }
         values.insert(record.list_id.clone(), record);
         Ok(true)
@@ -219,9 +280,11 @@ mod tests {
     #[tokio::test]
     async fn application_services_work_with_history() {
         use crate::application::{PublishStatusListWithHistory, UpdateStatusesWithHistory};
-        let repo = Arc::new(MemoryStatusLists::default());
         let cache = Arc::new(MemoryStatusListCache::default());
         let history = Arc::new(MemoryStatusListHistory::default());
+        // Share the history storage so the atomic update path can record its
+        // snapshot (mirrors the SQL adapter, where both writes hit one db).
+        let repo = Arc::new(MemoryStatusLists::default().with_history(history.as_ref()));
         let token_exp_secs = 900u64;
         PublishStatusListWithHistory::new(repo.clone(), history.clone(), token_exp_secs)
             .execute(record())
@@ -238,11 +301,22 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(fetched.list_id, "id");
-        UpdateStatusesWithHistory::new(repo, cache.clone(), history)
+        UpdateStatusesWithHistory::new(repo.clone(), cache.clone(), history.clone())
             .execute(&Issuer("issuer".into()), "id", Vec::new(), token_exp_secs)
             .await
             .unwrap();
         assert!(cache.get("id").await.unwrap().is_none());
+        // The atomic update committed its snapshot: the row's new stamp resolves
+        // to a stored historical snapshot.
+        let updated_at = repo.find("id").await.unwrap().unwrap().updated_at;
+        assert!(
+            history
+                .find_valid_at("id", updated_at)
+                .await
+                .unwrap()
+                .is_some(),
+            "the atomic update must persist a history snapshot for the new stamp"
+        );
     }
 
     #[tokio::test]
@@ -343,6 +417,22 @@ mod tests {
         ) -> Result<bool, PortError> {
             self.inner.update(record, expected_updated_at).await
         }
+        #[cfg(any(
+            feature = "server",
+            feature = "postgres",
+            feature = "sqlite",
+            feature = "mysql"
+        ))]
+        async fn update_with_snapshot(
+            &self,
+            record: StatusListRecord,
+            expected_updated_at: i64,
+            snapshot: StatusListSnapshot,
+        ) -> Result<bool, PortError> {
+            self.inner
+                .update_with_snapshot(record, expected_updated_at, snapshot)
+                .await
+        }
         async fn list_uris(&self) -> Result<Vec<String>, PortError> {
             self.inner.list_uris().await
         }
@@ -384,7 +474,10 @@ mod tests {
     #[tokio::test]
     async fn update_statuses_with_history_writes_nothing_on_conflict() {
         use crate::application::UpdateStatusesWithHistory;
-        let inner = MemoryStatusLists::default();
+        let history = Arc::new(MemoryStatusListHistory::default());
+        // Wire the shared history so the repo *could* record a snapshot: the
+        // assertion that it records nothing on conflict is then meaningful.
+        let inner = MemoryStatusLists::default().with_history(history.as_ref());
         inner.insert(record()).await.unwrap();
         let repo = Arc::new(StaleReadStatusLists {
             inner,
@@ -392,7 +485,6 @@ mod tests {
         });
         let cache = Arc::new(MemoryStatusListCache::default());
         cache.put(record()).await.unwrap();
-        let history = Arc::new(MemoryStatusListHistory::default());
         let token_exp_secs = 900u64;
 
         let result = UpdateStatusesWithHistory::new(repo, cache.clone(), history.clone())

--- a/src/adapters/memory.rs
+++ b/src/adapters/memory.rs
@@ -44,10 +44,8 @@ pub struct MemoryStatusLists {
     feature = "mysql"
 ))]
 impl MemoryStatusLists {
-    /// Share `history`'s underlying storage so the atomic
-    /// [`update_with_snapshot`](StatusListRepository::update_with_snapshot)
-    /// writes the row and its snapshot together. Without this, the memory repo
-    /// has nowhere to record snapshots and would silently drop them.
+    /// Shares `history`'s storage so `update_with_snapshot` can write the row
+    /// and its snapshot together; without it the repo would drop snapshots.
     pub fn with_history(mut self, history: &MemoryStatusListHistory) -> Self {
         self.history = Some(history.values.clone());
         self
@@ -66,9 +64,9 @@ impl StatusListRepository for MemoryStatusLists {
             .insert(record.list_id.clone(), record);
         Ok(())
     }
-    /// Mirrors the SQL adapter's optimistic guard so use-case concurrency
-    /// behavior is testable without a database: the write lands only if the
-    /// stored stamp is still `expected_updated_at`.
+    /// Mirrors the SQL adapter's optimistic guard so concurrency behavior is
+    /// testable without a database: the write lands only if the stored stamp is
+    /// still `expected_updated_at`.
     async fn update(
         &self,
         record: StatusListRecord,
@@ -83,11 +81,9 @@ impl StatusListRepository for MemoryStatusLists {
         Ok(true)
     }
     /// Atomic mirror of the SQL adapter's transactional update: the row CAS and
-    /// the snapshot insert happen while the row-map write lock is held, so a
-    /// reader can never observe the row advanced without its snapshot. A guard
-    /// miss returns `false` before either write, so nothing is recorded. Lock
-    /// order is always row-map then history-map, and no other path takes them in
-    /// the opposite order, so this cannot deadlock.
+    /// snapshot insert both happen under the row-map write lock, so no reader
+    /// sees the row advanced without its snapshot. Lock order is always row-map
+    /// then history-map (never the reverse), so this cannot deadlock.
     #[cfg(any(
         feature = "server",
         feature = "postgres",
@@ -114,9 +110,8 @@ impl StatusListRepository for MemoryStatusLists {
         values.insert(record.list_id.clone(), record);
         Ok(true)
     }
-    /// Mirrors the SQL adapter's `GROUP BY sub ORDER BY sub`: a `BTreeSet`
-    /// dedups and sorts, so this test double does not silently diverge from
-    /// production semantics the way a raw `values()` collect would.
+    /// Mirrors the SQL adapter's `GROUP BY sub ORDER BY sub` via a `BTreeSet`
+    /// (dedup + sort), so this double doesn't diverge from production semantics.
     async fn list_uris(&self) -> Result<Vec<String>, PortError> {
         let uris: std::collections::BTreeSet<String> = self
             .values

--- a/src/adapters/memory.rs
+++ b/src/adapters/memory.rs
@@ -44,11 +44,40 @@ pub struct MemoryStatusLists {
     feature = "mysql"
 ))]
 impl MemoryStatusLists {
-    /// Shares `history`'s storage so `update_with_snapshot` can write the row
+    /// Shares `history`'s storage so the atomic write paths can record the row
     /// and its snapshot together; without it the repo would drop snapshots.
     pub fn with_history(mut self, history: &MemoryStatusListHistory) -> Self {
         self.history = Some(history.values.clone());
         self
+    }
+
+    /// Borrows the shared snapshot storage, refusing to proceed when it was
+    /// never wired up.
+    ///
+    /// The atomic write paths promise the row and its snapshot land together.
+    /// Silently skipping the snapshot while still reporting success would make
+    /// this double certify the exact split the port forbids — and a test
+    /// asserting "the snapshot was persisted" would pass vacuously against a
+    /// `MemoryStatusLists::default()`. Failing here surfaces the missing
+    /// `.with_history(..)` as a loud wiring error instead.
+    #[cfg(any(
+        feature = "server",
+        feature = "postgres",
+        feature = "sqlite",
+        feature = "mysql"
+    ))]
+    fn require_history(
+        &self,
+    ) -> Result<&Arc<RwLock<HashMap<String, StatusListSnapshot>>>, PortError> {
+        self.history
+            .as_ref()
+            .ok_or_else(|| PortError::StorageUnavailable {
+                operation: crate::ports::PortOperation::UpdateStatusList,
+                detail: "MemoryStatusLists was built without shared history storage; \
+                         construct it with `.with_history(..)` so snapshots are \
+                         persisted atomically with the row write"
+                    .to_string(),
+            })
     }
 }
 
@@ -96,19 +125,42 @@ impl StatusListRepository for MemoryStatusLists {
         expected_updated_at: i64,
         snapshot: StatusListSnapshot,
     ) -> Result<bool, PortError> {
+        let history = self.require_history()?;
         let mut values = self.values.write().await;
         match values.get(&record.list_id) {
             Some(current) if current.updated_at == expected_updated_at => {}
             _ => return Ok(false),
         }
-        if let Some(history) = &self.history {
-            history
-                .write()
-                .await
-                .insert(snapshot.snapshot_id.clone(), snapshot);
-        }
+        history
+            .write()
+            .await
+            .insert(snapshot.snapshot_id.clone(), snapshot);
         values.insert(record.list_id.clone(), record);
         Ok(true)
+    }
+    /// Atomic mirror of the SQL adapter's transactional insert: the row and the
+    /// snapshot covering its initial state both land under the row-map write
+    /// lock, so no reader sees a published list without its snapshot. Same lock
+    /// order as `update_with_snapshot` (row-map then history-map).
+    #[cfg(any(
+        feature = "server",
+        feature = "postgres",
+        feature = "sqlite",
+        feature = "mysql"
+    ))]
+    async fn insert_with_snapshot(
+        &self,
+        record: StatusListRecord,
+        snapshot: StatusListSnapshot,
+    ) -> Result<(), PortError> {
+        let history = self.require_history()?;
+        let mut values = self.values.write().await;
+        history
+            .write()
+            .await
+            .insert(snapshot.snapshot_id.clone(), snapshot);
+        values.insert(record.list_id.clone(), record);
+        Ok(())
     }
     /// Mirrors the SQL adapter's `GROUP BY sub ORDER BY sub` via a `BTreeSet`
     /// (dedup + sort), so this double doesn't diverge from production semantics.
@@ -428,6 +480,19 @@ mod tests {
                 .update_with_snapshot(record, expected_updated_at, snapshot)
                 .await
         }
+        #[cfg(any(
+            feature = "server",
+            feature = "postgres",
+            feature = "sqlite",
+            feature = "mysql"
+        ))]
+        async fn insert_with_snapshot(
+            &self,
+            record: StatusListRecord,
+            snapshot: StatusListSnapshot,
+        ) -> Result<(), PortError> {
+            self.inner.insert_with_snapshot(record, snapshot).await
+        }
         async fn list_uris(&self) -> Result<Vec<String>, PortError> {
             self.inner.list_uris().await
         }
@@ -496,6 +561,82 @@ mod tests {
             history.find_valid_at("id", now).await.unwrap().is_none(),
             "a rejected write must not record a historical snapshot"
         );
+    }
+
+    /// A repo built without shared history storage must refuse the atomic write
+    /// paths rather than dropping the snapshot and reporting success. Without
+    /// this, any future test asserting "the snapshot was persisted" would pass
+    /// vacuously against a `default()` repo, and the double would certify the
+    /// very row-without-snapshot split the port forbids.
+    #[cfg(any(
+        feature = "server",
+        feature = "postgres",
+        feature = "sqlite",
+        feature = "mysql"
+    ))]
+    #[tokio::test]
+    async fn atomic_writes_fail_loudly_without_shared_history() {
+        use crate::domain::{StatusList as DomainStatusList, StatusListSnapshot};
+
+        let repo = MemoryStatusLists::default(); // deliberately not `.with_history(..)`
+        repo.insert(record()).await.unwrap();
+
+        let snapshot = StatusListSnapshot {
+            snapshot_id: "snap".into(),
+            list_id: "id".into(),
+            issuer: Issuer("issuer".into()),
+            status_list: DomainStatusList {
+                bits: 1,
+                lst: "".into(),
+            },
+            sub: "https://example/id".into(),
+            iat: 1672531200,
+            exp: 1672532100,
+        };
+
+        let updated = repo
+            .update_with_snapshot(record(), 1672531200, snapshot.clone())
+            .await;
+        assert!(
+            updated.is_err(),
+            "update_with_snapshot must not report success while dropping the snapshot"
+        );
+
+        let inserted = repo.insert_with_snapshot(record(), snapshot).await;
+        assert!(
+            inserted.is_err(),
+            "insert_with_snapshot must not report success while dropping the snapshot"
+        );
+    }
+
+    /// The publish path records the snapshot covering the list's initial state
+    /// through the repository, so a §8.4 lookup at the publish instant resolves
+    /// immediately rather than falling into a permanent hole.
+    #[cfg(any(
+        feature = "server",
+        feature = "postgres",
+        feature = "sqlite",
+        feature = "mysql"
+    ))]
+    #[tokio::test]
+    async fn publish_with_history_records_the_initial_snapshot() {
+        use crate::application::PublishStatusListWithHistory;
+        let history = Arc::new(MemoryStatusListHistory::default());
+        let repo = Arc::new(MemoryStatusLists::default().with_history(history.as_ref()));
+
+        PublishStatusListWithHistory::new(repo.clone(), history.clone(), 900)
+            .execute(record())
+            .await
+            .unwrap();
+
+        let published = repo.find("id").await.unwrap().unwrap();
+        let snapshot = history
+            .find_valid_at("id", published.updated_at)
+            .await
+            .unwrap()
+            .expect("publish must record a snapshot covering the initial state");
+        assert_eq!(snapshot.iat, published.updated_at);
+        assert_eq!(snapshot.list_id, "id");
     }
 
     /// End-to-end pin of the stamp monotonicity through the use case and the

--- a/src/adapters/sea_orm/migrations.rs
+++ b/src/adapters/sea_orm/migrations.rs
@@ -33,12 +33,18 @@ pub(crate) mod tables {
     impl MigrationTrait for Migration {
         /// Creates the necessary database tables if they don't exist
         async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-            // Create Credentials table for storing issuer credentials
+            // Create Credentials table for storing issuer credentials.
+            // `ENGINE=InnoDB` is emitted only on MySQL (ignored by the Postgres
+            // and SQLite builders); it makes the transactional-rollback
+            // guarantee that `update_with_snapshot` relies on explicit rather
+            // than dependent on the server's default engine, and is required for
+            // the foreign key below to be enforced on MySQL.
             manager
                 .create_table(
                     Table::create()
                         .table(Credentials::Table)
                         .if_not_exists()
+                        .engine("InnoDB")
                         .col(
                             ColumnDef::new(Credentials::Issuer)
                                 .string()
@@ -50,12 +56,15 @@ pub(crate) mod tables {
                 )
                 .await?;
 
-            // Create StatusLists table for storing status list entries
+            // Create StatusLists table for storing status list entries.
+            // InnoDB (MySQL-only clause) so the guarded UPDATE + snapshot INSERT
+            // in `update_with_snapshot` roll back atomically.
             manager
                 .create_table(
                     Table::create()
                         .table(StatusLists::Table)
                         .if_not_exists()
+                        .engine("InnoDB")
                         .col(
                             ColumnDef::new(StatusLists::ListId)
                                 .string()
@@ -278,11 +287,14 @@ pub(crate) mod status_list_history {
     #[allow(elided_lifetimes_in_paths)]
     impl MigrationTrait for Migration {
         async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+            // InnoDB (MySQL-only clause) so a snapshot INSERT that fails inside
+            // `update_with_snapshot` rolls the paired row UPDATE back.
             manager
                 .create_table(
                     Table::create()
                         .table(StatusListHistory::Table)
                         .if_not_exists()
+                        .engine("InnoDB")
                         .col(
                             ColumnDef::new(StatusListHistory::SnapshotId)
                                 .string()

--- a/src/adapters/sea_orm/migrations.rs
+++ b/src/adapters/sea_orm/migrations.rs
@@ -33,12 +33,9 @@ pub(crate) mod tables {
     impl MigrationTrait for Migration {
         /// Creates the necessary database tables if they don't exist
         async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-            // Create Credentials table for storing issuer credentials.
-            // `ENGINE=InnoDB` is emitted only on MySQL (ignored by the Postgres
-            // and SQLite builders); it makes the transactional-rollback
-            // guarantee that `update_with_snapshot` relies on explicit rather
-            // than dependent on the server's default engine, and is required for
-            // the foreign key below to be enforced on MySQL.
+            // Credentials table. `.engine("InnoDB")` is emitted only on MySQL
+            // (ignored elsewhere); it pins the transactional-rollback engine
+            // `update_with_snapshot` relies on, and lets MySQL enforce the FK.
             manager
                 .create_table(
                     Table::create()
@@ -56,9 +53,8 @@ pub(crate) mod tables {
                 )
                 .await?;
 
-            // Create StatusLists table for storing status list entries.
-            // InnoDB (MySQL-only clause) so the guarded UPDATE + snapshot INSERT
-            // in `update_with_snapshot` roll back atomically.
+            // StatusLists table; InnoDB (see above) so the guarded UPDATE and
+            // snapshot INSERT roll back atomically on MySQL.
             manager
                 .create_table(
                     Table::create()
@@ -75,8 +71,7 @@ pub(crate) mod tables {
                         .col(ColumnDef::new(StatusLists::StatusList).json().not_null())
                         .col(ColumnDef::new(StatusLists::Sub).string().not_null())
                         .foreign_key(
-                            // Foreign key use to ensures that the Issuer in the StatusLists table references
-                            // a valid Issuer in the Credentials table
+                            // FK: StatusLists.Issuer must reference a valid Credentials.Issuer.
                             ForeignKey::create()
                                 .name("fk_status_lists_issuer")
                                 .from(StatusLists::Table, StatusLists::Issuer)

--- a/src/adapters/sea_orm/migrations.rs
+++ b/src/adapters/sea_orm/migrations.rs
@@ -15,6 +15,16 @@ impl MigratorTrait for Migrator {
     }
 }
 
+/// Pins InnoDB on MySQL so `update_with_snapshot`'s UPDATE+INSERT roll back as a
+/// unit rather than depending on the server's default engine. MySQL-only:
+/// sea-query renders the engine option as a literal `ENGINE=InnoDB` clause on
+/// every backend, which SQLite and Postgres reject with a syntax error.
+fn pin_innodb_on_mysql(manager: &SchemaManager<'_>, stmt: &mut TableCreateStatement) {
+    if manager.get_database_backend() == sea_orm::DatabaseBackend::MySql {
+        stmt.engine("InnoDB");
+    }
+}
+
 /// Database tables module containing table creation migrations
 pub(crate) mod tables {
     use super::*;
@@ -33,55 +43,47 @@ pub(crate) mod tables {
     impl MigrationTrait for Migration {
         /// Creates the necessary database tables if they don't exist
         async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-            // Credentials table. `.engine("InnoDB")` is emitted only on MySQL
-            // (ignored elsewhere); it pins the transactional-rollback engine
-            // `update_with_snapshot` relies on, and lets MySQL enforce the FK.
-            manager
-                .create_table(
-                    Table::create()
-                        .table(Credentials::Table)
-                        .if_not_exists()
-                        .engine("InnoDB")
-                        .col(
-                            ColumnDef::new(Credentials::Issuer)
-                                .string()
-                                .not_null()
-                                .primary_key(),
-                        )
-                        .col(ColumnDef::new(Credentials::PublicKey).json().not_null())
-                        .to_owned(),
+            // Credentials table. InnoDB is pinned on MySQL (see
+            // `pin_innodb_on_mysql`) so the FK below is enforced there.
+            let mut credentials = Table::create();
+            credentials
+                .table(Credentials::Table)
+                .if_not_exists()
+                .col(
+                    ColumnDef::new(Credentials::Issuer)
+                        .string()
+                        .not_null()
+                        .primary_key(),
                 )
-                .await?;
+                .col(ColumnDef::new(Credentials::PublicKey).json().not_null());
+            pin_innodb_on_mysql(manager, &mut credentials);
+            manager.create_table(credentials).await?;
 
-            // StatusLists table; InnoDB (see above) so the guarded UPDATE and
-            // snapshot INSERT roll back atomically on MySQL.
-            manager
-                .create_table(
-                    Table::create()
-                        .table(StatusLists::Table)
-                        .if_not_exists()
-                        .engine("InnoDB")
-                        .col(
-                            ColumnDef::new(StatusLists::ListId)
-                                .string()
-                                .not_null()
-                                .primary_key(),
-                        )
-                        .col(ColumnDef::new(StatusLists::Issuer).string().not_null())
-                        .col(ColumnDef::new(StatusLists::StatusList).json().not_null())
-                        .col(ColumnDef::new(StatusLists::Sub).string().not_null())
-                        .foreign_key(
-                            // FK: StatusLists.Issuer must reference a valid Credentials.Issuer.
-                            ForeignKey::create()
-                                .name("fk_status_lists_issuer")
-                                .from(StatusLists::Table, StatusLists::Issuer)
-                                .to(Credentials::Table, Credentials::Issuer)
-                                .on_delete(ForeignKeyAction::Cascade)
-                                .on_update(ForeignKeyAction::Cascade),
-                        )
-                        .to_owned(),
+            // StatusLists table; InnoDB pinned on MySQL (see above).
+            let mut status_lists = Table::create();
+            status_lists
+                .table(StatusLists::Table)
+                .if_not_exists()
+                .col(
+                    ColumnDef::new(StatusLists::ListId)
+                        .string()
+                        .not_null()
+                        .primary_key(),
                 )
-                .await?;
+                .col(ColumnDef::new(StatusLists::Issuer).string().not_null())
+                .col(ColumnDef::new(StatusLists::StatusList).json().not_null())
+                .col(ColumnDef::new(StatusLists::Sub).string().not_null())
+                .foreign_key(
+                    // FK: StatusLists.Issuer must reference a valid Credentials.Issuer.
+                    ForeignKey::create()
+                        .name("fk_status_lists_issuer")
+                        .from(StatusLists::Table, StatusLists::Issuer)
+                        .to(Credentials::Table, Credentials::Issuer)
+                        .on_delete(ForeignKeyAction::Cascade)
+                        .on_update(ForeignKeyAction::Cascade),
+                );
+            pin_innodb_on_mysql(manager, &mut status_lists);
+            manager.create_table(status_lists).await?;
 
             // Create an index on list_id for faster lookups
             manager
@@ -282,49 +284,46 @@ pub(crate) mod status_list_history {
     #[allow(elided_lifetimes_in_paths)]
     impl MigrationTrait for Migration {
         async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-            // InnoDB (MySQL-only clause) so a snapshot INSERT that fails inside
-            // `update_with_snapshot` rolls the paired row UPDATE back.
-            manager
-                .create_table(
-                    Table::create()
-                        .table(StatusListHistory::Table)
-                        .if_not_exists()
-                        .engine("InnoDB")
-                        .col(
-                            ColumnDef::new(StatusListHistory::SnapshotId)
-                                .string()
-                                .not_null()
-                                .primary_key(),
-                        )
-                        .col(
-                            ColumnDef::new(StatusListHistory::ListId)
-                                .string()
-                                .not_null(),
-                        )
-                        .col(
-                            ColumnDef::new(StatusListHistory::Issuer)
-                                .string()
-                                .not_null(),
-                        )
-                        .col(
-                            ColumnDef::new(StatusListHistory::StatusList)
-                                .json()
-                                .not_null(),
-                        )
-                        .col(ColumnDef::new(StatusListHistory::Sub).string().not_null())
-                        .col(
-                            ColumnDef::new(StatusListHistory::Iat)
-                                .big_integer()
-                                .not_null(),
-                        )
-                        .col(
-                            ColumnDef::new(StatusListHistory::Exp)
-                                .big_integer()
-                                .not_null(),
-                        )
-                        .to_owned(),
+            // InnoDB pinned on MySQL (see `pin_innodb_on_mysql`) so a failing
+            // snapshot INSERT rolls the paired row UPDATE back.
+            let mut history = Table::create();
+            history
+                .table(StatusListHistory::Table)
+                .if_not_exists()
+                .col(
+                    ColumnDef::new(StatusListHistory::SnapshotId)
+                        .string()
+                        .not_null()
+                        .primary_key(),
                 )
-                .await?;
+                .col(
+                    ColumnDef::new(StatusListHistory::ListId)
+                        .string()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(StatusListHistory::Issuer)
+                        .string()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(StatusListHistory::StatusList)
+                        .json()
+                        .not_null(),
+                )
+                .col(ColumnDef::new(StatusListHistory::Sub).string().not_null())
+                .col(
+                    ColumnDef::new(StatusListHistory::Iat)
+                        .big_integer()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(StatusListHistory::Exp)
+                        .big_integer()
+                        .not_null(),
+                );
+            pin_innodb_on_mysql(manager, &mut history);
+            manager.create_table(history).await?;
             manager
                 .create_index(
                     Index::create()

--- a/src/adapters/sea_orm/mod.rs
+++ b/src/adapters/sea_orm/mod.rs
@@ -221,6 +221,28 @@ impl StatusListRepository for SeaOrmStatusListRepository {
                 detail: e.to_string(),
             })
     }
+    async fn update_with_snapshot(
+        &self,
+        record: domain::StatusListRecord,
+        expected_updated_at: i64,
+        snapshot: domain::StatusListSnapshot,
+    ) -> Result<bool, PortError> {
+        // The guarded row update and the snapshot insert run in one transaction
+        // inside the store; either both commit or neither does.
+        let id = record.list_id.clone();
+        self.store
+            .update_one_with_snapshot(
+                &id,
+                to_persistence(record),
+                expected_updated_at,
+                snapshot_to_persistence(snapshot),
+            )
+            .await
+            .map_err(|e| PortError::StorageUnavailable {
+                operation: PortOperation::UpdateStatusList,
+                detail: e.to_string(),
+            })
+    }
     async fn list_uris(&self) -> Result<Vec<String>, PortError> {
         self.store
             .find_all_status_list_uris()

--- a/src/adapters/sea_orm/mod.rs
+++ b/src/adapters/sea_orm/mod.rs
@@ -243,6 +243,23 @@ impl StatusListRepository for SeaOrmStatusListRepository {
                 detail: e.to_string(),
             })
     }
+    async fn insert_with_snapshot(
+        &self,
+        record: domain::StatusListRecord,
+        snapshot: domain::StatusListSnapshot,
+    ) -> Result<(), PortError> {
+        // The row insert and its initial snapshot run in one transaction inside
+        // the store; either both commit or neither does. `map_insert_err` keeps
+        // a duplicate `list_id` classified as a conflict (409), matching the
+        // non-transactional `insert`.
+        self.store
+            .insert_one_with_snapshot(to_persistence(record), snapshot_to_persistence(snapshot))
+            .await
+            .map_err(map_insert_err(
+                "status list",
+                PortOperation::InsertStatusList,
+            ))
+    }
     async fn list_uris(&self) -> Result<Vec<String>, PortError> {
         self.store
             .find_all_status_list_uris()

--- a/src/adapters/sea_orm/store.rs
+++ b/src/adapters/sea_orm/store.rs
@@ -1,6 +1,6 @@
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder,
-    QuerySelect, Set, sea_query::Expr,
+    QuerySelect, Set, TransactionTrait, sea_query::Expr,
 };
 use std::sync::Arc;
 
@@ -126,6 +126,95 @@ impl SeaOrmStore<StatusListRecord> {
             .await
             .map_err(|e| RepositoryError::UpdateError(e.to_string()))?;
         Ok(result.rows_affected > 0)
+    }
+
+    /// Optimistic update that records a history snapshot in the **same
+    /// transaction** as the guarded row update.
+    ///
+    /// Either the guarded `UPDATE status_lists` and the `status_list_history`
+    /// `INSERT` both commit, or neither does. This closes the split the plain
+    /// [`update_one`](Self::update_one) leaves open, where the row changes but a
+    /// subsequent snapshot insert fails, so nothing records the change.
+    ///
+    /// A `false` return means the optimistic guard did not match (a racing
+    /// writer advanced the stamp, or the row is gone): the transaction is rolled
+    /// back and nothing is written — identical outward behavior to
+    /// [`update_one`](Self::update_one). Transaction semantics are portable
+    /// across the Postgres/MySQL/SQLite sea-orm backends (#143), so the
+    /// all-or-nothing guarantee holds identically on all three.
+    ///
+    /// The same strictly-advancing `updated_at` caller contract as
+    /// [`update_one`](Self::update_one) applies and is enforced here too.
+    pub async fn update_one_with_snapshot(
+        &self,
+        list_id: &str,
+        entity: StatusListRecord,
+        expected_updated_at: i64,
+        snapshot: StatusListHistoryRecord,
+    ) -> Result<bool, RepositoryError> {
+        if entity.updated_at <= expected_updated_at {
+            return Err(RepositoryError::UpdateError(format!(
+                "guarded update requires a strictly newer updated_at \
+                 (new={}, expected-guard={}); a non-advancing stamp would \
+                 silently reintroduce the same-second lost update",
+                entity.updated_at, expected_updated_at
+            )));
+        }
+
+        let txn = self
+            .db
+            .begin()
+            .await
+            .map_err(|e| RepositoryError::UpdateError(e.to_string()))?;
+
+        let result = status_lists::Entity::update_many()
+            .col_expr(status_lists::Column::Issuer, Expr::value(entity.issuer))
+            .col_expr(
+                status_lists::Column::StatusList,
+                Expr::value(entity.status_list),
+            )
+            .col_expr(status_lists::Column::Sub, Expr::value(entity.sub))
+            .col_expr(
+                status_lists::Column::UpdatedAt,
+                Expr::value(entity.updated_at),
+            )
+            .filter(status_lists::Column::ListId.eq(list_id))
+            .filter(status_lists::Column::UpdatedAt.eq(expected_updated_at))
+            .exec(&txn)
+            .await
+            .map_err(|e| RepositoryError::UpdateError(e.to_string()))?;
+
+        if result.rows_affected == 0 {
+            // Optimistic-guard miss: roll back so the conflict path records
+            // nothing (no snapshot, no row change).
+            txn.rollback()
+                .await
+                .map_err(|e| RepositoryError::UpdateError(e.to_string()))?;
+            return Ok(false);
+        }
+
+        let history_active: status_list_history::ActiveModel = snapshot.into();
+        if let Err(insert_err) = status_list_history::Entity::insert(history_active)
+            .exec(&txn)
+            .await
+        {
+            // The row UPDATE already landed inside the transaction, but the
+            // snapshot INSERT failed. Roll back so the row reverts to its
+            // pre-update state — the whole point of this method: never leave a
+            // changed row without the snapshot that records the change.
+            txn.rollback().await.map_err(|rollback_err| {
+                RepositoryError::InsertError(format!(
+                    "history snapshot insert failed ({insert_err}); \
+                     rolling back the row update also failed: {rollback_err}"
+                ))
+            })?;
+            return Err(RepositoryError::InsertError(insert_err.to_string()));
+        }
+
+        txn.commit()
+            .await
+            .map_err(|e| RepositoryError::UpdateError(e.to_string()))?;
+        Ok(true)
     }
 
     pub async fn delete_by(&self, value: &str) -> Result<bool, RepositoryError> {
@@ -976,6 +1065,302 @@ mod test {
         // new < expected: going backwards.
         let backwards = store.update_one("list-x", entity, 1001).await;
         assert!(matches!(backwards, Err(RepositoryError::UpdateError(_))));
+    }
+
+    #[cfg(feature = "sqlite")]
+    const TEST_EC_JWK: &str = r#"{
+        "kty": "EC",
+        "crv": "P-256",
+        "x": "NeyFv_2L67OEplNbJpR02IFis4_lFW9HYmhfF5Or6m8",
+        "y": "eAH2qe8Pg3GQ28uxA8-qNAqdwQ_zfV2uKAvJ2sLpY9M"
+    }"#;
+
+    /// The core acceptance test for the transactional fix: the guarded row
+    /// UPDATE and the history INSERT succeed or fail as a unit. Exercises the
+    /// happy path (both commit), the forced-INSERT-failure path (row update
+    /// rolls back, no partial snapshot), and the conflict path (guard miss rolls
+    /// back cleanly) — all against a real SQLite backend, since a `MockDatabase`
+    /// cannot model transaction rollback.
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn test_sqlite_update_with_snapshot_is_atomic() {
+        let db = sqlite_connection().await;
+        let cred_store = SeaOrmStore::<Credentials>::new(db.clone());
+        let store = SeaOrmStore::<StatusListRecord>::new(db.clone());
+        let history = SeaOrmStore::<StatusListHistoryRecord>::new(db);
+
+        let key: Jwk = serde_json::from_str(TEST_EC_JWK).unwrap();
+        let issuer = "issuer-atomic-sqlite";
+        cred_store
+            .insert_one(Credentials::new(issuer.to_string(), key))
+            .await
+            .unwrap();
+
+        let v = 1000;
+        let base = StatusListRecord {
+            list_id: "list-atomic-sqlite".to_string(),
+            issuer: issuer.to_string(),
+            status_list: StatusList {
+                bits: 1,
+                lst: "initial".to_string(),
+            },
+            sub: "sub-atomic-sqlite".to_string(),
+            updated_at: v,
+        };
+        store.insert_one(base.clone()).await.unwrap();
+
+        // --- Happy path: row update and snapshot both commit. ---
+        let good_snapshot = StatusListHistoryRecord {
+            snapshot_id: "snap-good".to_string(),
+            list_id: base.list_id.clone(),
+            issuer: issuer.to_string(),
+            status_list: StatusList {
+                bits: 1,
+                lst: "flip-1".to_string(),
+            },
+            sub: base.sub.clone(),
+            iat: v + 1,
+            exp: v + 1 + 900,
+        };
+        let committed = store
+            .update_one_with_snapshot(
+                &base.list_id,
+                StatusListRecord {
+                    status_list: StatusList {
+                        bits: 1,
+                        lst: "flip-1".to_string(),
+                    },
+                    updated_at: v + 1,
+                    ..base.clone()
+                },
+                v,
+                good_snapshot,
+            )
+            .await
+            .unwrap();
+        assert!(
+            committed,
+            "advancing guarded update with snapshot must commit"
+        );
+        let row = store.find_one_by(&base.list_id).await.unwrap().unwrap();
+        assert_eq!(row.updated_at, v + 1);
+        assert_eq!(row.status_list.lst, "flip-1");
+        assert!(
+            history
+                .find_valid_at(&base.list_id, v + 1)
+                .await
+                .unwrap()
+                .is_some(),
+            "the committed snapshot must be resolvable"
+        );
+
+        // --- Rollback path: force the snapshot INSERT to fail (duplicate PK)
+        // and assert the paired row update did NOT land. ---
+        let colliding_snapshot = StatusListHistoryRecord {
+            snapshot_id: "snap-good".to_string(), // collides with the committed row
+            list_id: base.list_id.clone(),
+            issuer: issuer.to_string(),
+            status_list: StatusList {
+                bits: 1,
+                lst: "flip-2".to_string(),
+            },
+            sub: base.sub.clone(),
+            iat: v + 2,
+            exp: v + 2 + 900,
+        };
+        let result = store
+            .update_one_with_snapshot(
+                &base.list_id,
+                StatusListRecord {
+                    status_list: StatusList {
+                        bits: 1,
+                        lst: "flip-2".to_string(),
+                    },
+                    updated_at: v + 2,
+                    ..base.clone()
+                },
+                v + 1,
+                colliding_snapshot,
+            )
+            .await;
+        assert!(
+            result.is_err(),
+            "a failed snapshot insert must fail the whole unit"
+        );
+        let row = store.find_one_by(&base.list_id).await.unwrap().unwrap();
+        assert_eq!(
+            row.updated_at,
+            v + 1,
+            "row stamp must roll back when the snapshot insert fails"
+        );
+        assert_eq!(
+            row.status_list.lst, "flip-1",
+            "row content must roll back when the snapshot insert fails"
+        );
+        // No partial snapshot for the rolled-back update: what resolves at v+2 is
+        // still the previously committed snapshot, not the flip-2 attempt.
+        let resolved = history
+            .find_valid_at(&base.list_id, v + 2)
+            .await
+            .unwrap()
+            .expect("the earlier committed snapshot still covers v+2");
+        assert_eq!(
+            resolved.status_list.lst, "flip-1",
+            "no partial snapshot from the rolled-back update may exist"
+        );
+
+        // --- Conflict path: a stale guard rolls back cleanly and records
+        // nothing. ---
+        let conflict = store
+            .update_one_with_snapshot(
+                &base.list_id,
+                StatusListRecord {
+                    status_list: StatusList {
+                        bits: 1,
+                        lst: "flip-3".to_string(),
+                    },
+                    updated_at: v + 5,
+                    ..base.clone()
+                },
+                v, // stale: the row is at v+1 now
+                StatusListHistoryRecord {
+                    snapshot_id: "snap-conflict".to_string(),
+                    list_id: base.list_id.clone(),
+                    issuer: issuer.to_string(),
+                    status_list: StatusList {
+                        bits: 1,
+                        lst: "flip-3".to_string(),
+                    },
+                    sub: base.sub.clone(),
+                    iat: v + 5,
+                    exp: v + 5 + 900,
+                },
+            )
+            .await
+            .unwrap();
+        assert!(!conflict, "stale guard must report no rows and roll back");
+        let row = store.find_one_by(&base.list_id).await.unwrap().unwrap();
+        assert_eq!(row.updated_at, v + 1, "conflict must not change the row");
+        let resolved = history
+            .find_valid_at(&base.list_id, v + 5)
+            .await
+            .unwrap()
+            .expect("only the committed snapshot exists");
+        assert_eq!(
+            resolved.status_list.lst, "flip-1",
+            "conflict path must not record a snapshot"
+        );
+    }
+
+    /// Cross-backend proof (#143) that the transactional rollback holds on a
+    /// real non-sqlite backend: on MySQL, a failed snapshot INSERT must roll the
+    /// paired row UPDATE back (requires InnoDB — pinned by the migration). This
+    /// is the exact spot where a non-transactional table engine would silently
+    /// keep the row change, so it is verified against a live MySQL container.
+    #[cfg(feature = "mysql")]
+    #[tokio::test]
+    async fn test_mysql_update_with_snapshot_rolls_back_on_history_failure() {
+        let test_db = mysql_helpers::mysql_connection().await;
+        let cred_store = SeaOrmStore::<Credentials>::new(test_db.db.clone());
+        let store = SeaOrmStore::<StatusListRecord>::new(test_db.db.clone());
+
+        let key: Jwk = serde_json::from_str(
+            r#"{
+                "kty": "EC",
+                "crv": "P-256",
+                "x": "NeyFv_2L67OEplNbJpR02IFis4_lFW9HYmhfF5Or6m8",
+                "y": "eAH2qe8Pg3GQ28uxA8-qNAqdwQ_zfV2uKAvJ2sLpY9M"
+            }"#,
+        )
+        .unwrap();
+        let issuer = "issuer-atomic-mysql";
+        cred_store
+            .insert_one(Credentials::new(issuer.to_string(), key))
+            .await
+            .unwrap();
+
+        let v = 1000;
+        let base = StatusListRecord {
+            list_id: "list-atomic-mysql".to_string(),
+            issuer: issuer.to_string(),
+            status_list: StatusList {
+                bits: 1,
+                lst: "initial".to_string(),
+            },
+            sub: "sub-atomic-mysql".to_string(),
+            updated_at: v,
+        };
+        store.insert_one(base.clone()).await.unwrap();
+
+        // Commit one snapshot so its primary key exists to collide against.
+        store
+            .update_one_with_snapshot(
+                &base.list_id,
+                StatusListRecord {
+                    status_list: StatusList {
+                        bits: 1,
+                        lst: "flip-1".to_string(),
+                    },
+                    updated_at: v + 1,
+                    ..base.clone()
+                },
+                v,
+                StatusListHistoryRecord {
+                    snapshot_id: "snap-mysql".to_string(),
+                    list_id: base.list_id.clone(),
+                    issuer: issuer.to_string(),
+                    status_list: StatusList {
+                        bits: 1,
+                        lst: "flip-1".to_string(),
+                    },
+                    sub: base.sub.clone(),
+                    iat: v + 1,
+                    exp: v + 1 + 900,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Second update whose snapshot collides on the primary key: the INSERT
+        // fails, so the whole transaction must roll back.
+        let result = store
+            .update_one_with_snapshot(
+                &base.list_id,
+                StatusListRecord {
+                    status_list: StatusList {
+                        bits: 1,
+                        lst: "flip-2".to_string(),
+                    },
+                    updated_at: v + 2,
+                    ..base.clone()
+                },
+                v + 1,
+                StatusListHistoryRecord {
+                    snapshot_id: "snap-mysql".to_string(), // duplicate PK
+                    list_id: base.list_id.clone(),
+                    issuer: issuer.to_string(),
+                    status_list: StatusList {
+                        bits: 1,
+                        lst: "flip-2".to_string(),
+                    },
+                    sub: base.sub.clone(),
+                    iat: v + 2,
+                    exp: v + 2 + 900,
+                },
+            )
+            .await;
+        assert!(result.is_err(), "duplicate snapshot PK must fail the unit");
+
+        let row = store.find_one_by(&base.list_id).await.unwrap().unwrap();
+        assert_eq!(
+            row.updated_at,
+            v + 1,
+            "InnoDB must roll the row update back when the snapshot insert fails"
+        );
+        assert_eq!(
+            row.status_list.lst, "flip-1",
+            "the rolled-back row must retain its previously committed content"
+        );
     }
 
     #[cfg(feature = "sqlite")]

--- a/src/adapters/sea_orm/store.rs
+++ b/src/adapters/sea_orm/store.rs
@@ -25,10 +25,9 @@ impl<T> SeaOrmStore<T> {
     }
 }
 
-/// Maps an insert failure, distinguishing a unique-constraint violation — a
-/// concurrent writer won the check-then-insert race — from real storage
-/// failures. `sql_err()` is SeaORM's backend-normalized view of driver errors,
-/// so the same mapping serves Postgres, MySQL, and SQLite alike.
+/// Maps an insert failure, distinguishing a unique-constraint violation (a
+/// concurrent writer won the check-then-insert race) from real storage
+/// failures. `sql_err()` normalizes driver errors across all three backends.
 fn map_insert_err(e: sea_orm::DbErr) -> RepositoryError {
     match e.sql_err() {
         Some(sea_orm::SqlErr::UniqueConstraintViolation(_)) => RepositoryError::DuplicateEntry,
@@ -74,27 +73,17 @@ impl SeaOrmStore<StatusListRecord> {
             .map_err(|e| RepositoryError::FindError(e.to_string()))
     }
 
-    /// Optimistic-concurrency update guarded on `updated_at`.
+    /// Optimistic-concurrency update guarded on `updated_at`:
+    /// `UPDATE ... WHERE list_id = ? AND updated_at = ?`. `Ok(false)` means the
+    /// guard did not match — a racing writer advanced the stamp, or the row is
+    /// gone — so a lost update was prevented.
     ///
-    /// Executes a single atomic `UPDATE ... WHERE list_id = ? AND updated_at = ?`.
-    /// `list_id` is the primary key, so this touches at most one row and
-    /// `rows_affected` is exactly 0 or 1. A return of `Ok(false)` means the guard
-    /// did not match — another writer changed the row (or it was deleted) since
-    /// the caller read `expected_updated_at`, i.e. a lost-update was prevented.
+    /// Uses `rows_affected` rather than `SELECT ... FOR UPDATE` because its
+    /// semantics are identical across all three sea-orm backends (#143).
     ///
-    /// `rows_affected` is used deliberately: its semantics are identical across
-    /// the Postgres/MySQL/SQLite sea-orm backends, unlike `SELECT ... FOR UPDATE`
-    /// row locking (see #143).
-    ///
-    /// # Caller contract
-    ///
-    /// `entity.updated_at` MUST be strictly greater than `expected_updated_at`.
-    /// The guard only prevents a lost update if the write *advances* the stamp:
-    /// with a non-advancing value (`new == expected`) two same-second writers
-    /// would both match `WHERE updated_at = expected` and both succeed, silently
-    /// losing a flip. This invariant is enforced below rather than trusted, so a
-    /// future caller that forgets to advance the stamp fails loudly instead of
-    /// reintroducing the race.
+    /// `entity.updated_at` MUST be strictly greater than `expected_updated_at`,
+    /// enforced below: a non-advancing stamp lets two same-second writers both
+    /// match the guard, silently losing a flip.
     pub async fn update_one(
         &self,
         list_id: &str,
@@ -128,23 +117,13 @@ impl SeaOrmStore<StatusListRecord> {
         Ok(result.rows_affected > 0)
     }
 
-    /// Optimistic update that records a history snapshot in the **same
-    /// transaction** as the guarded row update.
-    ///
-    /// Either the guarded `UPDATE status_lists` and the `status_list_history`
-    /// `INSERT` both commit, or neither does. This closes the split the plain
-    /// [`update_one`](Self::update_one) leaves open, where the row changes but a
-    /// subsequent snapshot insert fails, so nothing records the change.
-    ///
-    /// A `false` return means the optimistic guard did not match (a racing
-    /// writer advanced the stamp, or the row is gone): the transaction is rolled
-    /// back and nothing is written — identical outward behavior to
-    /// [`update_one`](Self::update_one). Transaction semantics are portable
-    /// across the Postgres/MySQL/SQLite sea-orm backends (#143), so the
-    /// all-or-nothing guarantee holds identically on all three.
-    ///
-    /// The same strictly-advancing `updated_at` caller contract as
-    /// [`update_one`](Self::update_one) applies and is enforced here too.
+    /// Like [`update_one`](Self::update_one), but the guarded `UPDATE` and the
+    /// `status_list_history` `INSERT` run in one transaction: both commit or
+    /// neither does. This closes the split the plain `update_one` leaves open,
+    /// where the row changes but a failing snapshot insert leaves nothing
+    /// recording it. Transaction semantics are portable across all three
+    /// sea-orm backends (#143). Same `false`-on-guard-miss and
+    /// strictly-advancing-stamp contract as `update_one`.
     pub async fn update_one_with_snapshot(
         &self,
         list_id: &str,
@@ -185,8 +164,7 @@ impl SeaOrmStore<StatusListRecord> {
             .map_err(|e| RepositoryError::UpdateError(e.to_string()))?;
 
         if result.rows_affected == 0 {
-            // Optimistic-guard miss: roll back so the conflict path records
-            // nothing (no snapshot, no row change).
+            // Guard miss: roll back so nothing is recorded.
             txn.rollback()
                 .await
                 .map_err(|e| RepositoryError::UpdateError(e.to_string()))?;
@@ -198,10 +176,8 @@ impl SeaOrmStore<StatusListRecord> {
             .exec(&txn)
             .await
         {
-            // The row UPDATE already landed inside the transaction, but the
-            // snapshot INSERT failed. Roll back so the row reverts to its
-            // pre-update state — the whole point of this method: never leave a
-            // changed row without the snapshot that records the change.
+            // Snapshot INSERT failed after the row UPDATE landed: roll the row
+            // back so a changed row never outlives the snapshot recording it.
             txn.rollback().await.map_err(|rollback_err| {
                 RepositoryError::InsertError(format!(
                     "history snapshot insert failed ({insert_err}); \
@@ -266,17 +242,11 @@ impl SeaOrmStore<StatusListHistoryRecord> {
         Ok(())
     }
 
-    /// Finds the snapshot whose half-open validity interval contains `time`.
-    /// Using `iat <= time < exp` ensures the token returned to a client passes
-    /// the draft-21 §8.4 `iat`/`exp` validation rule.
-    ///
-    /// Intervals intentionally overlap: each update writes a fresh snapshot with
-    /// `exp = iat + token_exp_secs` while the superseded snapshot keeps its
-    /// original (later) `exp`, so both can match a `time` in the overlap. That is
-    /// not an inconsistency — `ORDER BY iat DESC LIMIT 1` deterministically
-    /// returns the newest snapshot in effect at `time`, which is the correct
-    /// answer for "what was the status then". The memory adapter mirrors this via
-    /// `max_by_key(iat)`.
+    /// Finds the snapshot whose half-open interval `iat <= time < exp` contains
+    /// `time` (draft-21 §8.4). Intervals intentionally overlap — a superseded
+    /// snapshot keeps its original later `exp` — so `ORDER BY iat DESC LIMIT 1`
+    /// picks the newest one in effect at `time`. The memory adapter mirrors this
+    /// via `max_by_key(iat)`.
     pub async fn find_valid_at(
         &self,
         list_id: &str,
@@ -358,7 +328,7 @@ mod test {
     use jsonwebtoken::jwk::Jwk;
     use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
     // `Migrator::up` is only called from the real-backend helpers below.
-    #[cfg(any(feature = "sqlite", feature = "mysql"))]
+    #[cfg(any(feature = "sqlite", feature = "mysql", feature = "postgres-tests"))]
     use sea_orm_migration::MigratorTrait;
 
     #[cfg(feature = "sqlite")]
@@ -428,6 +398,51 @@ mod test {
                 .await
                 .expect("Failed to run migrations on MySQL");
             MysqlTestDb {
+                _container: node,
+                db: Arc::new(db),
+            }
+        }
+    }
+
+    #[cfg(feature = "postgres-tests")]
+    mod postgres_helpers {
+        use super::*;
+        use testcontainers_modules::{
+            postgres::Postgres as PostgresImage,
+            testcontainers::{ContainerAsync, runners::AsyncRunner},
+        };
+
+        pub(super) struct PostgresTestDb {
+            #[allow(dead_code)]
+            pub(super) _container: ContainerAsync<PostgresImage>,
+            pub(super) db: Arc<DatabaseConnection>,
+        }
+
+        pub(super) async fn postgres_connection() -> PostgresTestDb {
+            let node = PostgresImage::default()
+                .start()
+                .await
+                .expect("Failed to start Postgres container");
+            let host = node
+                .get_host()
+                .await
+                .expect("Failed to resolve Postgres host");
+            let port = node
+                .get_host_port_ipv4(5432)
+                .await
+                .expect("Failed to resolve Postgres port");
+
+            // testcontainers' Postgres image defaults to postgres/postgres/postgres.
+            let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+            let mut opt = sea_orm::ConnectOptions::new(url);
+            opt.max_connections(5);
+            let db = sea_orm::Database::connect(opt)
+                .await
+                .expect("Failed to connect to Postgres");
+            crate::adapters::sea_orm::Migrator::up(&db, None)
+                .await
+                .expect("Failed to run migrations on Postgres");
+            PostgresTestDb {
                 _container: node,
                 db: Arc::new(db),
             }
@@ -784,12 +799,9 @@ mod test {
         cred_store.delete_by("issuer-neg-sqlite").await.unwrap();
     }
 
-    /// A second insert with the same primary key must surface as
-    /// `DuplicateEntry`, not a generic insert error. This is the one property a
-    /// mock cannot verify: whether the real backend's duplicate-key error
-    /// actually parses into `SqlErr::UniqueConstraintViolation`. The adapter
-    /// layer maps `DuplicateEntry` to a conflict so a racing publish returns
-    /// 409 instead of 500.
+    /// A duplicate primary key must surface as `DuplicateEntry`, not a generic
+    /// insert error — the one property a mock cannot verify, since it depends on
+    /// the real driver's error parsing into `SqlErr::UniqueConstraintViolation`.
     #[cfg(feature = "sqlite")]
     #[tokio::test]
     async fn test_sqlite_duplicate_insert_maps_to_duplicate_entry() {
@@ -840,10 +852,9 @@ mod test {
         );
     }
 
-    /// Cross-backend proof (#143) for the duplicate-key mapping: MySQL's
-    /// duplicate-key error must also parse into
-    /// `SqlErr::UniqueConstraintViolation` — the exact spot where a driver's
-    /// error format could diverge from sqlite without any mock test noticing.
+    /// Cross-backend proof (#143): MySQL's duplicate-key error must also parse
+    /// into `SqlErr::UniqueConstraintViolation`, where the driver format could
+    /// diverge from sqlite.
     #[cfg(feature = "mysql")]
     #[tokio::test]
     async fn test_mysql_duplicate_insert_maps_to_duplicate_entry() {
@@ -892,11 +903,9 @@ mod test {
         );
     }
 
-    /// The real proof for the lost-update fix: two writers that both read the
-    /// same `updated_at` cannot both win. This deterministically models the race
-    /// (no threads) — both capture the same guard value, the first guarded write
-    /// lands, the second's guard misses and is rejected — and asserts the
-    /// loser's flip did not overwrite the winner's.
+    /// The lost-update proof: two writers reading the same `updated_at` cannot
+    /// both win. Deterministic (no threads) — first write lands, second's guard
+    /// misses — and the loser's flip must not overwrite the winner's.
     #[cfg(feature = "sqlite")]
     #[tokio::test]
     async fn test_update_one_optimistic_guard_rejects_stale_write() {
@@ -965,11 +974,9 @@ mod test {
         assert_eq!(stored.updated_at, v + 1);
     }
 
-    /// Cross-backend proof (#143): the optimistic guard must behave identically
-    /// on a real non-sqlite backend. This exercises the JSON `col_expr` write and
-    /// `rows_affected` semantics against MySQL — the two things most likely to
-    /// diverge from sqlite — and asserts the same win/reject outcome as the
-    /// sqlite guard test.
+    /// Cross-backend proof (#143): the optimistic guard behaves identically on
+    /// MySQL, exercising the JSON `col_expr` write and `rows_affected` semantics
+    /// most likely to diverge from sqlite.
     #[cfg(feature = "mysql")]
     #[tokio::test]
     async fn test_mysql_update_one_optimistic_guard_rejects_stale_write() {
@@ -1036,12 +1043,10 @@ mod test {
         assert_eq!(stored.updated_at, v + 1);
     }
 
-    /// Pins the store-level caller contract: a guarded write whose new
-    /// `updated_at` does not strictly advance past the guard value is rejected
-    /// outright (before touching the DB), so a future caller that forgets to
-    /// advance the stamp fails loudly instead of silently reintroducing the
-    /// same-second lost update. No DB round-trip is needed — the check precedes
-    /// the query — so this runs on the mock backend.
+    /// A guarded write whose `updated_at` does not strictly advance past the
+    /// guard is rejected before touching the DB, so a caller that forgets to
+    /// advance the stamp fails loudly. The check precedes the query, so this
+    /// runs on the mock backend.
     #[tokio::test]
     async fn test_update_one_rejects_non_advancing_stamp() {
         let db_conn = Arc::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection());
@@ -1075,12 +1080,10 @@ mod test {
         "y": "eAH2qe8Pg3GQ28uxA8-qNAqdwQ_zfV2uKAvJ2sLpY9M"
     }"#;
 
-    /// The core acceptance test for the transactional fix: the guarded row
-    /// UPDATE and the history INSERT succeed or fail as a unit. Exercises the
-    /// happy path (both commit), the forced-INSERT-failure path (row update
-    /// rolls back, no partial snapshot), and the conflict path (guard miss rolls
-    /// back cleanly) — all against a real SQLite backend, since a `MockDatabase`
-    /// cannot model transaction rollback.
+    /// The core acceptance test: the guarded row UPDATE and the history INSERT
+    /// succeed or fail as a unit. Covers the happy path, the forced-INSERT-
+    /// failure rollback (no partial snapshot), and the conflict path — against
+    /// real SQLite, since `MockDatabase` cannot model rollback.
     #[cfg(feature = "sqlite")]
     #[tokio::test]
     async fn test_sqlite_update_with_snapshot_is_atomic() {
@@ -1252,11 +1255,9 @@ mod test {
         );
     }
 
-    /// Cross-backend proof (#143) that the transactional rollback holds on a
-    /// real non-sqlite backend: on MySQL, a failed snapshot INSERT must roll the
-    /// paired row UPDATE back (requires InnoDB — pinned by the migration). This
-    /// is the exact spot where a non-transactional table engine would silently
-    /// keep the row change, so it is verified against a live MySQL container.
+    /// Cross-backend proof (#143): on MySQL a failed snapshot INSERT must roll
+    /// the paired row UPDATE back. Requires InnoDB (pinned by the migration) —
+    /// a non-transactional engine would silently keep the row change.
     #[cfg(feature = "mysql")]
     #[tokio::test]
     async fn test_mysql_update_with_snapshot_rolls_back_on_history_failure() {
@@ -1356,6 +1357,115 @@ mod test {
             row.updated_at,
             v + 1,
             "InnoDB must roll the row update back when the snapshot insert fails"
+        );
+        assert_eq!(
+            row.status_list.lst, "flip-1",
+            "the rolled-back row must retain its previously committed content"
+        );
+    }
+
+    /// Postgres is the production backend, so the transactional rollback is
+    /// proven directly on it, not just inferred from the SQLite and MySQL
+    /// proofs: a colliding snapshot INSERT must roll the paired row UPDATE back.
+    #[cfg(feature = "postgres-tests")]
+    #[tokio::test]
+    async fn test_postgres_update_with_snapshot_rolls_back_on_history_failure() {
+        let test_db = postgres_helpers::postgres_connection().await;
+        let cred_store = SeaOrmStore::<Credentials>::new(test_db.db.clone());
+        let store = SeaOrmStore::<StatusListRecord>::new(test_db.db.clone());
+
+        let key: Jwk = serde_json::from_str(
+            r#"{
+                "kty": "EC",
+                "crv": "P-256",
+                "x": "NeyFv_2L67OEplNbJpR02IFis4_lFW9HYmhfF5Or6m8",
+                "y": "eAH2qe8Pg3GQ28uxA8-qNAqdwQ_zfV2uKAvJ2sLpY9M"
+            }"#,
+        )
+        .unwrap();
+        let issuer = "issuer-atomic-postgres";
+        cred_store
+            .insert_one(Credentials::new(issuer.to_string(), key))
+            .await
+            .unwrap();
+
+        let v = 1000;
+        let base = StatusListRecord {
+            list_id: "list-atomic-postgres".to_string(),
+            issuer: issuer.to_string(),
+            status_list: StatusList {
+                bits: 1,
+                lst: "initial".to_string(),
+            },
+            sub: "sub-atomic-postgres".to_string(),
+            updated_at: v,
+        };
+        store.insert_one(base.clone()).await.unwrap();
+
+        // Commit one snapshot so its primary key exists to collide against.
+        store
+            .update_one_with_snapshot(
+                &base.list_id,
+                StatusListRecord {
+                    status_list: StatusList {
+                        bits: 1,
+                        lst: "flip-1".to_string(),
+                    },
+                    updated_at: v + 1,
+                    ..base.clone()
+                },
+                v,
+                StatusListHistoryRecord {
+                    snapshot_id: "snap-postgres".to_string(),
+                    list_id: base.list_id.clone(),
+                    issuer: issuer.to_string(),
+                    status_list: StatusList {
+                        bits: 1,
+                        lst: "flip-1".to_string(),
+                    },
+                    sub: base.sub.clone(),
+                    iat: v + 1,
+                    exp: v + 1 + 900,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Second update whose snapshot collides on the primary key: the INSERT
+        // fails, so the whole transaction must roll back.
+        let result = store
+            .update_one_with_snapshot(
+                &base.list_id,
+                StatusListRecord {
+                    status_list: StatusList {
+                        bits: 1,
+                        lst: "flip-2".to_string(),
+                    },
+                    updated_at: v + 2,
+                    ..base.clone()
+                },
+                v + 1,
+                StatusListHistoryRecord {
+                    snapshot_id: "snap-postgres".to_string(), // duplicate PK
+                    list_id: base.list_id.clone(),
+                    issuer: issuer.to_string(),
+                    status_list: StatusList {
+                        bits: 1,
+                        lst: "flip-2".to_string(),
+                    },
+                    sub: base.sub.clone(),
+                    iat: v + 2,
+                    exp: v + 2 + 900,
+                },
+            )
+            .await;
+        assert!(result.is_err(), "duplicate snapshot PK must fail the unit");
+
+        let row = store.find_one_by(&base.list_id).await.unwrap().unwrap();
+        assert_eq!(
+            row.updated_at,
+            v + 1,
+            "Postgres must roll the row update back when the snapshot insert fails"
         );
         assert_eq!(
             row.status_list.lst, "flip-1",

--- a/src/adapters/sea_orm/store.rs
+++ b/src/adapters/sea_orm/store.rs
@@ -51,6 +51,72 @@ impl SeaOrmStore<StatusListRecord> {
         Ok(())
     }
 
+    /// Like [`insert_one`](Self::insert_one), but the row `INSERT` and the
+    /// `status_list_history` `INSERT` covering its initial state run in one
+    /// transaction: both commit or neither does. Without this a publish whose
+    /// snapshot insert fails leaves a list with no snapshot covering it, and —
+    /// unlike an update — no later write repairs that hole.
+    ///
+    /// A duplicate `list_id` is still reported as
+    /// [`RepositoryError::DuplicateEntry`] so the publish conflict keeps mapping
+    /// to 409 rather than 500.
+    pub async fn insert_one_with_snapshot(
+        &self,
+        entity: StatusListRecord,
+        snapshot: StatusListHistoryRecord,
+    ) -> Result<(), RepositoryError> {
+        let txn = self
+            .db
+            .begin()
+            .await
+            .map_err(|e| RepositoryError::InsertError(e.to_string()))?;
+
+        let active = status_lists::ActiveModel {
+            list_id: Set(entity.list_id),
+            issuer: Set(entity.issuer),
+            status_list: Set(entity.status_list),
+            sub: Set(entity.sub),
+            updated_at: Set(entity.updated_at),
+        };
+        if let Err(insert_err) = status_lists::Entity::insert(active)
+            .exec_without_returning(&txn)
+            .await
+        {
+            txn.rollback().await.map_err(|rollback_err| {
+                RepositoryError::InsertError(format!(
+                    "status list insert failed ({insert_err}); \
+                     rolling the transaction back also failed: {rollback_err}"
+                ))
+            })?;
+            // Preserves the duplicate-key classification, so a racing publish
+            // stays a 409 instead of degrading to a 500.
+            return Err(map_insert_err(insert_err));
+        }
+
+        let history_active: status_list_history::ActiveModel = snapshot.into();
+        if let Err(insert_err) = status_list_history::Entity::insert(history_active)
+            .exec_without_returning(&txn)
+            .await
+        {
+            // Snapshot INSERT failed after the row INSERT landed: roll the row
+            // back so a published list never outlives the snapshot recording it.
+            // A duplicate `snapshot_id` stays a 500 rather than a 409, for the
+            // reason spelled out in `update_one_with_snapshot`.
+            txn.rollback().await.map_err(|rollback_err| {
+                RepositoryError::InsertError(format!(
+                    "history snapshot insert failed ({insert_err}); \
+                     rolling back the status list insert also failed: {rollback_err}"
+                ))
+            })?;
+            return Err(RepositoryError::InsertError(insert_err.to_string()));
+        }
+
+        txn.commit()
+            .await
+            .map_err(|e| RepositoryError::InsertError(e.to_string()))?;
+        Ok(())
+    }
+
     pub async fn find_one_by(
         &self,
         value: &str,
@@ -124,6 +190,14 @@ impl SeaOrmStore<StatusListRecord> {
     /// recording it. Transaction semantics are portable across all three
     /// sea-orm backends (#143). Same `false`-on-guard-miss and
     /// strictly-advancing-stamp contract as `update_one`.
+    ///
+    /// Concurrency cost: unlike `update_one`, the exclusive row lock taken by
+    /// the `UPDATE` is held until `COMMIT`, spanning the snapshot `INSERT`'s
+    /// round trip. A racing writer guarded on the same stamp therefore *blocks*
+    /// on that lock rather than immediately reading `rows_affected == 0`; it
+    /// still resolves to `false` once the winner commits, so the outcome is
+    /// unchanged, but a conflict now costs a lock wait instead of failing fast.
+    /// Callers that treat conflicts as cheap should account for that.
     pub async fn update_one_with_snapshot(
         &self,
         list_id: &str,
@@ -178,6 +252,14 @@ impl SeaOrmStore<StatusListRecord> {
         {
             // Snapshot INSERT failed after the row UPDATE landed: roll the row
             // back so a changed row never outlives the snapshot recording it.
+            //
+            // Note this deliberately does NOT route through `map_insert_err`: a
+            // duplicate `snapshot_id` stays a plain insert failure (→ 500), not
+            // a conflict (→ 409). `snapshot_id` is a freshly minted UUIDv4, so a
+            // collision is a genuine bug or storage fault, never a client-
+            // retryable race — telling the caller to retry would be advice no
+            // retry can satisfy. The rollback tests force exactly this error
+            // path, so do not "fix" it into a conflict.
             txn.rollback().await.map_err(|rollback_err| {
                 RepositoryError::InsertError(format!(
                     "history snapshot insert failed ({insert_err}); \
@@ -1080,8 +1162,6 @@ mod test {
         "y": "eAH2qe8Pg3GQ28uxA8-qNAqdwQ_zfV2uKAvJ2sLpY9M"
     }"#;
 
-    /// The core acceptance test: the guarded row UPDATE and the history INSERT
-    /// succeed or fail as a unit. Covers the happy path, the forced-INSERT-
     /// failure rollback (no partial snapshot), and the conflict path — against
     /// real SQLite, since `MockDatabase` cannot model rollback.
     #[cfg(feature = "sqlite")]
@@ -1252,6 +1332,106 @@ mod test {
         assert_eq!(
             resolved.status_list.lst, "flip-1",
             "conflict path must not record a snapshot"
+        );
+    }
+
+    /// The publish counterpart of the atomicity proof: the row INSERT and the
+    /// snapshot covering its initial state succeed or fail as a unit. A hole
+    /// here is worse than on the update path — no later write repairs a missing
+    /// opening snapshot, so §8.4 lookups over that window would 404 forever.
+    /// Also pins that a duplicate `list_id` still classifies as `DuplicateEntry`
+    /// (409), not a generic insert failure (500).
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn test_sqlite_insert_with_snapshot_is_atomic() {
+        let db = sqlite_connection().await;
+        let cred_store = SeaOrmStore::<Credentials>::new(db.clone());
+        let store = SeaOrmStore::<StatusListRecord>::new(db.clone());
+        let history = SeaOrmStore::<StatusListHistoryRecord>::new(db);
+
+        let key: Jwk = serde_json::from_str(TEST_EC_JWK).unwrap();
+        let issuer = "issuer-insert-atomic";
+        cred_store
+            .insert_one(Credentials::new(issuer.to_string(), key))
+            .await
+            .unwrap();
+
+        let new_record = |list_id: &str| StatusListRecord {
+            list_id: list_id.to_string(),
+            issuer: issuer.to_string(),
+            status_list: StatusList {
+                bits: 1,
+                lst: "initial".to_string(),
+            },
+            sub: format!("sub-{list_id}"),
+            updated_at: 1000,
+        };
+        let new_snapshot = |snapshot_id: &str, list_id: &str| StatusListHistoryRecord {
+            snapshot_id: snapshot_id.to_string(),
+            list_id: list_id.to_string(),
+            issuer: issuer.to_string(),
+            status_list: StatusList {
+                bits: 1,
+                lst: "initial".to_string(),
+            },
+            sub: format!("sub-{list_id}"),
+            iat: 1000,
+            exp: 1900,
+        };
+
+        // --- Happy path: row and opening snapshot both commit. ---
+        store
+            .insert_one_with_snapshot(new_record("list-ok"), new_snapshot("snap-ok", "list-ok"))
+            .await
+            .unwrap();
+        assert!(store.find_one_by("list-ok").await.unwrap().is_some());
+        assert!(
+            history
+                .find_valid_at("list-ok", 1000)
+                .await
+                .unwrap()
+                .is_some(),
+            "the opening snapshot must be resolvable at the publish instant"
+        );
+
+        // --- Rollback path: the snapshot INSERT collides on its primary key,
+        // so the paired row INSERT must not survive. ---
+        let result = store
+            .insert_one_with_snapshot(
+                new_record("list-rolled-back"),
+                // Collides with the snapshot committed above.
+                new_snapshot("snap-ok", "list-rolled-back"),
+            )
+            .await;
+        assert!(
+            result.is_err(),
+            "a failed snapshot insert must fail the whole unit"
+        );
+        assert!(
+            store
+                .find_one_by("list-rolled-back")
+                .await
+                .unwrap()
+                .is_none(),
+            "the status list row must roll back when its snapshot insert fails"
+        );
+
+        // --- Conflict path: a duplicate list_id must stay a DuplicateEntry so
+        // a racing publish keeps mapping to 409 rather than 500. ---
+        let dup = store
+            .insert_one_with_snapshot(new_record("list-ok"), new_snapshot("snap-dup", "list-ok"))
+            .await;
+        assert!(
+            matches!(dup, Err(RepositoryError::DuplicateEntry)),
+            "duplicate list_id must map to DuplicateEntry, got {dup:?}"
+        );
+        // The rejected publish recorded no snapshot either.
+        assert!(
+            history
+                .find_valid_at("list-nonexistent", 1000)
+                .await
+                .unwrap()
+                .is_none()
         );
     }
 

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -651,3 +651,42 @@ impl<R: StatusListRepository + ?Sized, C: StatusListCache + ?Sized> GetStatusLis
         Ok(record.as_ref().clone())
     }
 }
+
+#[cfg(all(test, feature = "server"))]
+mod tests {
+    use super::*;
+    use crate::{
+        adapters::memory::{MemoryStatusListHistory, MemoryStatusLists},
+        test_utils::test_status_list_record,
+    };
+    use std::sync::Arc;
+
+    /// A snapshot's `iat` must mirror the row's `updated_at`, not the wall
+    /// clock — that is what keeps `Last-Modified` (served from `updated_at`)
+    /// and the §8.4 lookup key (`iat`) consistent, and what makes snapshot
+    /// ordering per list strict given `next_updated_at`.
+    #[tokio::test]
+    async fn test_snapshot_iat_mirrors_record_updated_at() {
+        let history = Arc::new(MemoryStatusListHistory::default());
+        let token_exp_secs = 900u64;
+        let publish = PublishStatusListWithHistory::new(
+            Arc::new(MemoryStatusLists::default()),
+            history.clone(),
+            token_exp_secs,
+        );
+
+        let mut record = test_status_list_record("issuer", "list-iat");
+        // A stamp the clock would never produce right now, in either direction.
+        record.updated_at = 4_102_444_800; // 2100-01-01
+
+        publish.execute(record.clone()).await.unwrap();
+
+        let snapshot = history
+            .find_valid_at("list-iat", record.updated_at)
+            .await
+            .unwrap()
+            .expect("snapshot was persisted");
+        assert_eq!(snapshot.iat, record.updated_at);
+        assert_eq!(snapshot.exp, record.updated_at + token_exp_secs as i64);
+    }
+}

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -30,11 +30,9 @@ fn current_unix_timestamp() -> i64 {
         .as_secs() as i64
 }
 
-/// Maps an insert-path port error: a duplicate-key conflict means another
-/// writer created the resource between our existence check and the insert —
-/// semantically the same "already exists" outcome as the pre-check, so a
-/// racing publish surfaces as 409, not 500. (`UseCaseError::Conflict` is
-/// reserved for the optimistic-concurrency update race.)
+/// Maps a duplicate-key insert conflict to `AlreadyExists` (racing publish →
+/// 409, same outcome as the pre-check), leaving `Conflict` for the
+/// optimistic-concurrency update race.
 fn map_insert_conflict(error: PortError) -> UseCaseError {
     match error {
         PortError::Conflict { .. } => UseCaseError::AlreadyExists,
@@ -44,18 +42,10 @@ fn map_insert_conflict(error: PortError) -> UseCaseError {
 
 /// Computes the next `updated_at` for an optimistic-concurrency write.
 ///
-/// Two distinct concerns, both required — do not drop either:
-///   * the `WHERE updated_at = previous` guard in
-///     [`StatusListRepository::update`] handles *concurrency* (a racing writer
-///     loses the race);
-///   * the `.max(previous + 1)` here handles *clock granularity*.
-///
-/// `updated_at` is unix seconds, so two writers in the same second both read the
-/// same `previous` and both see `now == previous`. If the stamp did not advance,
-/// the first write would leave `updated_at` unchanged and the second writer's
-/// guard would still match — both would succeed, silently losing a flip. Forcing
-/// the value to strictly increase guarantees the guard moves, so the loser's
-/// `WHERE` misses. Dropping the `+ 1` reintroduces the same-second lost update.
+/// `updated_at` is unix seconds, so two writers in the same second read the
+/// same `previous` and both see `now == previous`. `.max(previous + 1)` forces
+/// the stamp to strictly increase so the loser's `WHERE updated_at = previous`
+/// guard misses; dropping the `+ 1` reintroduces the same-second lost update.
 pub fn next_updated_at(previous: i64, now: i64) -> i64 {
     now.max(previous + 1)
 }
@@ -226,12 +216,9 @@ impl<R: StatusListRepository + ?Sized> PublishStatusList<R> {
     feature = "sqlite",
     feature = "mysql"
 ))]
-/// Build the point-in-time snapshot for `record`.
-///
-/// The snapshot becomes valid at the record's modification time. Reusing
-/// `record.updated_at` — rather than reading the clock a second time here —
-/// threads a single `now` through the write and its snapshot, so their
-/// timestamps cannot drift apart (C4).
+/// Builds the point-in-time snapshot for `record`. `iat` reuses
+/// `record.updated_at` rather than re-reading the clock, so the write and its
+/// snapshot share one `now` and cannot drift apart (C4).
 fn build_snapshot(record: &StatusListRecord, token_exp_secs: u64) -> StatusListSnapshot {
     let iat = record.updated_at;
     StatusListSnapshot {
@@ -308,11 +295,8 @@ impl<R: StatusListRepository + ?Sized, H: StatusListHistoryRepository + ?Sized>
     }
 
     pub async fn execute(&self, record: StatusListRecord) -> Result<(), UseCaseError> {
-        // Delegate the size-limit guard, existence check, and guarded insert to
-        // the single authoritative publish core, then record the snapshot on
-        // top. This is the only find→insert implementation; the service composes
-        // it rather than re-implementing it inline. The size limit is threaded
-        // into the core so it is enforced in exactly one place.
+        // Reuse the single publish core (size guard, existence check, guarded
+        // insert), then record the snapshot on top.
         PublishStatusList::new(self.repository.clone())
             .with_max_serialized_list_size(self.max_serialized_list_size)
             .execute(record.clone())
@@ -415,11 +399,8 @@ impl<
         sub: String,
         statuses: Vec<StatusEntry>,
     ) -> Result<(), UseCaseError> {
-        // Delegate to the publish use case so the size limit lives in the
-        // use-case layer, not this facade: any inbound adapter reaching for the
-        // use case gets the invariant for free instead of having to remember it.
-        // The configured limit is the service's own — there is no per-call
-        // override, so a caller cannot publish past it.
+        // Delegate to the publish use case so the size limit lives there, not in
+        // this facade, and applies to every inbound adapter.
         let publisher = match &self.history {
             Some(history) => PublishStatusListWithHistory::new(
                 self.repository.clone(),
@@ -535,10 +516,8 @@ impl<R: StatusListRepository + ?Sized, C: StatusListCache + ?Sized> UpdateStatus
         if existing.status_list.lst.len() > self.max_serialized_list_size {
             return Err(UseCaseError::StatusListTooLarge);
         }
-        // The stamp read here is the optimistic-concurrency guard: the write
-        // below only lands if `updated_at` is still this value, so a racing
-        // writer that already moved it is rejected instead of silently
-        // overwritten.
+        // Optimistic guard: the write below lands only if `updated_at` is still
+        // this value, so a racing writer that moved it is rejected.
         let previous_updated_at = existing.updated_at;
         existing.updated_at = next_updated_at(previous_updated_at, current_unix_timestamp());
         if !self
@@ -622,17 +601,14 @@ impl<
         if existing.status_list.lst.len() > self.max_serialized_list_size {
             return Err(UseCaseError::StatusListTooLarge);
         }
-        // See the non-history path: `previous_updated_at` is the optimistic
-        // guard. A rejected write must leave no trace behind.
+        // Optimistic guard; see the non-history path.
         let previous_updated_at = existing.updated_at;
         existing.updated_at = next_updated_at(previous_updated_at, current_unix_timestamp());
 
-        // The guarded row update and its history snapshot must commit or fail as
-        // a unit: a committed row change with no snapshot recording it is the
-        // bug this path exists to prevent. `update_with_snapshot` performs both
-        // writes in one transaction, so a snapshot-write failure rolls the row
-        // update back. When history is disabled there is no snapshot, so the
-        // plain guarded update suffices.
+        // With history, the row update and its snapshot must commit or fail as a
+        // unit (`update_with_snapshot` wraps both in one transaction) so a
+        // committed row can never lack the snapshot recording it. Without
+        // history there is no snapshot, so the plain guarded update suffices.
         let landed = match &self.history {
             Some(_) => {
                 let snapshot = build_snapshot(&existing, token_exp_secs);
@@ -655,13 +631,10 @@ impl<
     }
 }
 
-/// Invalidate the cache after a durable write has committed.
-///
-/// This runs only once the row (and, on the history path, its snapshot) is
-/// committed, and it deliberately does not fail the operation: the write is
-/// already durable, and a stale cache entry self-heals at the cache TTL.
-/// Returning an error here would misreport a committed write as a 500 and make
-/// the client retry into a 409 against the now-advanced stamp.
+/// Invalidates the cache after a durable write has committed. Deliberately does
+/// not fail the operation: the write is already durable and a stale entry
+/// self-heals at the TTL, whereas erroring here would misreport a committed
+/// write as 500 and make the client retry into a 409 against the new stamp.
 async fn invalidate_after_commit<C: StatusListCache + ?Sized>(cache: &C, list_id: &str) {
     if let Err(_error) = cache.invalidate(list_id).await {
         #[cfg(feature = "tracing")]
@@ -706,9 +679,8 @@ mod tests {
     use std::sync::Arc;
 
     /// A snapshot's `iat` must mirror the row's `updated_at`, not the wall
-    /// clock — that is what keeps `Last-Modified` (served from `updated_at`)
-    /// and the §8.4 lookup key (`iat`) consistent, and what makes snapshot
-    /// ordering per list strict given `next_updated_at`.
+    /// clock — that keeps `Last-Modified` and the §8.4 lookup key (`iat`)
+    /// consistent and per-list snapshot ordering strict.
     #[tokio::test]
     async fn test_snapshot_iat_mirrors_record_updated_at() {
         let history = Arc::new(MemoryStatusListHistory::default());

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -226,17 +226,15 @@ impl<R: StatusListRepository + ?Sized> PublishStatusList<R> {
     feature = "sqlite",
     feature = "mysql"
 ))]
-async fn persist_snapshot<H: StatusListHistoryRepository + ?Sized>(
-    history: &H,
-    record: &StatusListRecord,
-    token_exp_secs: u64,
-) -> Result<(), UseCaseError> {
-    // The snapshot becomes valid at the record's modification time. Reusing
-    // `record.updated_at` — rather than reading the clock a second time here —
-    // threads a single `now` through the write and its snapshot, so their
-    // timestamps cannot drift apart (C4).
+/// Build the point-in-time snapshot for `record`.
+///
+/// The snapshot becomes valid at the record's modification time. Reusing
+/// `record.updated_at` — rather than reading the clock a second time here —
+/// threads a single `now` through the write and its snapshot, so their
+/// timestamps cannot drift apart (C4).
+fn build_snapshot(record: &StatusListRecord, token_exp_secs: u64) -> StatusListSnapshot {
     let iat = record.updated_at;
-    let snapshot = StatusListSnapshot {
+    StatusListSnapshot {
         snapshot_id: uuid::Uuid::new_v4().to_string(),
         list_id: record.list_id.clone(),
         issuer: record.issuer.clone(),
@@ -244,8 +242,24 @@ async fn persist_snapshot<H: StatusListHistoryRepository + ?Sized>(
         sub: record.sub.clone(),
         iat,
         exp: iat + token_exp_secs as i64,
-    };
-    history.insert(snapshot).await.map_err(UseCaseError::Port)
+    }
+}
+
+#[cfg(any(
+    feature = "server",
+    feature = "postgres",
+    feature = "sqlite",
+    feature = "mysql"
+))]
+async fn persist_snapshot<H: StatusListHistoryRepository + ?Sized>(
+    history: &H,
+    record: &StatusListRecord,
+    token_exp_secs: u64,
+) -> Result<(), UseCaseError> {
+    history
+        .insert(build_snapshot(record, token_exp_secs))
+        .await
+        .map_err(UseCaseError::Port)
 }
 
 #[cfg(any(
@@ -534,7 +548,7 @@ impl<R: StatusListRepository + ?Sized, C: StatusListCache + ?Sized> UpdateStatus
         {
             return Err(UseCaseError::Conflict);
         }
-        self.cache.invalidate(&existing.list_id).await?;
+        invalidate_after_commit(self.cache.as_ref(), &existing.list_id).await;
         Ok(())
     }
 }
@@ -609,24 +623,54 @@ impl<
             return Err(UseCaseError::StatusListTooLarge);
         }
         // See the non-history path: `previous_updated_at` is the optimistic
-        // guard. Returning before the snapshot and the cache invalidation keeps
-        // a rejected write from leaving any trace behind.
+        // guard. A rejected write must leave no trace behind.
         let previous_updated_at = existing.updated_at;
         existing.updated_at = next_updated_at(previous_updated_at, current_unix_timestamp());
-        if !self
-            .repository
-            .update(existing.clone(), previous_updated_at)
-            .await?
-        {
+
+        // The guarded row update and its history snapshot must commit or fail as
+        // a unit: a committed row change with no snapshot recording it is the
+        // bug this path exists to prevent. `update_with_snapshot` performs both
+        // writes in one transaction, so a snapshot-write failure rolls the row
+        // update back. When history is disabled there is no snapshot, so the
+        // plain guarded update suffices.
+        let landed = match &self.history {
+            Some(_) => {
+                let snapshot = build_snapshot(&existing, token_exp_secs);
+                self.repository
+                    .update_with_snapshot(existing.clone(), previous_updated_at, snapshot)
+                    .await?
+            }
+            None => {
+                self.repository
+                    .update(existing.clone(), previous_updated_at)
+                    .await?
+            }
+        };
+        if !landed {
             return Err(UseCaseError::Conflict);
         }
-        self.cache.invalidate(&existing.list_id).await?;
 
-        if let Some(history) = &self.history {
-            persist_snapshot(history.as_ref(), &existing, token_exp_secs).await?;
-        }
-
+        invalidate_after_commit(self.cache.as_ref(), &existing.list_id).await;
         Ok(())
+    }
+}
+
+/// Invalidate the cache after a durable write has committed.
+///
+/// This runs only once the row (and, on the history path, its snapshot) is
+/// committed, and it deliberately does not fail the operation: the write is
+/// already durable, and a stale cache entry self-heals at the cache TTL.
+/// Returning an error here would misreport a committed write as a 500 and make
+/// the client retry into a 409 against the now-advanced stamp.
+async fn invalidate_after_commit<C: StatusListCache + ?Sized>(cache: &C, list_id: &str) {
+    if let Err(_error) = cache.invalidate(list_id).await {
+        #[cfg(feature = "tracing")]
+        tracing::warn!(
+            list_id = %list_id,
+            error = ?_error,
+            "status list write committed, but cache invalidation failed; \
+             reads may be stale until the cache entry expires"
+        );
     }
 }
 

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -179,12 +179,12 @@ impl<R: StatusListRepository + ?Sized> PublishStatusList<R> {
     }
 
     pub async fn execute(&self, record: StatusListRecord) -> Result<(), UseCaseError> {
-        if record.status_list.lst.len() > self.max_serialized_list_size {
-            return Err(UseCaseError::StatusListTooLarge);
-        }
-        if self.repository.find(&record.list_id).await?.is_some() {
-            return Err(UseCaseError::AlreadyExists);
-        }
+        check_publishable(
+            self.repository.as_ref(),
+            &record,
+            self.max_serialized_list_size,
+        )
+        .await?;
         self.repository
             .insert(record)
             .await
@@ -232,21 +232,21 @@ fn build_snapshot(record: &StatusListRecord, token_exp_secs: u64) -> StatusListS
     }
 }
 
-#[cfg(any(
-    feature = "server",
-    feature = "postgres",
-    feature = "sqlite",
-    feature = "mysql"
-))]
-async fn persist_snapshot<H: StatusListHistoryRepository + ?Sized>(
-    history: &H,
+/// Pre-insert validation shared by both publish paths: the serialized-size
+/// limit and the existence pre-check. Kept in one place so the history-aware
+/// path cannot drift from the plain one.
+async fn check_publishable<R: StatusListRepository + ?Sized>(
+    repository: &R,
     record: &StatusListRecord,
-    token_exp_secs: u64,
+    max_serialized_list_size: usize,
 ) -> Result<(), UseCaseError> {
-    history
-        .insert(build_snapshot(record, token_exp_secs))
-        .await
-        .map_err(UseCaseError::Port)
+    if record.status_list.lst.len() > max_serialized_list_size {
+        return Err(UseCaseError::StatusListTooLarge);
+    }
+    if repository.find(&record.list_id).await?.is_some() {
+        return Err(UseCaseError::AlreadyExists);
+    }
+    Ok(())
 }
 
 #[cfg(any(
@@ -295,15 +295,35 @@ impl<R: StatusListRepository + ?Sized, H: StatusListHistoryRepository + ?Sized>
     }
 
     pub async fn execute(&self, record: StatusListRecord) -> Result<(), UseCaseError> {
-        // Reuse the single publish core (size guard, existence check, guarded
-        // insert), then record the snapshot on top.
-        PublishStatusList::new(self.repository.clone())
-            .with_max_serialized_list_size(self.max_serialized_list_size)
-            .execute(record.clone())
-            .await?;
+        // Same pre-checks as the history-free publish, shared so the two paths
+        // cannot drift apart.
+        check_publishable(
+            self.repository.as_ref(),
+            &record,
+            self.max_serialized_list_size,
+        )
+        .await?;
 
-        if let Some(history) = &self.history {
-            persist_snapshot(history.as_ref(), &record, self.token_exp_secs).await?;
+        // With history, the row insert and the snapshot covering its initial
+        // state must commit or fail as a unit (`insert_with_snapshot` wraps both
+        // in one transaction). Otherwise a published list can exist with no
+        // snapshot covering it — and unlike a failed update, no later write
+        // repairs that hole: §8.4 lookups over the opening window would 404
+        // forever. Without history there is no snapshot, so a plain insert does.
+        match &self.history {
+            Some(_) => {
+                let snapshot = build_snapshot(&record, self.token_exp_secs);
+                self.repository
+                    .insert_with_snapshot(record, snapshot)
+                    .await
+                    .map_err(map_insert_conflict)?;
+            }
+            None => {
+                self.repository
+                    .insert(record)
+                    .await
+                    .map_err(map_insert_conflict)?;
+            }
         }
 
         Ok(())
@@ -685,8 +705,11 @@ mod tests {
     async fn test_snapshot_iat_mirrors_record_updated_at() {
         let history = Arc::new(MemoryStatusListHistory::default());
         let token_exp_secs = 900u64;
+        // The publish path now writes the row and its snapshot through the
+        // repository in one unit, so the repo must share the history storage
+        // this test reads back from.
         let publish = PublishStatusListWithHistory::new(
-            Arc::new(MemoryStatusLists::default()),
+            Arc::new(MemoryStatusLists::default().with_history(history.as_ref())),
             history.clone(),
             token_exp_secs,
         );

--- a/src/ports/mod.rs
+++ b/src/ports/mod.rs
@@ -93,6 +93,33 @@ pub trait StatusListRepository: Send + Sync {
         status_list: StatusListRecord,
         expected_updated_at: i64,
     ) -> Result<bool, PortError>;
+    /// Atomically persist the guarded row update **and** its point-in-time
+    /// history snapshot: both writes commit, or neither does.
+    ///
+    /// This is the durability guarantee the plain [`update`](Self::update) plus
+    /// a separate history insert cannot give: there, a committed row update
+    /// followed by a failed snapshot insert leaves the row changed with no
+    /// snapshot recording the change. Implementations MUST perform both writes
+    /// inside a single backend transaction (portable across Postgres/MySQL/
+    /// SQLite) so that any snapshot-write failure rolls the row update back.
+    ///
+    /// Returns `false` when the optimistic guard did not match — identical
+    /// semantics to [`update`](Self::update), and the transaction is rolled back
+    /// so nothing is persisted. `status_list.updated_at` must be strictly
+    /// greater than `expected_updated_at`. Callers that keep no history use
+    /// [`update`](Self::update).
+    #[cfg(any(
+        feature = "server",
+        feature = "postgres",
+        feature = "sqlite",
+        feature = "mysql"
+    ))]
+    async fn update_with_snapshot(
+        &self,
+        status_list: StatusListRecord,
+        expected_updated_at: i64,
+        snapshot: StatusListSnapshot,
+    ) -> Result<bool, PortError>;
     async fn list_uris(&self) -> Result<Vec<String>, PortError>;
 }
 

--- a/src/ports/mod.rs
+++ b/src/ports/mod.rs
@@ -81,33 +81,24 @@ pub enum PortError {
 pub trait StatusListRepository: Send + Sync {
     async fn find(&self, list_id: &str) -> Result<Option<Arc<StatusListRecord>>, PortError>;
     async fn insert(&self, status_list: StatusListRecord) -> Result<(), PortError>;
-    /// Persist `status_list` only if the stored row still carries
-    /// `expected_updated_at` (optimistic concurrency).
-    ///
-    /// Returns `false` when the guard did not match — a racing writer already
-    /// advanced the stamp, or the row is gone. `status_list.updated_at` must be
-    /// strictly greater than `expected_updated_at`; see
+    /// Persists `status_list` only if the stored row still carries
+    /// `expected_updated_at` (optimistic concurrency). Returns `false` on a
+    /// guard miss (a racing writer advanced the stamp, or the row is gone).
+    /// `status_list.updated_at` must be strictly greater than
+    /// `expected_updated_at`; see
     /// [`next_updated_at`](crate::application::next_updated_at) for why.
     async fn update(
         &self,
         status_list: StatusListRecord,
         expected_updated_at: i64,
     ) -> Result<bool, PortError>;
-    /// Atomically persist the guarded row update **and** its point-in-time
-    /// history snapshot: both writes commit, or neither does.
-    ///
-    /// This is the durability guarantee the plain [`update`](Self::update) plus
-    /// a separate history insert cannot give: there, a committed row update
-    /// followed by a failed snapshot insert leaves the row changed with no
-    /// snapshot recording the change. Implementations MUST perform both writes
-    /// inside a single backend transaction (portable across Postgres/MySQL/
-    /// SQLite) so that any snapshot-write failure rolls the row update back.
-    ///
-    /// Returns `false` when the optimistic guard did not match — identical
-    /// semantics to [`update`](Self::update), and the transaction is rolled back
-    /// so nothing is persisted. `status_list.updated_at` must be strictly
-    /// greater than `expected_updated_at`. Callers that keep no history use
-    /// [`update`](Self::update).
+    /// Like [`update`](Self::update), but atomically persists the guarded row
+    /// update **and** its history snapshot: both commit or neither does.
+    /// Implementations MUST perform both writes in a single backend transaction
+    /// (portable across Postgres/MySQL/SQLite) so a failed snapshot insert rolls
+    /// the row update back — a guarantee `update` plus a separate insert cannot
+    /// give. Same `false`-on-guard-miss and strictly-advancing-stamp contract as
+    /// `update`; callers that keep no history use it instead.
     #[cfg(any(
         feature = "server",
         feature = "postgres",

--- a/src/ports/mod.rs
+++ b/src/ports/mod.rs
@@ -111,6 +111,26 @@ pub trait StatusListRepository: Send + Sync {
         expected_updated_at: i64,
         snapshot: StatusListSnapshot,
     ) -> Result<bool, PortError>;
+    /// Like [`insert`](Self::insert), but atomically persists the new row **and**
+    /// the snapshot covering its initial state: both commit or neither does.
+    /// Implementations MUST perform both writes in a single backend transaction,
+    /// for the same reason as
+    /// [`update_with_snapshot`](Self::update_with_snapshot) — a published list
+    /// whose initial snapshot is missing leaves a permanent hole in §8.4
+    /// resolution for the window it should have covered, and unlike a failed
+    /// update there is no later write that repairs it. A duplicate `list_id`
+    /// still surfaces as [`PortError::Conflict`], exactly as `insert` does.
+    #[cfg(any(
+        feature = "server",
+        feature = "postgres",
+        feature = "sqlite",
+        feature = "mysql"
+    ))]
+    async fn insert_with_snapshot(
+        &self,
+        status_list: StatusListRecord,
+        snapshot: StatusListSnapshot,
+    ) -> Result<(), PortError>;
     async fn list_uris(&self) -> Result<Vec<String>, PortError>;
 }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -41,6 +41,49 @@ impl Storage for MockStorage {
     }
 }
 
+/// A minimal valid status list record, for tests that need a record rather
+/// than a database.
+pub(crate) fn test_status_list_record(
+    issuer: &str,
+    list_id: &str,
+) -> crate::domain::StatusListRecord {
+    crate::domain::StatusListRecord {
+        list_id: list_id.to_string(),
+        issuer: crate::domain::Issuer(issuer.to_string()),
+        status_list: crate::domain::StatusList {
+            bits: 1,
+            lst: "initial".to_string(),
+        },
+        sub: format!("https://example.com/statuslists/{list_id}"),
+        updated_at: 1000,
+    }
+}
+
+/// A migrated in-memory SQLite connection, for tests that need real database
+/// behavior (transactions, constraints, rollback) rather than `MockDatabase`.
+///
+/// `max_connections(1)` mirrors the production SQLite setup in
+/// [`crate::state::build_state`]: an open transaction holds the only
+/// connection, so any query routed to the pool instead of the transaction
+/// handle deadlocks. Tests using this should bound themselves with a timeout so
+/// that failure mode surfaces as a named assertion rather than a hang.
+#[cfg(feature = "sqlite")]
+#[allow(dead_code)] // scaffolding for upcoming transactional snapshot tests
+pub(crate) async fn sqlite_connection() -> Arc<sea_orm::DatabaseConnection> {
+    use sea_orm_migration::MigratorTrait;
+
+    let mut opt = sea_orm::ConnectOptions::new("sqlite::memory:");
+    opt.max_connections(1);
+    opt.map_sqlx_sqlite_opts(|o| o.foreign_keys(true));
+    let db = sea_orm::Database::connect(opt)
+        .await
+        .expect("Failed to connect to SQLite");
+    crate::adapters::sea_orm::Migrator::up(&db, None)
+        .await
+        .expect("Failed to run migrations on SQLite");
+    Arc::new(db)
+}
+
 pub(crate) async fn test_app_state(db_conn: Option<Arc<sea_orm::DatabaseConnection>>) -> AppState {
     build_test_app_state(db_conn, None, 1_048_576).await
 }

--- a/src/web/handlers/status_list/update_status.rs
+++ b/src/web/handlers/status_list/update_status.rs
@@ -53,24 +53,18 @@ pub async fn update_status(
             return Err(StatusListError::Generic(msg).into());
         }
         Err(UseCaseError::Domain(domain::DomainError::CorruptStoredList(detail))) => {
-            // The stored `lst` failed to decode: corrupt persisted state, not a
-            // caller error. Log the detail at error level (this is the alert)
-            // and return 500 — never blame the client for our data corruption.
+            // Corrupt persisted state, not a caller error: log as the alert and
+            // return 500 rather than blaming the client.
             tracing::error!(list_id = ?list_id, %detail, "Corrupt stored status list");
             return Err(StatusListError::InternalServerError.into());
         }
         Err(UseCaseError::Domain(error)) => return Err(map_domain_error(error).into()),
         Err(UseCaseError::StatusListTooLarge) => return Err(StatusListError::StatusTooLarge.into()),
         Err(UseCaseError::Conflict) => {
-            // The optimistic guard in the use case did not match: a concurrent
-            // writer won the race (or the row was deleted). The use case returns
-            // before recording a snapshot or invalidating the cache, so nothing
-            // is persisted for a write that never landed.
-            //
-            // Logged at info, not warn: under contention an optimistic conflict
-            // is the expected, correct outcome, not an anomaly — warn would
-            // pollute dashboards and trip alerting during exactly the high-load
-            // bursts where conflicts are normal.
+            // Optimistic guard miss: a concurrent writer won the race and nothing
+            // was persisted. Logged at info, not warn — under contention a
+            // conflict is the expected outcome, and warn would trip alerting
+            // during exactly the high-load bursts where conflicts are normal.
             tracing::info!(list_id = ?list_id, "Concurrent update conflict; write rejected");
             return Err(StatusListError::UpdateConflict.into());
         }

--- a/src/web/handlers/status_list/update_status.rs
+++ b/src/web/handlers/status_list/update_status.rs
@@ -65,6 +65,13 @@ pub async fn update_status(
             // was persisted. Logged at info, not warn — under contention a
             // conflict is the expected outcome, and warn would trip alerting
             // during exactly the high-load bursts where conflicts are normal.
+            //
+            // Expected, but no longer free: now that the row update and its
+            // snapshot share one transaction, the winner holds the row lock
+            // until it commits, so the loser blocks on that lock before landing
+            // here rather than failing fast. Conflicts are still the normal
+            // outcome under contention; they just cost a lock wait, which is
+            // worth remembering when reading latency on a hot list.
             tracing::info!(list_id = ?list_id, "Concurrent update conflict; write rejected");
             return Err(StatusListError::UpdateConflict.into());
         }


### PR DESCRIPTION
## Summary

`update_status` performs two independent writes with no transaction around
them:
1. The guarded `UPDATE status_lists ... WHERE updated_at = ?` (the current row).
2. The `INSERT` into `status_list_history` (the point-in-time snapshot).

If the `UPDATE` succeeds and the history `INSERT` then fails, the row has changed but **no snapshot records the change**, and the handler returns 500.

## Acceptance criteria

- [ ] `UPDATE status_lists` and the `status_list_history` `INSERT` succeed or fail as a unit.
- [ ] A forced history-insert failure rolls back the row update (test: inject INSERT failure, assert the row is unchanged and no partial snapshot exists).
- [ ] The 409 conflict path still rolls back cleanly and records nothing.
- [ ] Behavior verified on Postgres, MySQL, and SQLite (transaction semantics are portable, but confirm the rollback path on at least MySQL + SQLite).