### PR TITLE
fix: hide DB error details from HTTP response bodies (#453)

### DIFF
--- a/src/web/errors.rs
+++ b/src/web/errors.rs
@@ -7,7 +7,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::database::error::RepositoryError;
+use crate::adapters::sea_orm::error::RepositoryError;
 use crate::web::auth::errors::AuthenticationError;
 use crate::web::handlers::issue_credential::CredentialError;
 use crate::web::handlers::status_list::error::StatusListError;
@@ -89,7 +89,6 @@ impl From<CredentialError> for ApiError {
                 "internal_error",
                 "The server encountered an unexpected error.",
             ),
-            CredentialError::RepoError(err) => ApiError::from(err),
         }
     }
 }

--- a/src/web/errors.rs
+++ b/src/web/errors.rs
@@ -7,6 +7,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 
+use crate::database::error::RepositoryError;
 use crate::web::auth::errors::AuthenticationError;
 use crate::web::handlers::issue_credential::CredentialError;
 use crate::web::handlers::status_list::error::StatusListError;
@@ -88,6 +89,30 @@ impl From<CredentialError> for ApiError {
                 "internal_error",
                 "The server encountered an unexpected error.",
             ),
+            CredentialError::RepoError(err) => ApiError::from(err),
+        }
+    }
+}
+
+impl From<RepositoryError> for ApiError {
+    fn from(err: RepositoryError) -> Self {
+        tracing::error!(error = %err, "repository error");
+        let (status, error_code, description) = match &err {
+            RepositoryError::DuplicateEntry => (
+                StatusCode::CONFLICT,
+                Cow::Borrowed("duplicate_entry"),
+                "A duplicate entry was detected.",
+            ),
+            _ => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Cow::Borrowed("internal_error"),
+                "An internal error occurred.",
+            ),
+        };
+        Self {
+            status,
+            error: error_code,
+            error_description: Some(description.to_string()),
         }
     }
 }
@@ -152,5 +177,27 @@ mod tests {
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(json["error"], "test_error");
         assert!(json.get("status").is_none());
+    }
+
+    #[test]
+    fn test_repository_error_does_not_leak_db_details() {
+        let db_error_message = "DbErr: error connecting: server error? details: host=secret-db password=supersecret user=admin";
+        let repo_error = RepositoryError::Generic(db_error_message.to_string());
+        let error = ApiError::from(repo_error);
+        let response = error.into_response();
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        let body = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(async { to_bytes(response.into_body(), usize::MAX).await.unwrap() });
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&body_str).unwrap();
+
+        assert_eq!(json["error"], "internal_error");
+        assert!(!body_str.contains("secret-db"));
+        assert!(!body_str.contains("supersecret"));
+        assert!(!body_str.contains("DbErr"));
+        assert!(!body_str.contains("host="));
     }
 }

--- a/src/web/errors.rs
+++ b/src/web/errors.rs
@@ -178,8 +178,8 @@ mod tests {
         assert!(json.get("status").is_none());
     }
 
-    #[test]
-    fn test_repository_error_does_not_leak_db_details() {
+    #[tokio::test]
+    async fn test_repository_error_does_not_leak_db_details() {
         let db_error_message = "DbErr: error connecting: server error? details: host=secret-db password=supersecret user=admin";
         let repo_error = RepositoryError::Generic(db_error_message.to_string());
         let error = ApiError::from(repo_error);
@@ -187,11 +187,9 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
 
-        let body = tokio::runtime::Runtime::new()
-            .unwrap()
-            .block_on(async { to_bytes(response.into_body(), usize::MAX).await.unwrap() });
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         let body_str = String::from_utf8(body.to_vec()).unwrap();
-        let json: serde_json::Value = serde_json::from_str(&body_str).unwrap();
 
         assert_eq!(json["error"], "internal_error");
         assert!(!body_str.contains("secret-db"));


### PR DESCRIPTION
closes #453 by:

- Replace `err.to_string()` in `From<RepositoryError> for ApiError` with opaque "An internal error occurred." message
- Keep `tracing::error!` logging the full RepositoryError for server-side diagnostics
- `DuplicateEntry` case returns "A duplicate entry was detected." - no DB schema text
- Added test `test_repository_error_does_not_leak_db_details` verifying no DB/constraint details in response body

**Acceptance criteria:**
- `RepositoryError` surfaced to client produces opaque body, not raw DB text
- Full error detail is still logged server-side  
- Test asserts response body contains no schema/constraint text