### PR TITLE
adding podcontainer security context

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -225,7 +225,9 @@ jobs:
         uses: azure/setup-helm@v3
 
       - name: Build Helm dependencies
-        run: helm dependency build helm/chart
+        run: |
+          helm repo add dandydeveloper https://dandydeveloper.github.io/charts
+          helm dependency build helm/chart
 
       - name: Render Helm template
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -221,11 +221,19 @@ jobs:
       - name: Fetch Repository
         uses: actions/checkout@v7
 
-      - name: Run Trivy config scan on Helm chart
+      - name: Setup Helm
+        uses: azure/setup-helm@v3
+
+      - name: Render Helm template
+        run: |
+          mkdir -p /tmp/rendered
+          helm template status-list-server helm/chart -f helm/chart/values.yaml --output-dir /tmp/rendered
+
+      - name: Run Trivy config scan
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: config
-          scan-ref: helm/chart
+          scan-ref: /tmp/rendered
           severity: HIGH,CRITICAL
           exit-code: 1
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -243,6 +243,34 @@ jobs:
           exit-code: 1
           trivyignores: .trivyignore.yaml
 
+  kube-linter:
+    name: KubeLinter Scan (Helm Chart)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch Repository
+        uses: actions/checkout@v7
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v3
+
+      - name: Build Helm dependencies
+        run: |
+          helm repo add dandydeveloper https://dandydeveloper.github.io/charts
+          helm dependency build helm/chart
+
+      - name: Render Helm template
+        run: |
+          mkdir -p /tmp/rendered
+          helm template status-list-server helm/chart -f helm/chart/values.yaml --output-dir /tmp/rendered
+
+      - name: Run KubeLinter
+        uses: stackrox/kube-linter-action@v1
+        with:
+          directory: /tmp/rendered
+          format: sarif
+          output: kube-linter-results.sarif
+
   yaml-lint:
     name: YAML Lint and Format Check
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -269,6 +269,7 @@ jobs:
         with:
           directory: /tmp/rendered
           format: sarif
+          config: .kube-linter.yaml
           output-file: kube-linter-results.sarif
 
   yaml-lint:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -224,6 +224,9 @@ jobs:
       - name: Setup Helm
         uses: azure/setup-helm@v3
 
+      - name: Build Helm dependencies
+        run: helm dependency build helm/chart
+
       - name: Render Helm template
         run: |
           mkdir -p /tmp/rendered

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -269,7 +269,7 @@ jobs:
         with:
           directory: /tmp/rendered
           format: sarif
-          output: kube-linter-results.sarif
+          output-file: kube-linter-results.sarif
 
   yaml-lint:
     name: YAML Lint and Format Check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -241,6 +241,7 @@ jobs:
           scan-ref: /tmp/rendered
           severity: HIGH,CRITICAL
           exit-code: 1
+          trivyignores: .trivyignore.yaml
 
   yaml-lint:
     name: YAML Lint and Format Check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -222,7 +222,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Run Trivy config scan on Helm chart
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: config
           scan-ref: helm/chart

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -213,6 +213,22 @@ jobs:
         with:
           globs: "**/*.md"
 
+  trivy-config:
+    name: Trivy Config Scan (Helm Chart)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch Repository
+        uses: actions/checkout@v7
+
+      - name: Run Trivy config scan on Helm chart
+        uses: aquasecurity/trivy-action@0.30.0
+        with:
+          scan-type: config
+          scan-ref: helm/chart
+          severity: HIGH,CRITICAL
+          exit-code: 1
+
   yaml-lint:
     name: YAML Lint and Format Check
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,6 +31,7 @@ jobs:
     name: Cargo Build
     runs-on: ubuntu-latest
     needs: cargo-fmt
+    timeout-minutes: 45
 
     steps:
       - name: Fetch Repository
@@ -109,6 +110,7 @@ jobs:
     if: ${{ needs.check-crate-type.outputs.is_lib == 'true' }}
     name: Cargo test doc
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - name: Fetch Repository

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -239,7 +239,7 @@ jobs:
         with:
           scan-type: config
           scan-ref: /tmp/rendered
-          severity: CRITICAL
+          severity: HIGH,CRITICAL
           exit-code: 1
 
   yaml-lint:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -239,7 +239,7 @@ jobs:
         with:
           scan-type: config
           scan-ref: /tmp/rendered
-          severity: HIGH,CRITICAL
+          severity: CRITICAL
           exit-code: 1
 
   yaml-lint:

--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -1,7 +1,10 @@
 checks:
   exclude:
-    # Subchart containers (postgres, redis-ha) do not set read-only root fs.
+    # Subchart containers (postgres, redis-ha) use template-level defaults
+    # that don't set cpu/memory resources or read-only root fs.
     # These are third-party packaged charts we cannot modify.
+    - "unset-cpu-requirements"
+    - "unset-memory-requirements"
     - "no-read-only-root-fs"
     # Redis HA announce services use pod-name-specific selectors intentionally.
     - "dangling-service"

--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -1,0 +1,12 @@
+checks:
+  exclude:
+    # Subchart containers (postgres, redis-ha) do not set read-only root fs.
+    # These are third-party packaged charts we cannot modify.
+    - "no-read-only-root-fs"
+    # Redis HA announce services use pod-name-specific selectors intentionally.
+    - "dangling-service"
+    # APP_AWS__SECRETS_CACHE_TTL is a cache TTL, not a plaintext secret value.
+    - "env-var-secret"
+    # The status-list-server:latest and init container busybox images are
+    # template defaults overridden by CI tag injection at deploy time.
+    - "latest-tag"

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,8 @@
+misconfigurations:
+  - id: KSV-0014
+    paths:
+      - "*/charts/postgres*/**"
+      - "*/charts/redis-ha*/**"
+  - id: KSV-0118
+    paths:
+      - "*/charts/redis-ha*/**"

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,8 +1,8 @@
 misconfigurations:
-  - id: KSV-0014
+  - id: AVD-KSV-0014
     paths:
       - "*/charts/postgres*/**"
       - "*/charts/redis-ha*/**"
-  - id: KSV-0118
+  - id: AVD-KSV-0118
     paths:
       - "*/charts/redis-ha*/**"

--- a/helm/chart/templates/deployment.yaml
+++ b/helm/chart/templates/deployment.yaml
@@ -100,8 +100,10 @@ spec:
                   key: redis-password
             - name: APP_REDIS__URI
               value: {{ include "status-list-server-chart.redisUri" . | quote }}
-          {{- if .Values.secretStore.enabled }}
           volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          {{- if .Values.secretStore.enabled }}
             - name: aws-credentials-volume
               mountPath: /home/nobody/.aws
               readOnly: true

--- a/helm/chart/templates/deployment.yaml
+++ b/helm/chart/templates/deployment.yaml
@@ -24,6 +24,9 @@ spec:
                 "readOnlyRootFilesystem" true
                 "allowPrivilegeEscalation" false
                 "capabilities" (dict "drop" (list "ALL")))
+              "resources" (dict
+                "requests" (dict "cpu" "50m" "memory" "64Mi")
+                "limits" (dict "cpu" "100m" "memory" "128Mi"))
               "volumeMounts" (list (dict "name" "tmp" "mountPath" "/tmp")) }}
         - {{- tpl (toYaml (mustMergeOverwrite $ic $hardened)) $ | nindent 10 }}
         {{- end }}

--- a/helm/chart/templates/deployment.yaml
+++ b/helm/chart/templates/deployment.yaml
@@ -19,16 +19,13 @@ spec:
       {{- with .Values.statuslist.initContainers }}
       initContainers:
         {{- range $ic := . }}
-        - {{- tpl (toYaml $ic) $ | nindent 10 }}
-          securityContext:
-            readOnlyRootFilesystem: true
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-          volumeMounts:
-            - name: tmp
-              mountPath: /tmp
+        {{- $hardened := dict
+              "securityContext" (dict
+                "readOnlyRootFilesystem" true
+                "allowPrivilegeEscalation" false
+                "capabilities" (dict "drop" (list "ALL")))
+              "volumeMounts" (list (dict "name" "tmp" "mountPath" "/tmp")) }}
+        - {{- tpl (toYaml (mustMergeOverwrite $ic $hardened)) $ | nindent 10 }}
         {{- end }}
       {{- end }}
       securityContext:
@@ -46,6 +43,8 @@ spec:
             capabilities:
               drop:
                 - ALL
+            seccompProfile:
+              type: RuntimeDefault
           image: {{ .Values.statuslist.image.repository }}:{{ .Values.statuslist.image.tag }}
           imagePullPolicy: {{ .Values.statuslist.image.pullPolicy }}
           ports:
@@ -88,6 +87,10 @@ spec:
             {{- if .Values.secretStore.enabled }}
             - name: APP_AWS__REGION
               value: {{ .Values.secretStore.aws.region | quote }}
+            - name: AWS_SHARED_CREDENTIALS_FILE
+              value: /home/nobody/.aws/credentials
+            - name: AWS_CONFIG_FILE
+              value: /home/nobody/.aws/config
             {{- end }}
             - name: POSTGRES_DB
               value: {{ .Values.postgres.auth.database | quote }}

--- a/helm/chart/templates/deployment.yaml
+++ b/helm/chart/templates/deployment.yaml
@@ -20,14 +20,39 @@ spec:
       initContainers:
         {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: {{ include "status-list-server-chart.name" . }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           image: {{ .Values.statuslist.image.repository }}:{{ .Values.statuslist.image.tag }}
           imagePullPolicy: {{ .Values.statuslist.image.pullPolicy }}
           ports:
             - name: http
               containerPort: {{ .Values.statuslist.service.targetPort | int }}
               protocol: TCP
+          {{- with .Values.statuslist.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.statuslist.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.statuslist.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             {{- $env := dict }}
             {{- range $name, $value := .Values.statuslist.env }}
@@ -67,7 +92,7 @@ spec:
           {{- if .Values.secretStore.enabled }}
           volumeMounts:
             - name: aws-credentials-volume
-              mountPath: /root/.aws
+              mountPath: /home/nobody/.aws
               readOnly: true
           {{- end }}
       {{- if .Values.secretStore.enabled }}

--- a/helm/chart/templates/deployment.yaml
+++ b/helm/chart/templates/deployment.yaml
@@ -18,7 +18,18 @@ spec:
     spec:
       {{- with .Values.statuslist.initContainers }}
       initContainers:
-        {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- range $ic := . }}
+        - {{- tpl (toYaml $ic) $ | nindent 10 }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+        {{- end }}
       {{- end }}
       securityContext:
         runAsNonRoot: true
@@ -95,8 +106,10 @@ spec:
               mountPath: /home/nobody/.aws
               readOnly: true
           {{- end }}
-      {{- if .Values.secretStore.enabled }}
       volumes:
+        - name: tmp
+          emptyDir: {}
+      {{- if .Values.secretStore.enabled }}
         - name: aws-credentials-volume
           secret:
             secretName: aws-credentials-secret

--- a/helm/chart/templates/deployment.yaml
+++ b/helm/chart/templates/deployment.yaml
@@ -114,6 +114,26 @@ spec:
               mountPath: /home/nobody/.aws
               readOnly: true
           {{- end }}
+        {{- if and .Values.otelCollector.enabled .Values.otelCollector.sidecar.enabled }}
+        - name: otel-collector
+          image: {{ .Values.otelCollector.sidecar.image.repository }}:{{ .Values.otelCollector.sidecar.image.tag }}
+          args: ["--config", "/etc/otelcol/config.yaml"]
+          ports:
+            - name: otlp-grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+          volumeMounts:
+            - name: otel-collector-config
+              mountPath: /etc/otelcol
+              readOnly: true
+          {{- with .Values.otelCollector.sidecar.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
       volumes:
         - name: tmp
           emptyDir: {}
@@ -121,5 +141,10 @@ spec:
         - name: aws-credentials-volume
           secret:
             secretName: aws-credentials-secret
+      {{- end }}
+      {{- if and .Values.otelCollector.enabled .Values.otelCollector.sidecar.enabled }}
+        - name: otel-collector-config
+          configMap:
+            name: {{ include "status-list-server-chart.fullname" . }}-otel-collector-config
       {{- end }}
 {{- end }}

--- a/helm/chart/templates/network-policy.yaml
+++ b/helm/chart/templates/network-policy.yaml
@@ -40,4 +40,9 @@ spec:
           protocol: TCP
         - port: 53
           protocol: UDP
+    - ports:
+        - port: 4317
+          protocol: TCP
+        - port: 4318
+          protocol: TCP
 {{- end }}

--- a/helm/chart/templates/network-policy.yaml
+++ b/helm/chart/templates/network-policy.yaml
@@ -32,6 +32,8 @@ spec:
         - port: 443
           protocol: TCP
         - port: 53
+          protocol: TCP
+        - port: 53
           protocol: UDP
       {{- with .Values.statuslist.networkPolicy.egress }}
       to:

--- a/helm/chart/templates/network-policy.yaml
+++ b/helm/chart/templates/network-policy.yaml
@@ -29,14 +29,15 @@ spec:
           protocol: TCP
         - port: 6380
           protocol: TCP
+      {{- with .Values.statuslist.networkPolicy.egressInternal }}
+      to:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    - ports:
         - port: 443
           protocol: TCP
         - port: 53
           protocol: TCP
         - port: 53
           protocol: UDP
-      {{- with .Values.statuslist.networkPolicy.egress }}
-      to:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
 {{- end }}

--- a/helm/chart/templates/network-policy.yaml
+++ b/helm/chart/templates/network-policy.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.statuslist.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "status-list-server-chart.fullname" . }}-network-policy
+  labels:
+    {{- include "status-list-server-chart.labels" . | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "status-list-server-chart.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        - port: {{ .Values.statuslist.service.targetPort | int }}
+          protocol: TCP
+      {{- with .Values.statuslist.networkPolicy.ingress }}
+      from:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  egress:
+    - ports:
+        - port: 5432
+          protocol: TCP
+        - port: 6379
+          protocol: TCP
+        - port: 6380
+          protocol: TCP
+        - port: 443
+          protocol: TCP
+        - port: 53
+          protocol: UDP
+      {{- with .Values.statuslist.networkPolicy.egress }}
+      to:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/helm/chart/templates/otel-collector-configmap.yaml
+++ b/helm/chart/templates/otel-collector-configmap.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.otelCollector.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "status-list-server-chart.fullname" . }}-otel-collector-config
+  labels:
+    {{- include "status-list-server-chart.labels" . | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
+data:
+  config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+    processors:
+      batch:
+        timeout: 5s
+        send_batch_size: 1024
+    exporters:
+      otlp/backend:
+        endpoint: {{ .Values.otelCollector.config.exporters.otlpEndpoint | quote }}
+        tls:
+          insecure: true
+      debug:
+        verbosity: basic
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [otlp/backend, debug]
+        logs:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [debug]
+{{- end }}

--- a/helm/chart/templates/otel-collector-deployment.yaml
+++ b/helm/chart/templates/otel-collector-deployment.yaml
@@ -1,0 +1,68 @@
+{{- if and .Values.otelCollector.enabled .Values.otelCollector.standalone.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "status-list-server-chart.fullname" . }}-otel-collector
+  labels:
+    {{- include "status-list-server-chart.labels" . | nindent 4 }}
+    app.kubernetes.io/component: otel-collector
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.otelCollector.standalone.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: otel-collector
+      {{- include "status-list-server-chart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: otel-collector
+        {{- include "status-list-server-chart.labels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: otel-collector
+          image: {{ .Values.otelCollector.standalone.image.repository }}:{{ .Values.otelCollector.standalone.image.tag }}
+          args: ["--config", "/etc/otelcol/config.yaml"]
+          ports:
+            - name: otlp-grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+          volumeMounts:
+            - name: config
+              mountPath: /etc/otelcol
+              readOnly: true
+          {{- with .Values.otelCollector.standalone.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "status-list-server-chart.fullname" . }}-otel-collector-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "status-list-server-chart.fullname" . }}-otel-collector
+  labels:
+    {{- include "status-list-server-chart.labels" . | nindent 4 }}
+    app.kubernetes.io/component: otel-collector
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: {{ .Values.otelCollector.standalone.service.type }}
+  ports:
+    - name: otlp-grpc
+      port: {{ .Values.otelCollector.standalone.service.grpcPort }}
+      targetPort: 4317
+      protocol: TCP
+    - name: otlp-http
+      port: {{ .Values.otelCollector.standalone.service.httpPort }}
+      targetPort: 4318
+      protocol: TCP
+  selector:
+    app.kubernetes.io/component: otel-collector
+    {{- include "status-list-server-chart.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/chart/templates/redis-ha-cert-sync.yaml
+++ b/helm/chart/templates/redis-ha-cert-sync.yaml
@@ -97,7 +97,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: redis-cert-sync
-              image: bitnami/kubectl:latest
+              image: bitnami/kubectl:1.31
               imagePullPolicy: IfNotPresent
               securityContext:
                 readOnlyRootFilesystem: true

--- a/helm/chart/templates/redis-ha-cert-sync.yaml
+++ b/helm/chart/templates/redis-ha-cert-sync.yaml
@@ -99,6 +99,13 @@ spec:
             - name: redis-cert-sync
               image: bitnami/kubectl:1.31
               imagePullPolicy: IfNotPresent
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  cpu: 100m
+                  memory: 128Mi
               securityContext:
                 readOnlyRootFilesystem: true
                 allowPrivilegeEscalation: false

--- a/helm/chart/templates/redis-ha-cert-sync.yaml
+++ b/helm/chart/templates/redis-ha-cert-sync.yaml
@@ -88,10 +88,23 @@ spec:
         spec:
           serviceAccountName: redis-cert-sync-sa
           restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            fsGroup: 65534
+            seccompProfile:
+              type: RuntimeDefault
           containers:
             - name: redis-cert-sync
               image: bitnami/kubectl:latest
               imagePullPolicy: IfNotPresent
+              securityContext:
+                readOnlyRootFilesystem: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
               env:
                 - name: NAMESPACE
                   valueFrom:

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -98,6 +98,11 @@ statuslist:
     APP_LIMITS__MAX_STATUS_INDEX: "100000"
     APP_LIMITS__MAX_STATUSES_PER_REQUEST: "5000"
     APP_LIMITS__MAX_SERIALIZED_LIST_SIZE: "1048576"
+    # Telemetry / OpenTelemetry
+    APP_TELEMETRY__ENVIRONMENT: "production"
+    APP_TELEMETRY__OTLP_ENDPOINT: "http://localhost:4317"
+    APP_TELEMETRY__ENABLED: "true"
+    APP_TELEMETRY__SAMPLER_RATIO: "1.0"
   livenessProbe:
     httpGet:
       path: /health
@@ -242,3 +247,38 @@ redis-ha:
 
 redis:
   enabled: true
+
+otelCollector:
+  enabled: false
+  sidecar:
+    enabled: false
+    image:
+      repository: otel/opentelemetry-collector-contrib
+      tag: "0.156.0"
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "50m"
+      limits:
+        memory: "128Mi"
+        cpu: "100m"
+  standalone:
+    enabled: false
+    replicaCount: 1
+    image:
+      repository: otel/opentelemetry-collector-contrib
+      tag: "0.156.0"
+    service:
+      type: ClusterIP
+      grpcPort: 4317
+      httpPort: 4318
+    resources:
+      requests:
+        memory: "128Mi"
+        cpu: "100m"
+      limits:
+        memory: "256Mi"
+        cpu: "200m"
+  config:
+    exporters:
+      otlpEndpoint: "jaeger-collector:4317"

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -116,10 +116,12 @@ statuslist:
     failureThreshold: 3
   networkPolicy:
     enabled: true
-    # Restrict ingress to specific namespaces or CIDR blocks
+    # When ingress is empty [], ANY source can reach the service port (port-only restriction).
+    # Add podSelector/namespaceSelector/ipBlock entries to restrict sources.
     ingress: []
-    # Restrict egress to specific destinations (e.g., PostgreSQL, Redis, AWS API)
-    egress: []
+    # Restrict egress for internal ports (5432, 6379, 6380) to specific destinations.
+    # External ports (443, 53) are always allowed without destination restriction.
+    egressInternal: []
   resources:
     requests:
       memory: "256Mi"

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -5,7 +5,7 @@ statuslist:
   enabled: true
   initContainers:
     - name: wait-for-postgres
-      image: busybox
+      image: busybox:1.37
       command:
         - "sh"
         - "-c"
@@ -18,7 +18,7 @@ statuslist:
           echo "Postgres is up."
 
     - name: wait-for-redis
-      image: busybox
+      image: busybox:1.37
       command:
         - "sh"
         - "-c"
@@ -132,6 +132,13 @@ statuslist:
 
 postgres:
   enabled: true
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
   auth:
     username: postgres
     database: status-list
@@ -178,6 +185,13 @@ secretStore:
 redis-ha:
   enabled: true
   externalDnsHostname: redis.eudi-adorsys.com
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+    limits:
+      cpu: 500m
+      memory: 700Mi
   image:
     repository: docker.io/redis
     tag: 8.2
@@ -208,6 +222,13 @@ redis-ha:
   haproxy:
     enabled: true
     replicas: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
     tls:
       enabled: true
       secretName: statuslist-haproxy-tls

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -116,7 +116,9 @@ statuslist:
     failureThreshold: 3
   networkPolicy:
     enabled: true
+    # Restrict ingress to specific namespaces or CIDR blocks
     ingress: []
+    # Restrict egress to specific destinations (e.g., PostgreSQL, Redis, AWS API)
     egress: []
   resources:
     requests:

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -98,6 +98,26 @@ statuslist:
     APP_LIMITS__MAX_STATUS_INDEX: "100000"
     APP_LIMITS__MAX_STATUSES_PER_REQUEST: "5000"
     APP_LIMITS__MAX_SERIALIZED_LIST_SIZE: "1048576"
+  livenessProbe:
+    httpGet:
+      path: /health
+      port: http
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: http
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+  networkPolicy:
+    enabled: true
+    ingress: []
+    egress: []
   resources:
     requests:
       memory: "256Mi"


### PR DESCRIPTION
The implementation render `runAsNonRoot`, `runAsUser: 65534`, `readOnlyRootFilesystem`,  `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, `seccompProfile: RuntimeDefault`; wire `resources`; add probes; fix creds mount path; add `NetworkPolicy`.

- Have added `trivy config` on the chart (catches all of the above);  and `kube-linter` for
  chart-specific.


Was complited:
 
- [x] Add container + pod `securityContext`
- [x] Render `resources` into the container spec
- [x] Add liveness/readiness probes
- [x] Fix AWS-creds mount path for UID 65534
- [x] Add `NetworkPolicy`
- [x] Add `trivy config` CI job