### PR TITLE
Duplicate key classification is unverified on my sql and postgres

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,7 +1,30 @@
-[test-groups]
-container-backed = { max-threads = 4 }
+# Container-backed tests must not run concurrently with each other.
+#
+# Two suites start real Docker containers: the SQL backend proofs, one database
+# per test (`src/outbound/sql/test_containers.rs`), and the ACME provisioning
+# tests, which start four apiece — pebble, challtestsrv, localstack and redis
+# (`tests/cert_provisioning.rs`). nextest runs tests in parallel by default, so
+# unconstrained these try to boot a dozen servers at once and starve each other
+# of CPU during init. The failures land *before* any test code runs and look
+# nothing like the code under test: MySQL reports
+# `WaitContainer(StartupTimeout)`, and the ACME tests time out waiting on
+# pebble. Both are pure scheduling artefacts.
+#
+# Serialising the group trades wall-clock time for determinism, which is the
+# right trade for tests whose entire purpose is proving real-backend behaviour.
+[test-groups.containers]
+max-threads = 1
 
 [[profile.default.overrides]]
-filter = 'test(test_mysql_) | test(test_postgres_) | test(cert_provisioning)'
-test-group = 'container-backed'
+# `test(...)` matches the SQL fixtures' callers by name; `binary(...)` catches
+# the whole ACME integration suite. The name match also sweeps in
+# `config::tests::test_mysql_backend_config`, a pure deserialisation check
+# costing microseconds, so the imprecision is free.
+#
+# Keep `mysql` or `postgres` in the name of any new database-backed test, and
+# confirm membership with `cargo nextest show-config test-groups`.
+filter = 'test(mysql) or test(postgres) or binary(cert_provisioning)'
+test-group = 'containers'
+# A container that never becomes ready would otherwise hang the run: fail the
+# test after two 2m periods rather than waiting on the job timeout.
 slow-timeout = { period = "2m", terminate-after = 2, grace-period = "10s" }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -10,9 +10,22 @@ info:
     and allows credential issuers to register, publish, and update status lists.
     Relying parties can retrieve status list tokens in JWT or CWT format.
 
-    Error responses are modelled as RFC 7807 problem details
-    (`application/problem+json`). This is the canonical error format intended
-    for the API; individual endpoints may migrate to this format over time.
+    Error responses are JSON objects of the form
+    `{"error": "<code>", "error_description": "<human-readable text>"}`, served
+    as `application/json` with `Cache-Control: no-store, max-age=0`. The
+    `error` field is a stable machine-readable identifier and is the field
+    clients should branch on — the HTTP status alone is not sufficient, since
+    (for example) `409` covers both `status_list_already_exists` and
+    `update_conflict`. `error_description` is for humans and its wording is not
+    part of the contract.
+
+    Two endpoints predate this shape and still return plain text: see the
+    `UnprocessableEntity` and `TooManyRequests` responses below.
+
+    > **Note:** RFC 7807 problem details (`application/problem+json`) are the
+    > intended long-term format for the whole API. Adoption is tracked in issue
+    > #156; until it lands, the schema documented here is what the server
+    > actually sends.
 
     Status list tokens are signed by the server and delivered as
     `application/statuslist+jwt` or `application/statuslist+cwt`. JWT-format
@@ -364,9 +377,9 @@ paths:
               schema:
                 type: string
                 format: binary
-              description: |
-                Raw COSE_Sign1_Tagged CBOR bytes (CBOR tag 18). Never
-                gzip-compressed regardless of the request's `Accept-Encoding`.
+                description: |
+                  Raw COSE_Sign1_Tagged CBOR bytes (CBOR tag 18). Never
+                  gzip-compressed regardless of the request's `Accept-Encoding`.
               example: "0gEAAQ..."
           headers:
             Content-Encoding:
@@ -592,35 +605,60 @@ components:
             - "https://statuslist.example.com/api/v1/status-lists/477121aa-b598-419e-916f-1e74654ff38b"
             - "https://statuslist.example.com/api/v1/status-lists/8e4ebb4a-dd79-498f-ac97-966f22884037"
 
-    ProblemDetails:
+    ErrorResponse:
       type: object
       description: |
-        RFC 7807 problem details object. Error responses use
-        `application/problem+json` where applicable.
+        The error body returned by every JSON error response. Serialized from
+        `server::error::ErrorResponse`.
+
+        RFC 7807 problem details are the intended long-term replacement
+        (issue #156); this schema documents the current wire format.
+      required:
+        - error
       properties:
-        type:
+        error:
           type: string
-          format: uri
-          description: A URI reference that identifies the problem type.
-          default: "about:blank"
-          example: "about:blank"
-        title:
+          description: |
+            Stable machine-readable error identifier. Branch on this rather
+            than on the HTTP status, which is not unique across error kinds.
+          enum:
+            # 400
+            - invalid_list_id
+            - invalid_query
+            - invalid_input
+            - invalid_index
+            - invalid_historical_time
+            - invalid_public_jwk
+            - too_many_statuses
+            - index_too_large
+            # 401 — emitted by the authentication middleware
+            - invalid_auth_header
+            - jwt_error
+            - unsupported_algorithm
+            - issuer_not_found
+            # 403
+            - issuer_mismatch
+            # 404
+            - status_list_not_found
+            - historical_status_list_not_found
+            # 406
+            - invalid_accept_header
+            # 409
+            - status_list_already_exists
+            - credentials_already_exist
+            - update_conflict
+            # 422
+            - status_too_large
+            # 500 / 503
+            - internal_error
+            - service_unavailable
+          example: "status_list_already_exists"
+        error_description:
           type: string
-          description: Short, human-readable summary of the problem.
-          example: "Bad Request"
-        status:
-          type: integer
-          description: HTTP status code.
-          example: 400
-        detail:
-          type: string
-          description: Human-readable explanation of the error.
-          example: "Invalid list ID string"
-        instance:
-          type: string
-          format: uri
-          description: URI reference that identifies the specific occurrence.
-          example: "/api/v1/status-lists/invalid-uuid/statuses"
+          description: |
+            Human-readable explanation. Omitted when absent; wording is not
+            part of the contract and may change without notice.
+          example: "Status list already exists"
 
   responses:
     BadRequest:
@@ -636,80 +674,62 @@ components:
             (default 100000) — `Status index <n> exceeds the configured
             maximum`.
       content:
-        application/problem+json:
+        application/json:
           schema:
-            $ref: "#/components/schemas/ProblemDetails"
+            $ref: "#/components/schemas/ErrorResponse"
           example:
-            type: "about:blank"
-            title: "Bad Request"
-            status: 400
-            detail: "Too many statuses in request: 6000 > 5000"
-            instance: "/api/v1/status-lists/477121aa-b598-419e-916f-1e74654ff38b/statuses"
+            error: "too_many_statuses"
+            error_description: "too many statuses in request: 6000 > 5000"
 
     Unauthorized:
       description: Missing or invalid authentication token
       content:
-        application/problem+json:
+        application/json:
           schema:
-            $ref: "#/components/schemas/ProblemDetails"
+            $ref: "#/components/schemas/ErrorResponse"
           example:
-            type: "about:blank"
-            title: "Unauthorized"
-            status: 401
-            detail: "Missing or invalid Authorization header"
-            instance: "/api/v1/status-lists/477121aa-b598-419e-916f-1e74654ff38b/statuses"
+            error: "invalid_auth_header"
+            error_description: "Missing or invalid Authorization header"
 
     Forbidden:
       description: Insufficient permissions to access the resource
       content:
-        application/problem+json:
+        application/json:
           schema:
-            $ref: "#/components/schemas/ProblemDetails"
+            $ref: "#/components/schemas/ErrorResponse"
           example:
-            type: "about:blank"
-            title: "Forbidden"
-            status: 403
-            detail: "Issuer mismatch"
-            instance: "/api/v1/status-lists/477121aa-b598-419e-916f-1e74654ff38b/statuses"
+            error: "issuer_mismatch"
+            error_description: "Issuer does not own the status list"
 
     NotFound:
       description: Resource not found
       content:
-        application/problem+json:
+        application/json:
           schema:
-            $ref: "#/components/schemas/ProblemDetails"
+            $ref: "#/components/schemas/ErrorResponse"
           example:
-            type: "about:blank"
-            title: "Not Found"
-            status: 404
-            detail: "Status list not found"
-            instance: "/api/v1/status-lists/477121aa-b598-419e-916f-1e74654ff38b/statuses"
+            error: "status_list_not_found"
+            error_description: "Status list was not found"
 
     NotAcceptable:
       description: Requested response format not supported
       content:
-        application/problem+json:
+        application/json:
           schema:
-            $ref: "#/components/schemas/ProblemDetails"
+            $ref: "#/components/schemas/ErrorResponse"
           example:
-            type: "about:blank"
-            title: "Not Acceptable"
-            status: 406
-            detail: "Invalid accept header"
-            instance: "/statuslists/477121aa-b598-419e-916f-1e74654ff38b"
+            error: "invalid_accept_header"
+            error_description: "Invalid accept header"
 
     Conflict:
       description: Resource already exists
       content:
-        application/problem+json:
+        application/json:
           schema:
-            $ref: "#/components/schemas/ProblemDetails"
+            $ref: "#/components/schemas/ErrorResponse"
           example:
-            type: "about:blank"
-            title: "Conflict"
-            status: 409
-            detail: "Status list already exists"
-            instance: "/api/v1/status-lists/477121aa-b598-419e-916f-1e74654ff38b/statuses"
+            error: "status_list_already_exists"
+            error_description: "Status list already exists"
 
     PayloadTooLarge:
       description: |
@@ -756,16 +776,16 @@ components:
         this write (optimistic-concurrency conflict): another writer's update
         landed first, so this request was rejected rather than silently
         overwriting it. The client should re-read the current state and retry.
+
+        Distinguished from the publish conflict by the `error` code: this
+        response carries `update_conflict`, not `status_list_already_exists`.
       content:
-        application/problem+json:
+        application/json:
           schema:
-            $ref: "#/components/schemas/ProblemDetails"
+            $ref: "#/components/schemas/ErrorResponse"
           example:
-            type: "about:blank"
-            title: "Conflict"
-            status: 409
-            detail: "the status list was modified concurrently; re-read the current state and retry"
-            instance: "/api/v1/status-lists/477121aa-b598-419e-916f-1e74654ff38b/statuses"
+            error: "update_conflict"
+            error_description: "The status list was modified concurrently"
 
     UpdateInternalServerError:
       description: |
@@ -779,38 +799,29 @@ components:
         another writer got there first. A `409` requires re-reading the current
         state before retrying; a `500` does not.
       content:
-        application/problem+json:
+        application/json:
           schema:
-            $ref: "#/components/schemas/ProblemDetails"
+            $ref: "#/components/schemas/ErrorResponse"
           example:
-            type: "about:blank"
-            title: "Internal Server Error"
-            status: 500
-            detail: "Internal server error"
-            instance: "/api/v1/status-lists/477121aa-b598-419e-916f-1e74654ff38b/statuses"
+            error: "internal_error"
+            error_description: "Internal server error"
 
     ServiceUnavailable:
       description: Service temporarily unavailable
       content:
-        application/problem+json:
+        application/json:
           schema:
-            $ref: "#/components/schemas/ProblemDetails"
+            $ref: "#/components/schemas/ErrorResponse"
           example:
-            type: "about:blank"
-            title: "Service Unavailable"
-            status: 503
-            detail: "The service is currently unavailable. Please try again later"
-            instance: "/statuslists/477121aa-b598-419e-916f-1e74654ff38b"
+            error: "service_unavailable"
+            error_description: "The service is currently unavailable. Please try again later"
 
     InternalServerError:
       description: Internal server error
       content:
-        application/problem+json:
+        application/json:
           schema:
-            $ref: "#/components/schemas/ProblemDetails"
+            $ref: "#/components/schemas/ErrorResponse"
           example:
-            type: "about:blank"
-            title: "Internal Server Error"
-            status: 500
-            detail: "Internal server error"
-            instance: "/api/v1/status-lists/477121aa-b598-419e-916f-1e74654ff38b/statuses"
+            error: "internal_error"
+            error_description: "Internal server error"

--- a/src/domain/service.rs
+++ b/src/domain/service.rs
@@ -118,10 +118,14 @@ impl Service {
         if record.status_list.lst.len() > max_serialized_list_size {
             return Err(StatusListError::TooLarge);
         }
-        if self.status_list_repo.find(&record.list_id).await?.is_some() {
-            return Err(StatusListError::AlreadyExists);
-        }
 
+        // No `find` pre-check: the primary key on `list_id` is the only check
+        // that is not a TOCTOU race, and every repository classifies the
+        // resulting violation as `AlreadyExists` — proven against SQLite, MySQL
+        // and Postgres by `assert_insert_with_snapshot_duplicate_is_conflict`,
+        // and by construction for the in-memory adapter. A pre-check would add a
+        // round trip to every publish and still have to defer to this path when
+        // a competing writer commits between the read and the insert.
         match &self.snapshot_repo {
             Some(_) => {
                 let snapshot = build_snapshot(&record, token_exp_secs);

--- a/src/domain/service.rs
+++ b/src/domain/service.rs
@@ -122,10 +122,23 @@ impl Service {
         // No `find` pre-check: the primary key on `list_id` is the only check
         // that is not a TOCTOU race, and every repository classifies the
         // resulting violation as `AlreadyExists` — proven against SQLite, MySQL
-        // and Postgres by `assert_insert_with_snapshot_duplicate_is_conflict`,
-        // and by construction for the in-memory adapter. A pre-check would add a
-        // round trip to every publish and still have to defer to this path when
-        // a competing writer commits between the read and the insert.
+        // and Postgres by `assert_duplicate_list_id_is_conflict` (which covers
+        // both branches below), and by construction for the in-memory adapter.
+        // A pre-check would add a round trip to every publish and still have to
+        // defer to this path when a competing writer commits between the read
+        // and the insert.
+        //
+        // The trade is not free on the duplicate path: a rejected publish now
+        // costs BEGIN + failed INSERT + ROLLBACK instead of one SELECT, which on
+        // Postgres burns a transaction ID and leaves a dead tuple for autovacuum.
+        // That is the right way round — duplicates are the rare case, and the
+        // pre-check never actually prevented one.
+        //
+        // Only unique violations are classified. A foreign-key violation on
+        // `issuer` still surfaces as a generic backend error (500); that is
+        // unreachable in practice because authentication resolves the issuer's
+        // credential before this runs, so an unregistered issuer is rejected as
+        // 401 long before the insert.
         match &self.snapshot_repo {
             Some(_) => {
                 let snapshot = build_snapshot(&record, token_exp_secs);
@@ -256,16 +269,18 @@ impl Service {
         snapshot_repo.delete_older_than(cutoff).await
     }
 
-    /// Publish new credentials for an issuer after verifying uniqueness invariant.
+    /// Publish new credentials for an issuer.
+    ///
+    /// Uniqueness is enforced by the primary key on `credentials.issuer`, not by
+    /// a `find` pre-check — same reasoning as [`Self::publish_status_list`]: the
+    /// pre-check is a TOCTOU race that still has to defer to the constraint when
+    /// two registrations for one issuer arrive together, so it buys a round trip
+    /// and no guarantee. `insert_one` classifies the violation through
+    /// `map_insert_err` (proven on SQLite and MySQL by
+    /// `test_*_duplicate_insert_maps_to_duplicate_entry`) and
+    /// `impl From<RepositoryError> for CredentialError` maps it to
+    /// `AlreadyExists`, so the 409 is unchanged.
     pub async fn publish_credential(&self, credential: Credential) -> Result<(), CredentialError> {
-        if self
-            .credential_repo
-            .find(&credential.issuer.0)
-            .await?
-            .is_some()
-        {
-            return Err(CredentialError::AlreadyExists);
-        }
         self.credential_repo.insert(credential).await
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+// Ungated on purpose: plain `&str` data with no dependencies, so it is reachable
+// from test modules whatever feature gate they carry.
+#[cfg(test)]
+mod test_fixtures;
 #[cfg(test)]
 mod test_utils;
 mod utils;

--- a/src/outbound/sql/error.rs
+++ b/src/outbound/sql/error.rs
@@ -14,24 +14,17 @@ pub enum RepositoryError {
     RepositoryNotSet,
     #[error("Duplicate entry")]
     DuplicateEntry,
-    #[error("Generic error: {0}")]
-    Generic(String),
 }
 
-impl From<sea_orm::DbErr> for RepositoryError {
-    fn from(err: sea_orm::DbErr) -> Self {
-        RepositoryError::Generic(err.to_string())
-    }
-}
-
-impl From<sea_orm::DbErr> for crate::domain::models::status_list::StatusListError {
-    fn from(err: sea_orm::DbErr) -> Self {
-        crate::domain::models::status_list::StatusListError::Backend(Box::new(err))
-    }
-}
-
-impl From<sea_orm::DbErr> for crate::domain::models::credential::CredentialError {
-    fn from(err: sea_orm::DbErr) -> Self {
-        crate::domain::models::credential::CredentialError::Backend(Box::new(err))
-    }
-}
+// There is deliberately no `impl From<sea_orm::DbErr>` for this type, nor for
+// `StatusListError` / `CredentialError`.
+//
+// A blanket conversion would make `?` on a `DbErr` compile anywhere, and every
+// such conversion silently discards `DbErr::sql_err()` — turning a unique-key
+// violation into a generic backend error, and a racing publish into a 500
+// instead of a 409 (#143, #244). Requiring `.map_err(map_insert_err)` at each
+// insert site keeps that classification an explicit, reviewable decision rather
+// than something a one-character edit can drop.
+//
+// The `Generic` variant went with it: it existed only as that impl's output, and
+// an unclassified catch-all is the same trapdoor wearing a different hat.

--- a/src/outbound/sql/mod.rs
+++ b/src/outbound/sql/mod.rs
@@ -4,6 +4,10 @@ mod error;
 mod migrations;
 mod models;
 mod store;
+// Real-backend container fixtures, shared by the store's own backend proofs and
+// by the HTTP-layer publish test.
+#[cfg(test)]
+pub(crate) mod test_containers;
 
 pub use error::RepositoryError;
 pub use migrations::Migrator;

--- a/src/outbound/sql/store.rs
+++ b/src/outbound/sql/store.rs
@@ -518,9 +518,17 @@ mod test {
     use crate::outbound::sql::models::StatusList;
     use jsonwebtoken::jwk::Jwk;
     use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
-    // `Migrator::up` is only called from the real-backend helpers below.
-    #[cfg(any(feature = "sqlite", feature = "mysql", feature = "postgres-tests"))]
+    // `Migrator::up` is only called from `sqlite_connection` below; the MySQL and
+    // Postgres fixtures run their own migrations inside `test_containers`.
+    #[cfg(feature = "sqlite")]
     use sea_orm_migration::MigratorTrait;
+
+    // Container fixtures live in `test_containers` because the HTTP-layer
+    // publish test needs them too; the call sites below are unchanged.
+    #[cfg(feature = "mysql")]
+    use crate::outbound::sql::test_containers::mysql_helpers;
+    #[cfg(feature = "postgres-tests")]
+    use crate::outbound::sql::test_containers::postgres_helpers;
 
     #[cfg(feature = "sqlite")]
     async fn sqlite_connection() -> Arc<DatabaseConnection> {
@@ -534,171 +542,6 @@ mod test {
             .await
             .expect("Failed to run migrations on SQLite");
         Arc::new(db)
-    }
-
-    #[cfg(feature = "mysql")]
-    mod mysql_helpers {
-        use super::*;
-        use sea_orm::ConnectionTrait;
-        use testcontainers_modules::{
-            mysql::Mysql as MysqlImage,
-            testcontainers::{ContainerAsync, runners::AsyncRunner},
-        };
-        use tokio::sync::OnceCell;
-
-        static MYSQL_CONTAINER: OnceCell<ContainerAsync<MysqlImage>> = OnceCell::const_new();
-
-        pub(super) struct MysqlTestDb {
-            #[allow(dead_code)]
-            pub(super) _container: &'static ContainerAsync<MysqlImage>,
-            pub(super) url: String,
-        }
-
-        impl MysqlTestDb {
-            pub(super) async fn start() -> Self {
-                let node = MYSQL_CONTAINER
-                    .get_or_init(|| async {
-                        MysqlImage::default()
-                            .start()
-                            .await
-                            .expect("Failed to start MySQL container")
-                    })
-                    .await;
-
-                let host = node.get_host().await.expect("Failed to resolve MySQL host");
-                let port = node
-                    .get_host_port_ipv4(3306)
-                    .await
-                    .expect("Failed to resolve MySQL port");
-
-                // Connect without database first to create a unique database.
-                let admin_url = format!("mysql://{}:{}", host, port);
-                let db_name = format!("test_{}", uuid::Uuid::new_v4().simple());
-
-                let mut admin_opt = sea_orm::ConnectOptions::new(admin_url);
-                admin_opt.max_connections(1).min_connections(1);
-                let admin_conn = sea_orm::Database::connect(admin_opt)
-                    .await
-                    .expect("Failed to connect to MySQL admin");
-                admin_conn
-                    .execute_unprepared(&format!(
-                        "CREATE DATABASE {} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci",
-                        db_name
-                    ))
-                    .await
-                    .expect("Failed to create test database");
-
-                let url = format!("mysql://{}:{}/{}", host, port, db_name);
-                let db = Self::connect_pinned(&url).await;
-                crate::outbound::sql::Migrator::up(db.as_ref(), None)
-                    .await
-                    .expect("Failed to run migrations on MySQL");
-
-                Self {
-                    _container: node,
-                    url,
-                }
-            }
-
-            pub(super) async fn connection(&self) -> Arc<DatabaseConnection> {
-                Self::connect_pinned(&self.url).await
-            }
-
-            async fn connect_pinned(url: &str) -> Arc<DatabaseConnection> {
-                let mut opt = sea_orm::ConnectOptions::new(url.to_owned());
-                opt.max_connections(1).min_connections(1);
-                Arc::new(
-                    sea_orm::Database::connect(opt)
-                        .await
-                        .expect("Failed to connect to MySQL"),
-                )
-            }
-        }
-
-        pub(super) async fn connect_to_test_db(
-            mysql_url: &str,
-            max_connections: u32,
-        ) -> DatabaseConnection {
-            let mut opt = sea_orm::ConnectOptions::new(mysql_url.to_string());
-            opt.max_connections(max_connections)
-                .min_connections(max_connections);
-            sea_orm::Database::connect(opt)
-                .await
-                .expect("Failed to connect to MySQL test database")
-        }
-
-        /// Backward-compatible helper that creates a new test database.
-        /// Prefer `MysqlTestDb::start()` for new tests.
-        pub(super) async fn mysql_connection() -> MysqlTestDb {
-            MysqlTestDb::start().await
-        }
-    }
-
-    #[cfg(feature = "postgres-tests")]
-    mod postgres_helpers {
-        use super::*;
-        use sea_orm::ConnectionTrait;
-        use testcontainers_modules::{
-            postgres::Postgres as PostgresImage,
-            testcontainers::{ContainerAsync, runners::AsyncRunner},
-        };
-        use tokio::sync::OnceCell;
-
-        static POSTGRES_CONTAINER: OnceCell<ContainerAsync<PostgresImage>> = OnceCell::const_new();
-
-        pub(super) struct PostgresTestDb {
-            #[allow(dead_code)]
-            pub(super) _container: &'static ContainerAsync<PostgresImage>,
-            pub(super) db: Arc<DatabaseConnection>,
-        }
-
-        pub(super) async fn postgres_connection() -> PostgresTestDb {
-            let node = POSTGRES_CONTAINER
-                .get_or_init(|| async {
-                    PostgresImage::default()
-                        .start()
-                        .await
-                        .expect("Failed to start Postgres container")
-                })
-                .await;
-            let host = node
-                .get_host()
-                .await
-                .expect("Failed to resolve Postgres host");
-            let port = node
-                .get_host_port_ipv4(5432)
-                .await
-                .expect("Failed to resolve Postgres port");
-
-            // testcontainers' Postgres image defaults to postgres/postgres/postgres.
-            let admin_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
-            let db_name = format!("test_{}", uuid::Uuid::new_v4().simple());
-
-            let mut admin_opt = sea_orm::ConnectOptions::new(admin_url);
-            admin_opt.max_connections(1).min_connections(1);
-            let admin_conn = sea_orm::Database::connect(admin_opt)
-                .await
-                .expect("Failed to connect to Postgres admin");
-            admin_conn
-                .execute_unprepared(&format!("CREATE DATABASE {}", db_name))
-                .await
-                .expect("Failed to create Postgres test database");
-
-            let url = format!("postgres://postgres:postgres@{host}:{port}/{db_name}");
-            let mut opt = sea_orm::ConnectOptions::new(url);
-            opt.max_connections(1).min_connections(1);
-            let db = sea_orm::Database::connect(opt)
-                .await
-                .expect("Failed to connect to Postgres");
-            crate::outbound::sql::Migrator::up(&db, None)
-                .await
-                .expect("Failed to run migrations on Postgres");
-
-            PostgresTestDb {
-                _container: node,
-                db: Arc::new(db),
-            }
-        }
     }
 
     #[cfg(feature = "sqlite")]
@@ -1363,14 +1206,6 @@ mod test {
         assert!(matches!(backwards, Err(RepositoryError::UpdateError(_))));
     }
 
-    #[cfg(feature = "sqlite")]
-    const TEST_EC_JWK: &str = r#"{
-        "kty": "EC",
-        "crv": "P-256",
-        "x": "NeyFv_2L67OEplNbJpR02IFis4_lFW9HYmhfF5Or6m8",
-        "y": "eAH2qe8Pg3GQ28uxA8-qNAqdwQ_zfV2uKAvJ2sLpY9M"
-    }"#;
-
     /// failure rollback (no partial snapshot), and the conflict path — against
     /// real SQLite, since `MockDatabase` cannot model rollback.
     #[cfg(feature = "sqlite")]
@@ -1381,7 +1216,7 @@ mod test {
         let store = SeaOrmStore::<StatusListRecord>::new(db.clone());
         let history = SeaOrmStore::<StatusListHistoryRecord>::new(db);
 
-        let key: Jwk = serde_json::from_str(TEST_EC_JWK).unwrap();
+        let key: Jwk = serde_json::from_str(crate::test_fixtures::TEST_EC_PUBLIC_JWK).unwrap();
         let issuer = "issuer-atomic-sqlite";
         cred_store
             .insert_one(Credentials::new(issuer.to_string(), key))
@@ -1476,8 +1311,9 @@ mod test {
             )
             .await;
         assert!(
-            result.is_err(),
-            "a failed snapshot insert must fail the whole unit"
+            matches!(result, Err(RepositoryError::InsertError(_))),
+            "a failed snapshot insert must fail the whole unit as a plain \
+             insert error, got {result:?}"
         );
         let row = store.find_one_by(&base.list_id).await.unwrap().unwrap();
         assert_eq!(
@@ -1558,7 +1394,7 @@ mod test {
         let store = SeaOrmStore::<StatusListRecord>::new(db.clone());
         let history = SeaOrmStore::<StatusListHistoryRecord>::new(db);
 
-        let key: Jwk = serde_json::from_str(TEST_EC_JWK).unwrap();
+        let key: Jwk = serde_json::from_str(crate::test_fixtures::TEST_EC_PUBLIC_JWK).unwrap();
         let issuer = "issuer-insert-atomic";
         cred_store
             .insert_one(Credentials::new(issuer.to_string(), key))
@@ -1612,9 +1448,16 @@ mod test {
                 new_snapshot("snap-ok", "list-rolled-back"),
             )
             .await;
+        // Specifically an `InsertError`, not a `DuplicateEntry`: only the *row*
+        // insert classifies duplicates (`map_insert_err`), because only a
+        // duplicate `list_id` is a client-visible conflict. `snapshot_id` is a
+        // fresh v4 UUID per publish, so a collision here is a server fault and
+        // must stay a 500. `assert_insert_with_snapshot_duplicate_is_conflict`
+        // reasons from this asymmetry, so it is pinned rather than assumed.
         assert!(
-            result.is_err(),
-            "a failed snapshot insert must fail the whole unit"
+            matches!(result, Err(RepositoryError::InsertError(_))),
+            "a failed snapshot insert must fail the whole unit as a plain \
+             insert error, got {result:?}"
         );
         assert!(
             store
@@ -1634,13 +1477,204 @@ mod test {
             matches!(dup, Err(RepositoryError::DuplicateEntry)),
             "duplicate list_id must map to DuplicateEntry, got {dup:?}"
         );
-        // The rejected publish recorded no snapshot either.
+        // The rolled-back publish recorded no snapshot either. This must name
+        // `list-rolled-back` — the list that actually failed. Asserting against
+        // a list_id that was never inserted proves nothing about rollback.
         assert!(
             history
-                .find_valid_at("list-nonexistent", 1000)
+                .find_valid_at("list-rolled-back", 1000)
                 .await
                 .unwrap()
-                .is_none()
+                .is_none(),
+            "the rolled-back publish must not leave a snapshot behind"
+        );
+        // ...and the duplicate attempt left the committed snapshot alone.
+        let surviving = history
+            .find_valid_at("list-ok", 1000)
+            .await
+            .unwrap()
+            .expect("the first publish's snapshot must survive");
+        assert_eq!(surviving.snapshot_id, "snap-ok");
+    }
+
+    /// Cross-backend proof: a duplicate `list_id` raised *inside* the open
+    /// transaction must still classify as `DuplicateEntry` on MySQL. The
+    /// non-transactional `insert_one` is already covered by
+    /// `test_mysql_duplicate_insert_maps_to_duplicate_entry`; what is untested
+    /// there is that `insert_one_with_snapshot` — which rolls back first and
+    /// classifies afterwards (`map_insert_err` on the error captured *before*
+    /// the rollback) — does not lose the classification along the way. Losing it
+    /// turns every racing publish into a 500 instead of a 409.
+    #[cfg(feature = "mysql")]
+    #[tokio::test]
+    async fn test_mysql_insert_with_snapshot_duplicate_maps_to_duplicate_entry() {
+        let test_db = mysql_helpers::MysqlTestDb::start().await;
+        assert_insert_with_snapshot_duplicate_is_conflict(
+            test_db.connection().await,
+            "issuer-dup-txn-mysql",
+            "list-dup-txn-mysql",
+            "MySQL",
+        )
+        .await;
+    }
+
+    /// The same proof on Postgres, the production backend. Postgres is the
+    /// backend where this could plausibly diverge: a failed statement poisons
+    /// the transaction (`25P02`), so if the classification were ever read from
+    /// the rollback rather than from the original `23505`, it would degrade to a
+    /// generic insert error here and nowhere else.
+    #[cfg(feature = "postgres-tests")]
+    #[tokio::test]
+    async fn test_postgres_insert_with_snapshot_duplicate_maps_to_duplicate_entry() {
+        let test_db = postgres_helpers::postgres_connection().await;
+        assert_insert_with_snapshot_duplicate_is_conflict(
+            test_db.db.clone(),
+            "issuer-dup-txn-postgres",
+            "list-dup-txn-postgres",
+            "Postgres",
+        )
+        .await;
+    }
+
+    /// The same proof on SQLite. Redundant with the two container tests above on
+    /// the classification question itself — but it is the only one of the three
+    /// that runs under a plain `cargo test`, with no Docker and no
+    /// `--all-features`. A regression in `insert_one_with_snapshot`'s error
+    /// mapping therefore fails in milliseconds locally instead of waiting for
+    /// the container job.
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn test_sqlite_insert_with_snapshot_duplicate_maps_to_duplicate_entry() {
+        let db = sqlite_connection().await;
+        assert_insert_with_snapshot_duplicate_is_conflict(
+            db,
+            "issuer-dup-txn-sqlite",
+            "list-dup-txn-sqlite",
+            "SQLite",
+        )
+        .await;
+    }
+
+    /// Publishes `list_id` once, then republishes it with a *different*
+    /// `snapshot_id`, and asserts the failure is the duplicate `list_id`
+    /// classified as `DuplicateEntry` — on both publish paths, transactional
+    /// (`insert_one_with_snapshot`) and not (`insert_one`).
+    ///
+    /// The distinct `snapshot_id` keeps the assertion aimed at one constraint.
+    /// A duplicate `snapshot_id` deliberately stays a plain `InsertError` rather
+    /// than a `DuplicateEntry` (pinned by
+    /// `test_sqlite_insert_with_snapshot_is_atomic`), so reusing the committed
+    /// one would couple this test to statement *ordering*: today the row INSERT
+    /// fails first and short-circuits, but if that order ever flipped, the
+    /// snapshot would collide first and this test would fail for a reason that
+    /// has nothing to do with the property under test. A fresh `snapshot_id`
+    /// leaves the duplicate `list_id` as the only thing that can fail.
+    ///
+    /// Seeds its own issuer because `status_lists.issuer` is a foreign key onto
+    /// `credentials.issuer`; callers pass a per-backend `issuer`/`list_id` pair
+    /// so a shared database would still keep them apart.
+    #[cfg(any(feature = "sqlite", feature = "mysql", feature = "postgres-tests"))]
+    async fn assert_insert_with_snapshot_duplicate_is_conflict(
+        db: Arc<DatabaseConnection>,
+        issuer: &str,
+        list_id: &str,
+        backend: &str,
+    ) {
+        let cred_store = SeaOrmStore::<Credentials>::new(db.clone());
+        let store = SeaOrmStore::<StatusListRecord>::new(db.clone());
+        let history = SeaOrmStore::<StatusListHistoryRecord>::new(db);
+
+        let key: Jwk = serde_json::from_str(crate::test_fixtures::TEST_EC_PUBLIC_JWK).unwrap();
+        cred_store
+            .insert_one(Credentials::new(issuer.to_string(), key))
+            .await
+            .unwrap();
+
+        let record = |updated_at: i64| StatusListRecord {
+            list_id: list_id.to_string(),
+            issuer: issuer.to_string(),
+            status_list: StatusList {
+                bits: 1,
+                lst: "initial".to_string(),
+            },
+            sub: format!("sub-{list_id}"),
+            updated_at,
+        };
+        let snapshot = |snapshot_id: &str, iat: i64| StatusListHistoryRecord {
+            snapshot_id: snapshot_id.to_string(),
+            list_id: list_id.to_string(),
+            issuer: issuer.to_string(),
+            status_list: StatusList {
+                bits: 1,
+                lst: "initial".to_string(),
+            },
+            sub: format!("sub-{list_id}"),
+            iat,
+            exp: iat + 900,
+        };
+
+        store
+            .insert_one_with_snapshot(record(1000), snapshot("snap-first", 1000))
+            .await
+            .unwrap();
+
+        // Racing publish: same list_id, freshly minted snapshot_id.
+        let dup = store
+            .insert_one_with_snapshot(record(2000), snapshot("snap-second", 2000))
+            .await;
+        assert!(
+            matches!(dup, Err(RepositoryError::DuplicateEntry)),
+            "duplicate list_id inside a transaction must map to DuplicateEntry \
+             on {backend}, got {dup:?}"
+        );
+
+        // The rejected publish rolled back cleanly. Its snapshot would have
+        // covered `[2000, 2900)`, and the first publish's covers `[1000, 1900)`,
+        // so *anything* resolvable at 2000 could only be the leak this asserts
+        // against — the windows do not overlap.
+        assert!(
+            history
+                .find_valid_at(list_id, 2000)
+                .await
+                .unwrap()
+                .is_none(),
+            "the rejected publish must not leave a snapshot behind on {backend}"
+        );
+
+        // ...and the failed attempt did not disturb the committed one.
+        let first = history
+            .find_valid_at(list_id, 1000)
+            .await
+            .unwrap()
+            .unwrap_or_else(|| panic!("the first publish's snapshot must survive on {backend}"));
+        assert_eq!(first.snapshot_id, "snap-first");
+
+        // The row itself is untouched. The two records differ only in
+        // `updated_at`, so this is what catches a silent upsert: an
+        // `ON CONFLICT DO UPDATE` "optimization" would leave 2000 here while
+        // every assertion above still passed.
+        let row = store
+            .find_one_by(list_id)
+            .await
+            .unwrap()
+            .unwrap_or_else(|| panic!("the committed row must survive on {backend}"));
+        assert_eq!(
+            row.updated_at, 1000,
+            "the rejected publish must not overwrite the committed row on {backend}"
+        );
+
+        // The same conflict on the *non-transactional* path. Operators can set
+        // `snapshot_retention_secs = 0`, which builds a `Service` with no
+        // snapshot repo, and `publish_status_list` then calls plain `insert_one`
+        // — a different `map_insert_err` call site with no transaction or
+        // rollback around it. Reuses this test's backend rather than paying for
+        // another container, since the row it collides with is already
+        // committed.
+        let plain = store.insert_one(record(3000)).await;
+        assert!(
+            matches!(plain, Err(RepositoryError::DuplicateEntry)),
+            "duplicate list_id on the history-disabled publish path must also \
+             map to DuplicateEntry on {backend}, got {plain:?}"
         );
     }
 

--- a/src/outbound/sql/store.rs
+++ b/src/outbound/sql/store.rs
@@ -59,6 +59,11 @@ impl SeaOrmStore<StatusListRecord> {
         entity: StatusListRecord,
         snapshot: StatusListHistoryRecord,
     ) -> Result<(), RepositoryError> {
+        // Captured before `entity` is consumed below; only the contention test
+        // reads it.
+        #[cfg(test)]
+        let probed_list_id = entity.list_id.clone();
+
         let txn = self
             .db
             .begin()
@@ -76,6 +81,17 @@ impl SeaOrmStore<StatusListRecord> {
             .exec_without_returning(&txn)
             .await
         {
+            // `insert_err` is captured *before* the rollback and classified
+            // after it, which is what keeps a duplicate a 409 rather than a 500:
+            // on Postgres the failed statement poisons the transaction (`25P02`),
+            // so a classification read from the rollback's own error would
+            // degrade to a generic backend failure. Verified on MySQL and
+            // Postgres by `assert_duplicate_list_id_is_conflict`.
+            //
+            // If the rollback itself fails the classification is deliberately
+            // dropped and the caller gets a 500. A transaction that will not
+            // roll back is a server fault, not a client conflict, and telling
+            // the client "retry with a different id" would be wrong.
             txn.rollback().await.map_err(|rollback_err| {
                 RepositoryError::InsertError(format!(
                     "status list insert failed ({insert_err}); \
@@ -98,6 +114,11 @@ impl SeaOrmStore<StatusListRecord> {
             })?;
             return Err(RepositoryError::InsertError(insert_err.to_string()));
         }
+
+        #[cfg(test)]
+        snapshot_txn_test_hook::INSERT_BEFORE_COMMIT
+            .pause(&probed_list_id)
+            .await;
 
         txn.commit()
             .await
@@ -260,7 +281,9 @@ impl SeaOrmStore<StatusListRecord> {
         }
 
         #[cfg(test)]
-        update_snapshot_test_hook::pause_after_snapshot_insert(list_id).await;
+        snapshot_txn_test_hook::UPDATE_BEFORE_COMMIT
+            .pause(list_id)
+            .await;
 
         txn.commit()
             .await
@@ -459,6 +482,21 @@ impl SeaOrmStore<Credentials> {
     }
 }
 
+/// Classifies an insert failure, distinguishing the one case that is a client
+/// conflict rather than a server fault.
+///
+/// Only unique-constraint violations are singled out, because only they are
+/// caused by something the client can see and act on — a `list_id` or `issuer`
+/// that is already taken — and they must reach the client as 409, not 500
+/// (#143, #244).
+///
+/// Foreign-key violations deliberately fall through to `InsertError`/500.
+/// The only FK on the write paths is `status_lists.issuer -> credentials.issuer`,
+/// and authentication resolves the issuer's credential before any handler runs,
+/// so reaching this function with a missing issuer means the credential was
+/// deleted mid-request — a server-side consistency failure, correctly a 500.
+/// If that ever stops holding, add a `ForeignKeyConstraintViolation` arm rather
+/// than widening the unique-violation one.
 fn map_insert_err(e: sea_orm::DbErr) -> RepositoryError {
     match e.sql_err() {
         Some(sea_orm::SqlErr::UniqueConstraintViolation(_)) => RepositoryError::DuplicateEntry,
@@ -466,50 +504,86 @@ fn map_insert_err(e: sea_orm::DbErr) -> RepositoryError {
     }
 }
 
+/// Lets a contention test hold a transaction open at a chosen point so a second
+/// writer provably collides with it, rather than with an already-committed row.
+///
+/// Without this a "race" test is really a sequential test: the first writer has
+/// already committed by the time the second starts, so the second never blocks
+/// on a lock and the interesting window — one writer holding an uncommitted row
+/// or index entry while another arrives — is never entered.
 #[cfg(test)]
-mod update_snapshot_test_hook {
+mod snapshot_txn_test_hook {
     use std::sync::OnceLock;
     use tokio::sync::{Mutex, oneshot};
 
     pub(super) struct Probe {
         pub(super) list_id: String,
+        /// Fires once the paused writer is inside the transaction, holding its
+        /// locks. The test waits on this before starting the second writer.
         pub(super) ready: oneshot::Sender<()>,
+        /// The test fires this to let the paused writer commit.
         pub(super) release: oneshot::Receiver<()>,
     }
 
-    static PROBE: OnceLock<Mutex<Option<Probe>>> = OnceLock::new();
-
-    fn probe() -> &'static Mutex<Option<Probe>> {
-        PROBE.get_or_init(|| Mutex::new(None))
+    /// One installable pause point. Each site owns its own slot so the insert
+    /// and update contention tests cannot capture each other's probe.
+    pub(super) struct PauseSite {
+        slot: OnceLock<Mutex<Option<Probe>>>,
+        site: &'static str,
     }
 
-    pub(super) async fn install(probe_to_install: Probe) {
-        let mut guard = probe().lock().await;
-        assert!(
-            guard.is_none(),
-            "only one update_one_with_snapshot contention probe can be installed at a time"
-        );
-        *guard = Some(probe_to_install);
-    }
-
-    pub(super) async fn pause_after_snapshot_insert(list_id: &str) {
-        let installed_probe = {
-            let mut guard = probe().lock().await;
-            if guard
-                .as_ref()
-                .is_some_and(|installed| installed.list_id == list_id)
-            {
-                guard.take()
-            } else {
-                None
+    impl PauseSite {
+        const fn new(site: &'static str) -> Self {
+            Self {
+                slot: OnceLock::new(),
+                site,
             }
-        };
+        }
 
-        if let Some(installed_probe) = installed_probe {
-            let _ = installed_probe.ready.send(());
-            let _ = installed_probe.release.await;
+        fn slot(&self) -> &Mutex<Option<Probe>> {
+            self.slot.get_or_init(|| Mutex::new(None))
+        }
+
+        pub(super) async fn install(&self, probe_to_install: Probe) {
+            let mut guard = self.slot().lock().await;
+            assert!(
+                guard.is_none(),
+                "only one {} contention probe can be installed at a time",
+                self.site
+            );
+            *guard = Some(probe_to_install);
+        }
+
+        /// Pauses only the writer working on the probed `list_id`, and only
+        /// once — the probe is taken, so every other call is a no-op and the
+        /// production path is untouched for all other rows.
+        pub(super) async fn pause(&self, list_id: &str) {
+            let installed_probe = {
+                let mut guard = self.slot().lock().await;
+                if guard
+                    .as_ref()
+                    .is_some_and(|installed| installed.list_id == list_id)
+                {
+                    guard.take()
+                } else {
+                    None
+                }
+            };
+
+            if let Some(installed_probe) = installed_probe {
+                let _ = installed_probe.ready.send(());
+                let _ = installed_probe.release.await;
+            }
         }
     }
+
+    /// Inside `update_one_with_snapshot`, after the snapshot INSERT, while the
+    /// guarded UPDATE still holds its exclusive row lock.
+    pub(super) static UPDATE_BEFORE_COMMIT: PauseSite = PauseSite::new("update_one_with_snapshot");
+
+    /// Inside `insert_one_with_snapshot`, after the snapshot INSERT, while the
+    /// row INSERT still holds its uncommitted primary-key entry.
+    pub(super) static INSERT_BEFORE_COMMIT: PauseSite = PauseSite::new("insert_one_with_snapshot");
 }
 
 #[cfg(test)]
@@ -1452,7 +1526,7 @@ mod test {
         // insert classifies duplicates (`map_insert_err`), because only a
         // duplicate `list_id` is a client-visible conflict. `snapshot_id` is a
         // fresh v4 UUID per publish, so a collision here is a server fault and
-        // must stay a 500. `assert_insert_with_snapshot_duplicate_is_conflict`
+        // must stay a 500. `assert_duplicate_list_id_is_conflict`
         // reasons from this asymmetry, so it is pinned rather than assumed.
         assert!(
             matches!(result, Err(RepositoryError::InsertError(_))),
@@ -1509,7 +1583,7 @@ mod test {
     #[tokio::test]
     async fn test_mysql_insert_with_snapshot_duplicate_maps_to_duplicate_entry() {
         let test_db = mysql_helpers::MysqlTestDb::start().await;
-        assert_insert_with_snapshot_duplicate_is_conflict(
+        assert_duplicate_list_id_is_conflict(
             test_db.connection().await,
             "issuer-dup-txn-mysql",
             "list-dup-txn-mysql",
@@ -1527,7 +1601,7 @@ mod test {
     #[tokio::test]
     async fn test_postgres_insert_with_snapshot_duplicate_maps_to_duplicate_entry() {
         let test_db = postgres_helpers::postgres_connection().await;
-        assert_insert_with_snapshot_duplicate_is_conflict(
+        assert_duplicate_list_id_is_conflict(
             test_db.db.clone(),
             "issuer-dup-txn-postgres",
             "list-dup-txn-postgres",
@@ -1546,7 +1620,7 @@ mod test {
     #[tokio::test]
     async fn test_sqlite_insert_with_snapshot_duplicate_maps_to_duplicate_entry() {
         let db = sqlite_connection().await;
-        assert_insert_with_snapshot_duplicate_is_conflict(
+        assert_duplicate_list_id_is_conflict(
             db,
             "issuer-dup-txn-sqlite",
             "list-dup-txn-sqlite",
@@ -1574,7 +1648,7 @@ mod test {
     /// `credentials.issuer`; callers pass a per-backend `issuer`/`list_id` pair
     /// so a shared database would still keep them apart.
     #[cfg(any(feature = "sqlite", feature = "mysql", feature = "postgres-tests"))]
-    async fn assert_insert_with_snapshot_duplicate_is_conflict(
+    async fn assert_duplicate_list_id_is_conflict(
         db: Arc<DatabaseConnection>,
         issuer: &str,
         list_id: &str,
@@ -1673,7 +1747,7 @@ mod test {
         let plain = store.insert_one(record(3000)).await;
         assert!(
             matches!(plain, Err(RepositoryError::DuplicateEntry)),
-            "duplicate list_id on the history-disabled publish path must also \
+            "duplicate list_id on the snapshot-disabled publish path must also \
              map to DuplicateEntry on {backend}, got {plain:?}"
         );
     }
@@ -2111,12 +2185,13 @@ mod test {
         let (tx_a_release, rx_a_release) = oneshot::channel();
         let (tx_b_complete, rx_b_complete) = oneshot::channel::<(bool, Instant)>();
 
-        update_snapshot_test_hook::install(update_snapshot_test_hook::Probe {
-            list_id: list_id.to_string(),
-            ready: tx_a_ready,
-            release: rx_a_release,
-        })
-        .await;
+        snapshot_txn_test_hook::UPDATE_BEFORE_COMMIT
+            .install(snapshot_txn_test_hook::Probe {
+                list_id: list_id.to_string(),
+                ready: tx_a_ready,
+                release: rx_a_release,
+            })
+            .await;
 
         // Connection A: run the real update + snapshot method, pausing after
         // the snapshot insert and before commit while the row lock is held.
@@ -2283,5 +2358,208 @@ mod test {
             loser_snapshot.is_none(),
             "B's guard-miss path must not record a snapshot"
         );
+    }
+
+    /// The publish race itself, on two real connections.
+    ///
+    /// `assert_duplicate_list_id_is_conflict` collides with a row that is
+    /// already **committed**, which is the common case but not the one the
+    /// issue describes. This collides with a row that is still **uncommitted**:
+    /// writer A holds the primary-key entry inside an open transaction while
+    /// writer B arrives, so B blocks in the engine and only learns the outcome
+    /// when A commits. That is a different code path — the driver surfaces the
+    /// violation at a different point — and it is the one a real racing publish
+    /// takes.
+    ///
+    /// Asserts three things:
+    ///
+    /// 1. B genuinely blocked (it cannot finish before A starts committing),
+    ///    which is what makes this a race test rather than a sequential one.
+    /// 2. B's failure still classifies as `DuplicateEntry` → 409, not a generic
+    ///    backend error → 500. This is the property the issue is about.
+    /// 3. The loser left nothing behind: no snapshot, and A's row intact.
+    #[cfg(any(feature = "mysql", feature = "postgres-tests"))]
+    async fn assert_concurrent_publish_loser_gets_conflict(
+        pool_a: DatabaseConnection,
+        pool_b: DatabaseConnection,
+        pool_verify: DatabaseConnection,
+        issuer: &'static str,
+        list_id: &'static str,
+        backend: &'static str,
+    ) {
+        use std::time::{Duration, Instant};
+        use tokio::sync::oneshot;
+
+        let store_a = SeaOrmStore::<StatusListRecord>::new(Arc::new(pool_a));
+        let store_b = SeaOrmStore::<StatusListRecord>::new(Arc::new(pool_b));
+        let store_verify = SeaOrmStore::<StatusListRecord>::new(Arc::new(pool_verify));
+
+        // status_lists.issuer is a foreign key onto credentials.issuer, so the
+        // credential has to be committed before either writer starts.
+        let key: Jwk = serde_json::from_str(crate::test_fixtures::TEST_EC_PUBLIC_JWK).unwrap();
+        SeaOrmStore::<Credentials>::new(store_verify.db.clone())
+            .insert_one(Credentials::new(issuer.to_string(), key))
+            .await
+            .unwrap();
+
+        // `move` so both closures capture the `&'static str`s by copy and stay
+        // `Copy` themselves — each spawned writer below needs its own.
+        let record = move |lst: &str, updated_at: i64| StatusListRecord {
+            list_id: list_id.to_string(),
+            issuer: issuer.to_string(),
+            status_list: StatusList {
+                bits: 1,
+                lst: lst.to_string(),
+            },
+            sub: format!("sub-{list_id}"),
+            updated_at,
+        };
+        let snapshot = move |snapshot_id: &str, iat: i64| StatusListHistoryRecord {
+            snapshot_id: snapshot_id.to_string(),
+            list_id: list_id.to_string(),
+            issuer: issuer.to_string(),
+            status_list: StatusList {
+                bits: 1,
+                lst: "initial".to_string(),
+            },
+            sub: format!("sub-{list_id}"),
+            iat,
+            exp: iat + 900,
+        };
+
+        let (tx_a_ready, rx_a_ready) = oneshot::channel();
+        let (tx_b_started, rx_b_started) = oneshot::channel();
+        let (tx_a_release, rx_a_release) = oneshot::channel();
+        let (tx_b_done, rx_b_done) = oneshot::channel::<(Result<(), RepositoryError>, Instant)>();
+
+        snapshot_txn_test_hook::INSERT_BEFORE_COMMIT
+            .install(snapshot_txn_test_hook::Probe {
+                list_id: list_id.to_string(),
+                ready: tx_a_ready,
+                release: rx_a_release,
+            })
+            .await;
+
+        // Writer A: the winning publish, paused just before COMMIT while its
+        // primary-key entry is still uncommitted.
+        let handle_a = tokio::spawn(async move {
+            store_a
+                .insert_one_with_snapshot(record("writer-a", 1000), snapshot("snap-race-a", 1000))
+                .await
+        });
+
+        // Writer B: the losing publish. Starts only once A is known to be
+        // holding the uncommitted key.
+        let handle_b = tokio::spawn(async move {
+            rx_a_ready.await.expect("A never reached its pause point");
+            tx_b_started.send(()).expect("failed to signal B started");
+
+            let result = store_b
+                .insert_one_with_snapshot(record("writer-b", 2000), snapshot("snap-race-b", 2000))
+                .await;
+            // Timestamped the instant the call returns, before any channel work,
+            // so nothing downstream can manufacture the ordering.
+            let b_done = Instant::now();
+            tx_b_done
+                .send((result, b_done))
+                .expect("failed to send B result");
+        });
+
+        rx_b_started.await.expect("B never started");
+        // Give B time to reach the database and block on A's key.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let a_releasing = Instant::now();
+        tx_a_release.send(()).expect("failed to release A");
+
+        let timeout = Duration::from_secs(30);
+        let (a_join, b_join) = tokio::join!(
+            tokio::time::timeout(timeout, handle_a),
+            tokio::time::timeout(timeout, handle_b)
+        );
+        a_join
+            .unwrap_or_else(|_| panic!("timed out waiting for writer A on {backend}"))
+            .expect("writer A panicked")
+            .unwrap_or_else(|e| panic!("writer A should win the publish on {backend}: {e:?}"));
+        b_join
+            .unwrap_or_else(|_| panic!("timed out waiting for writer B on {backend}"))
+            .expect("writer B panicked");
+
+        let (b_result, b_done) = rx_b_done.await.expect("failed to receive B result");
+
+        // Falsifiable: if B had not blocked on A's uncommitted key it would have
+        // finished during the sleep above, before A began committing.
+        assert!(
+            b_done > a_releasing,
+            "B must block until A commits on {backend} — otherwise this is not a \
+             race (B: {b_done:?}, A releasing: {a_releasing:?})"
+        );
+
+        // The property under test: a genuinely concurrent duplicate is still a
+        // client conflict, not a server error.
+        assert!(
+            matches!(b_result, Err(RepositoryError::DuplicateEntry)),
+            "the losing publisher of a real race must get DuplicateEntry (409) \
+             on {backend}, not a generic error (500), got {b_result:?}"
+        );
+
+        // A's row won and B disturbed nothing.
+        let row = store_verify
+            .find_one_by(list_id)
+            .await
+            .unwrap()
+            .unwrap_or_else(|| panic!("A's row must be committed on {backend}"));
+        assert_eq!(
+            row.status_list.lst, "writer-a",
+            "A's publish must be the one that persisted on {backend}"
+        );
+        assert_eq!(
+            row.updated_at, 1000,
+            "B must not have overwritten A's row on {backend}"
+        );
+
+        let loser_snapshot = status_list_history::Entity::find_by_id("snap-race-b")
+            .one(&*store_verify.db)
+            .await
+            .expect("loser snapshot lookup should succeed");
+        assert!(
+            loser_snapshot.is_none(),
+            "the losing publisher must not leave a snapshot behind on {backend}"
+        );
+    }
+
+    /// The publish race on MySQL, whose driver reports duplicate keys as `1062`.
+    #[cfg(feature = "mysql")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+    async fn test_mysql_concurrent_publish_loser_gets_conflict() {
+        let test_db = mysql_helpers::MysqlTestDb::start().await;
+        assert_concurrent_publish_loser_gets_conflict(
+            mysql_helpers::connect_to_test_db(&test_db.url, 1).await,
+            mysql_helpers::connect_to_test_db(&test_db.url, 1).await,
+            mysql_helpers::connect_to_test_db(&test_db.url, 2).await,
+            "issuer-race-txn-mysql",
+            "list-race-txn-mysql",
+            "MySQL",
+        )
+        .await;
+    }
+
+    /// The same race on Postgres, the production backend and the one the issue
+    /// singles out: a failed statement poisons the transaction (`25P02`), so a
+    /// classification taken from anywhere but the original `23505` degrades to a
+    /// 500 here and nowhere else.
+    #[cfg(feature = "postgres-tests")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+    async fn test_postgres_concurrent_publish_loser_gets_conflict() {
+        let test_db = postgres_helpers::postgres_connection().await;
+        assert_concurrent_publish_loser_gets_conflict(
+            postgres_helpers::connect_to_test_db(&test_db.url, 1).await,
+            postgres_helpers::connect_to_test_db(&test_db.url, 1).await,
+            postgres_helpers::connect_to_test_db(&test_db.url, 2).await,
+            "issuer-race-txn-postgres",
+            "list-race-txn-postgres",
+            "Postgres",
+        )
+        .await;
     }
 }

--- a/src/outbound/sql/test_containers.rs
+++ b/src/outbound/sql/test_containers.rs
@@ -169,6 +169,26 @@ pub(crate) mod postgres_helpers {
         #[allow(dead_code)]
         pub(crate) _container: &'static ContainerAsync<PostgresImage>,
         pub(crate) db: Arc<DatabaseConnection>,
+        /// Connection URL for this test's database, for opening further pools —
+        /// see [`connect_to_test_db`].
+        pub(crate) url: String,
+    }
+
+    /// Opens an additional pool of a caller-chosen size against an
+    /// already-migrated database. The counterpart of
+    /// [`super::mysql_helpers::connect_to_test_db`]; contention tests need it
+    /// because two halves sharing one multi-slot pool can be handed the same
+    /// connection, and the row lock they mean to fight over is never contended.
+    pub(crate) async fn connect_to_test_db(
+        postgres_url: &str,
+        max_connections: u32,
+    ) -> DatabaseConnection {
+        let mut opt = sea_orm::ConnectOptions::new(postgres_url.to_string());
+        opt.max_connections(max_connections)
+            .min_connections(max_connections);
+        sea_orm::Database::connect(opt)
+            .await
+            .expect("Failed to connect to Postgres test database")
     }
 
     pub(crate) async fn postgres_connection() -> PostgresTestDb {
@@ -204,7 +224,7 @@ pub(crate) mod postgres_helpers {
             .expect("Failed to create Postgres test database");
 
         let url = format!("postgres://postgres:postgres@{host}:{port}/{db_name}");
-        let mut opt = sea_orm::ConnectOptions::new(url);
+        let mut opt = sea_orm::ConnectOptions::new(url.clone());
         opt.max_connections(1).min_connections(1);
         let db = sea_orm::Database::connect(opt)
             .await
@@ -216,6 +236,7 @@ pub(crate) mod postgres_helpers {
         PostgresTestDb {
             _container: node,
             db: Arc::new(db),
+            url,
         }
     }
 }

--- a/src/outbound/sql/test_containers.rs
+++ b/src/outbound/sql/test_containers.rs
@@ -1,0 +1,221 @@
+//! Throwaway MySQL and Postgres databases with the migrations already applied,
+//! for tests that need a real backend rather than `MockDatabase`.
+//!
+//! These live here rather than inside `store`'s `#[cfg(test)] mod test` because
+//! the HTTP-layer publish tests need them too: an item inside a private test
+//! module has no path nameable from another module, whatever its visibility.
+//!
+//! Each submodule carries only its backend's own feature gate. Both call
+//! `Migrator::up`, but `Migrator` is re-exported unconditionally from
+//! [`crate::outbound::sql`], whose own gate any consumer of these fixtures
+//! already satisfies.
+//!
+//! # Isolation
+//!
+//! One container per *process*, held in a `OnceCell`, and one freshly created
+//! database per *call*. Tests therefore never share tables, and the per-call
+//! cost after the first is a `CREATE DATABASE` plus a migration run rather than
+//! a container boot.
+//!
+//! Pools are pinned with `max_connections(1).min_connections(1)` so a test that
+//! wants two genuinely distinct connections gets them: with a shared multi-slot
+//! pool, both halves of a contention test can be handed the same connection and
+//! the row lock they mean to fight over is never contended. Tests needing an
+//! extra pool of known size call [`mysql_helpers::connect_to_test_db`].
+//!
+//! # Concurrency
+//!
+//! The `OnceCell` bounds containers per process, not per run: under
+//! `cargo nextest` every test executes in its own process, so the cell is
+//! initialised once per test and parallel tests still boot a container apiece.
+//! That is what the `containers` test group in `.config/nextest.toml` is for —
+//! it serialises these alongside the ACME suite in `tests/cert_provisioning.rs`,
+//! which starts four containers of its own. Booting several servers at once
+//! starves them of CPU during init and they fail before any test code runs:
+//! MySQL reports `WaitContainer(StartupTimeout)`, pebble simply times out.
+//!
+//! The group selects database tests by `mysql`/`postgres` in the test name, so
+//! keep that substring in the name of any new one, and confirm with
+//! `cargo nextest show-config test-groups`. Under plain `cargo test` the
+//! equivalent is `--test-threads=1` — though there the `OnceCell` does share a
+//! single container across the whole binary, since it is one process.
+
+/// MySQL fixture. The container is shared per process; each call carves its own
+/// uniquely named database, so `Migrator::up` has nothing to race against.
+#[cfg(feature = "mysql")]
+pub(crate) mod mysql_helpers {
+    use sea_orm::{ConnectionTrait, DatabaseConnection};
+    use sea_orm_migration::MigratorTrait;
+    use std::sync::Arc;
+    use testcontainers_modules::{
+        mysql::Mysql as MysqlImage,
+        testcontainers::{ContainerAsync, runners::AsyncRunner},
+    };
+    use tokio::sync::OnceCell;
+
+    static MYSQL_CONTAINER: OnceCell<ContainerAsync<MysqlImage>> = OnceCell::const_new();
+
+    /// A migrated, test-private database on the shared container. The container
+    /// itself is `&'static`, so unlike a per-test container this can be dropped
+    /// without cutting off connections handed out earlier.
+    pub(crate) struct MysqlTestDb {
+        #[allow(dead_code)]
+        pub(crate) _container: &'static ContainerAsync<MysqlImage>,
+        /// Connection URL for this test's database, for opening further pools —
+        /// see [`connect_to_test_db`].
+        pub(crate) url: String,
+    }
+
+    impl MysqlTestDb {
+        pub(crate) async fn start() -> Self {
+            let node = MYSQL_CONTAINER
+                .get_or_init(|| async {
+                    MysqlImage::default()
+                        .start()
+                        .await
+                        .expect("Failed to start MySQL container")
+                })
+                .await;
+
+            let host = node.get_host().await.expect("Failed to resolve MySQL host");
+            let port = node
+                .get_host_port_ipv4(3306)
+                .await
+                .expect("Failed to resolve MySQL port");
+
+            // Connect without a database first, to create this test's own.
+            let admin_url = format!("mysql://{host}:{port}");
+            let db_name = format!("test_{}", uuid::Uuid::new_v4().simple());
+
+            let mut admin_opt = sea_orm::ConnectOptions::new(admin_url);
+            admin_opt.max_connections(1).min_connections(1);
+            let admin_conn = sea_orm::Database::connect(admin_opt)
+                .await
+                .expect("Failed to connect to MySQL admin");
+            admin_conn
+                .execute_unprepared(&format!(
+                    "CREATE DATABASE {db_name} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+                ))
+                .await
+                .expect("Failed to create test database");
+
+            let url = format!("mysql://{host}:{port}/{db_name}");
+            let db = Self::connect_pinned(&url).await;
+            crate::outbound::sql::Migrator::up(db.as_ref(), None)
+                .await
+                .expect("Failed to run migrations on MySQL");
+
+            Self {
+                _container: node,
+                url,
+            }
+        }
+
+        /// Opens a fresh single-connection pool against this test's database.
+        pub(crate) async fn connection(&self) -> Arc<DatabaseConnection> {
+            Self::connect_pinned(&self.url).await
+        }
+
+        async fn connect_pinned(url: &str) -> Arc<DatabaseConnection> {
+            let mut opt = sea_orm::ConnectOptions::new(url.to_owned());
+            opt.max_connections(1).min_connections(1);
+            Arc::new(
+                sea_orm::Database::connect(opt)
+                    .await
+                    .expect("Failed to connect to MySQL"),
+            )
+        }
+    }
+
+    /// Opens an additional pool of a caller-chosen size against an
+    /// already-migrated database. Contention tests use this to hold a known
+    /// number of connections; ordinary tests want [`MysqlTestDb::connection`].
+    pub(crate) async fn connect_to_test_db(
+        mysql_url: &str,
+        max_connections: u32,
+    ) -> DatabaseConnection {
+        let mut opt = sea_orm::ConnectOptions::new(mysql_url.to_string());
+        opt.max_connections(max_connections)
+            .min_connections(max_connections);
+        sea_orm::Database::connect(opt)
+            .await
+            .expect("Failed to connect to MySQL test database")
+    }
+
+    /// Backward-compatible helper that creates a new test database.
+    /// Prefer [`MysqlTestDb::start`] for new tests.
+    pub(crate) async fn mysql_connection() -> MysqlTestDb {
+        MysqlTestDb::start().await
+    }
+}
+
+/// Postgres fixture. As with MySQL the container is shared per process and each
+/// call carves its own database; this one hands back the connection directly,
+/// since no Postgres test needs a second pool.
+#[cfg(feature = "postgres-tests")]
+pub(crate) mod postgres_helpers {
+    use sea_orm::{ConnectionTrait, DatabaseConnection};
+    use sea_orm_migration::MigratorTrait;
+    use std::sync::Arc;
+    use testcontainers_modules::{
+        postgres::Postgres as PostgresImage,
+        testcontainers::{ContainerAsync, runners::AsyncRunner},
+    };
+    use tokio::sync::OnceCell;
+
+    static POSTGRES_CONTAINER: OnceCell<ContainerAsync<PostgresImage>> = OnceCell::const_new();
+
+    pub(crate) struct PostgresTestDb {
+        #[allow(dead_code)]
+        pub(crate) _container: &'static ContainerAsync<PostgresImage>,
+        pub(crate) db: Arc<DatabaseConnection>,
+    }
+
+    pub(crate) async fn postgres_connection() -> PostgresTestDb {
+        let node = POSTGRES_CONTAINER
+            .get_or_init(|| async {
+                PostgresImage::default()
+                    .start()
+                    .await
+                    .expect("Failed to start Postgres container")
+            })
+            .await;
+        let host = node
+            .get_host()
+            .await
+            .expect("Failed to resolve Postgres host");
+        let port = node
+            .get_host_port_ipv4(5432)
+            .await
+            .expect("Failed to resolve Postgres port");
+
+        // testcontainers' Postgres image defaults to postgres/postgres/postgres.
+        let admin_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+        let db_name = format!("test_{}", uuid::Uuid::new_v4().simple());
+
+        let mut admin_opt = sea_orm::ConnectOptions::new(admin_url);
+        admin_opt.max_connections(1).min_connections(1);
+        let admin_conn = sea_orm::Database::connect(admin_opt)
+            .await
+            .expect("Failed to connect to Postgres admin");
+        admin_conn
+            .execute_unprepared(&format!("CREATE DATABASE {db_name}"))
+            .await
+            .expect("Failed to create Postgres test database");
+
+        let url = format!("postgres://postgres:postgres@{host}:{port}/{db_name}");
+        let mut opt = sea_orm::ConnectOptions::new(url);
+        opt.max_connections(1).min_connections(1);
+        let db = sea_orm::Database::connect(opt)
+            .await
+            .expect("Failed to connect to Postgres");
+        crate::outbound::sql::Migrator::up(&db, None)
+            .await
+            .expect("Failed to run migrations on Postgres");
+
+        PostgresTestDb {
+            _container: node,
+            db: Arc::new(db),
+        }
+    }
+}

--- a/src/server/handlers/status_list/publish_status.rs
+++ b/src/server/handlers/status_list/publish_status.rs
@@ -152,7 +152,7 @@ mod tests {
     /// → **409** (`server::error`).
     ///
     /// Only the first hop can vary by backend, so the store's own
-    /// `assert_insert_with_snapshot_duplicate_is_conflict` carries the
+    /// `assert_duplicate_list_id_is_conflict` carries the
     /// per-backend burden — including the proof that the rolled-back publish
     /// leaves neither a snapshot nor a modified row. What *this* test adds is
     /// that the remaining hops are wired up at all: that the classification the
@@ -259,6 +259,107 @@ mod tests {
             "MySQL",
         )
         .await;
+    }
+
+    /// The snapshot-disabled publish path must also return 409, not 500.
+    ///
+    /// `snapshot_retention_secs = 0` builds a `Service` with no snapshot repo,
+    /// so `publish_status_list` takes its `None` branch into the plain
+    /// non-transactional `insert` — a different duplicate-classification call
+    /// site from `insert_with_snapshot`, and the one no other end-to-end test
+    /// covers. This matters more since `publish_status_list` stopped
+    /// pre-checking with `find`: the constraint is now the only thing standing
+    /// between a duplicate publish and a 500.
+    #[tokio::test]
+    async fn test_publish_duplicate_without_snapshots_returns_409() {
+        use crate::domain::models::credential::{Credential, Issuer, PublicJwk};
+        use crate::test_fixtures::TEST_EC_PUBLIC_JWK;
+        use crate::test_utils::test_app_state_without_snapshots;
+
+        let app_state = test_app_state_without_snapshots().await;
+        assert!(
+            app_state.service.snapshot_repo().is_none(),
+            "this test is meaningless unless the snapshot repo is actually absent"
+        );
+
+        let issuer = "issuer-no-snapshots";
+        app_state
+            .service
+            .publish_credential(Credential {
+                issuer: Issuer(issuer.to_string()),
+                public_key: PublicJwk::try_new(TEST_EC_PUBLIC_JWK.as_bytes().to_vec()).unwrap(),
+            })
+            .await
+            .unwrap();
+
+        let list_id = uuid::Uuid::new_v4().to_string();
+        let publish = || {
+            let state = app_state.clone();
+            let list_id = list_id.clone();
+            async move {
+                publish_status(
+                    State(state),
+                    Extension(issuer.to_string()),
+                    Path(list_id),
+                    Json(StatusesRequest {
+                        statuses: vec![RequestStatusEntry {
+                            index: 0,
+                            status: RequestStatus::VALID,
+                        }],
+                    }),
+                )
+                .await
+            }
+        };
+
+        assert_eq!(
+            publish()
+                .await
+                .expect("first publish should succeed")
+                .into_response()
+                .status(),
+            StatusCode::CREATED
+        );
+
+        let err = publish()
+            .await
+            .err()
+            .expect("the duplicate publish must not report success");
+        assert_eq!(err.status, StatusCode::CONFLICT);
+        assert_eq!(err.error, "status_list_already_exists");
+    }
+
+    /// Registering an issuer twice is a 409.
+    ///
+    /// `publish_credential` no longer pre-checks with `find`, so this pins that
+    /// the primary key on `credentials.issuer` carries the conflict on its own
+    /// and still reaches the client as `credentials_already_exist`.
+    #[tokio::test]
+    async fn test_duplicate_credential_registration_returns_409() {
+        use crate::domain::models::credential::{Credential, Issuer, PublicJwk};
+        use crate::server::error::ApiError;
+        use crate::test_fixtures::TEST_EC_PUBLIC_JWK;
+
+        let app_state = test_app_state(None).await;
+        let credential = || Credential {
+            issuer: Issuer("issuer-dup-registration".to_string()),
+            public_key: PublicJwk::try_new(TEST_EC_PUBLIC_JWK.as_bytes().to_vec()).unwrap(),
+        };
+
+        app_state
+            .service
+            .publish_credential(credential())
+            .await
+            .expect("first registration should succeed");
+
+        let err: ApiError = app_state
+            .service
+            .publish_credential(credential())
+            .await
+            .expect_err("the second registration must be rejected")
+            .into();
+        assert_eq!(err.status, StatusCode::CONFLICT);
+        assert_eq!(err.error, "credentials_already_exist");
     }
 
     #[tokio::test]

--- a/src/server/handlers/status_list/publish_status.rs
+++ b/src/server/handlers/status_list/publish_status.rs
@@ -138,6 +138,129 @@ mod tests {
         assert_eq!(err.status, StatusCode::CONFLICT);
     }
 
+    /// The losing publisher of a `list_id` race gets 409, not 500 — end to end,
+    /// on a real backend.
+    ///
+    /// `test_token_conflict` above proves the same thing over the in-memory
+    /// adapter, where `AlreadyExists` is returned by a `HashMap` lookup. That
+    /// says nothing about a relational backend, where the conflict surfaces as a
+    /// driver error raised *inside* an open transaction and has to survive the
+    /// rollback with its classification intact:
+    ///
+    /// `sql_err()` → `RepositoryError::DuplicateEntry` (`sql::store::map_insert_err`)
+    /// → `StatusListError::AlreadyExists` (`impl From<RepositoryError>` in `outbound::sql`)
+    /// → **409** (`server::error`).
+    ///
+    /// Only the first hop can vary by backend, so the store's own
+    /// `assert_insert_with_snapshot_duplicate_is_conflict` carries the
+    /// per-backend burden — including the proof that the rolled-back publish
+    /// leaves neither a snapshot nor a modified row. What *this* test adds is
+    /// that the remaining hops are wired up at all: that the classification the
+    /// store produces actually reaches the client as a status code.
+    #[cfg(any(feature = "postgres-tests", feature = "mysql"))]
+    async fn assert_publish_duplicate_is_conflict(
+        db: std::sync::Arc<sea_orm::DatabaseConnection>,
+        issuer: &str,
+        backend: &str,
+    ) {
+        use crate::domain::models::credential::{Credential, Issuer, PublicJwk};
+        use crate::test_fixtures::TEST_EC_PUBLIC_JWK;
+        use crate::test_utils::test_app_state;
+
+        let app_state = test_app_state(Some(db)).await;
+
+        // status_lists.issuer is a foreign key onto credentials.issuer. Seeded
+        // through the service rather than the store so this test depends only on
+        // the domain API, not on the persistence schema.
+        app_state
+            .service
+            .publish_credential(Credential {
+                issuer: Issuer(issuer.to_string()),
+                public_key: PublicJwk::try_new(TEST_EC_PUBLIC_JWK.as_bytes().to_vec()).unwrap(),
+            })
+            .await
+            .unwrap();
+
+        // The handler rejects a non-UUID list_id before reaching the service.
+        let list_id = uuid::Uuid::new_v4().to_string();
+        let publish = || {
+            let state = app_state.clone();
+            let list_id = list_id.clone();
+            async move {
+                publish_status(
+                    State(state),
+                    Extension(issuer.to_string()),
+                    Path(list_id),
+                    Json(StatusesRequest {
+                        statuses: vec![RequestStatusEntry {
+                            index: 0,
+                            status: RequestStatus::VALID,
+                        }],
+                    }),
+                )
+                .await
+            }
+        };
+
+        let created = publish()
+            .await
+            .unwrap_or_else(|e| panic!("first publish should succeed on {backend}: {e:?}"))
+            .into_response();
+        assert_eq!(
+            created.status(),
+            StatusCode::CREATED,
+            "first publish should create the list on {backend}"
+        );
+
+        let err = match publish().await {
+            Ok(_) => panic!("the losing publisher must not report success on {backend}"),
+            Err(e) => e,
+        };
+        assert_eq!(
+            err.status,
+            StatusCode::CONFLICT,
+            "a duplicate publish must map to 409, not 500, on {backend}"
+        );
+        // The status code alone does not pin the contract: 409 is also the
+        // credential-conflict code. Assert the documented error identity too.
+        assert_eq!(
+            err.error, "status_list_already_exists",
+            "the 409 must carry the status-list conflict code on {backend}"
+        );
+    }
+
+    /// Postgres is the production backend, and the one where this could
+    /// plausibly diverge: a failed statement poisons the transaction (`25P02`),
+    /// so a classification read from the rollback rather than from the original
+    /// `23505` would degrade to a 500 here and nowhere else.
+    #[cfg(feature = "postgres-tests")]
+    #[tokio::test]
+    async fn test_postgres_publish_duplicate_returns_409_not_500() {
+        let test_db =
+            crate::outbound::sql::test_containers::postgres_helpers::postgres_connection().await;
+        assert_publish_duplicate_is_conflict(
+            test_db.db.clone(),
+            "issuer-race-postgres",
+            "Postgres",
+        )
+        .await;
+    }
+
+    /// The same end-to-end proof on MySQL, whose driver reports duplicate keys
+    /// in a different wire format (`1062`) that `sql_err()` has to normalise.
+    #[cfg(feature = "mysql")]
+    #[tokio::test]
+    async fn test_mysql_publish_duplicate_returns_409_not_500() {
+        let test_db =
+            crate::outbound::sql::test_containers::mysql_helpers::MysqlTestDb::start().await;
+        assert_publish_duplicate_is_conflict(
+            test_db.connection().await,
+            "issuer-race-mysql",
+            "MySQL",
+        )
+        .await;
+    }
+
     #[tokio::test]
     async fn test_publish_status_rejects_too_many_statuses() {
         let token_id = uuid::Uuid::new_v4().to_string();

--- a/src/test_fixtures.rs
+++ b/src/test_fixtures.rs
@@ -10,8 +10,12 @@
 ///
 /// `server::auth` keeps its own copy on purpose: there it is the public half of
 /// a matched keypair, and splitting the halves across modules would hide that
-/// the PEM and the JWK correspond.
-#[allow(dead_code)]
+/// the PEM and the JWK correspond. Do not "deduplicate" the two.
+///
+/// Gated rather than `#[allow(dead_code)]` so that it stays genuinely dead-code
+/// checked: every consumer is behind one of these features, and if the last one
+/// goes away the constant should start warning instead of sitting here forever.
+#[cfg(any(feature = "sqlite", feature = "mysql", feature = "postgres-tests"))]
 pub(crate) const TEST_EC_PUBLIC_JWK: &str = r#"{
     "kty": "EC",
     "crv": "P-256",

--- a/src/test_fixtures.rs
+++ b/src/test_fixtures.rs
@@ -12,10 +12,11 @@
 /// a matched keypair, and splitting the halves across modules would hide that
 /// the PEM and the JWK correspond. Do not "deduplicate" the two.
 ///
-/// Gated rather than `#[allow(dead_code)]` so that it stays genuinely dead-code
-/// checked: every consumer is behind one of these features, and if the last one
-/// goes away the constant should start warning instead of sitting here forever.
-#[cfg(any(feature = "sqlite", feature = "mysql", feature = "postgres-tests"))]
+/// Deliberately carries neither a `cfg` nor `#[allow(dead_code)]`. Both the
+/// container-backed store proofs and the memory-backed handler tests use it, and
+/// the latter are ungated — so it is live in every test build, and dead-code
+/// analysis stays meaningful. A `cfg` narrowed to the SQL backends would break
+/// `cargo test` under default features.
 pub(crate) const TEST_EC_PUBLIC_JWK: &str = r#"{
     "kty": "EC",
     "crv": "P-256",

--- a/src/test_fixtures.rs
+++ b/src/test_fixtures.rs
@@ -1,0 +1,20 @@
+//! Literal test data shared across test modules.
+//!
+//! Deliberately free of feature gates and dependencies — everything here is a
+//! plain `&str`, so any test module can reach it whatever its own gate. That is
+//! the point: [`crate::test_utils`] pulls in the memory and SQL adapters, so a
+//! test module compiled without them cannot host shared data there.
+
+/// A syntactically valid P-256 public JWK, for tests that need a key they never
+/// verify anything against.
+///
+/// `server::auth` keeps its own copy on purpose: there it is the public half of
+/// a matched keypair, and splitting the halves across modules would hide that
+/// the PEM and the JWK correspond.
+#[allow(dead_code)]
+pub(crate) const TEST_EC_PUBLIC_JWK: &str = r#"{
+    "kty": "EC",
+    "crv": "P-256",
+    "x": "NeyFv_2L67OEplNbJpR02IFis4_lFW9HYmhfF5Or6m8",
+    "y": "eAH2qe8Pg3GQ28uxA8-qNAqdwQ_zfV2uKAvJ2sLpY9M"
+}"#;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,3 +1,10 @@
+//! Test harness: builds a wired [`AppState`] over the memory or SQL adapters.
+//!
+//! Shared test *data* does not belong here. This module pulls in the adapters,
+//! so anything defined in it is unreachable from a test module compiled without
+//! them. Put plain literals in [`crate::test_fixtures`], which is dependency-
+//! free precisely so that any test module can reach it whatever its own gate.
+
 use crate::domain::ports::{CredentialRepo, StatusListRepo, StatusListSnapshotRepo};
 use crate::domain::service::Service;
 use crate::outbound::cache::MokaStatusListCache;
@@ -49,6 +56,40 @@ pub(crate) async fn test_app_state(db_conn: Option<Arc<sea_orm::DatabaseConnecti
 #[cfg(not(feature = "history"))]
 pub(crate) async fn test_app_state(_db_conn: Option<Arc<()>>) -> AppState {
     build_test_app_state(None, 1_048_576).await
+}
+
+/// An [`AppState`] whose `Service` has **no** snapshot repo, as built when an
+/// operator sets `snapshot_retention_secs = 0`.
+///
+/// That configuration routes publishes down `Service::publish_status_list`'s
+/// `None` branch to the plain, non-transactional `insert`, which is a different
+/// duplicate-classification call site from `insert_with_snapshot`. Memory-backed
+/// because the branch being exercised is in the service, not the adapter.
+pub(crate) async fn test_app_state_without_snapshots() -> AppState {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+    let service = Arc::new(Service::from_arcs(
+        Arc::new(MemoryStatusLists::default()),
+        Arc::new(MemoryCredentials::default()),
+        Arc::new(MokaStatusListCache::new(5 * 60, 100)),
+        None,
+        Arc::new(TestCertProvider {
+            key_pem: include_str!("../test_data/ec-private.pem").to_string(),
+            cert_chain: vec!["ZHVtbXlfY2VydA==".into()],
+        }),
+    ));
+
+    AppState {
+        service,
+        server_domain: "example.com".to_string(),
+        aggregation_uri: None,
+        token_exp_secs: 900,
+        token_ttl_secs: 300,
+        max_status_index: 100_000,
+        max_statuses_per_request: 5_000,
+        max_serialized_list_size: 1_048_576,
+        snapshot_retention_secs: 0,
+    }
 }
 
 pub(crate) struct TestCertProvider {


### PR DESCRIPTION
### Problem
 
#244 fixed the original defect `insert_one_with_snapshot` (`store.rs:63-118`), the port (`mod.rs:246`), and the wiring (`application/mod.rs:317`) all shipped. What's left is a cross-backend gap:
 
| | sqlite | MySQL | Postgres | memory |
|---|---|---|---|---|
| `update_one_with_snapshot` | ✅ | ✅ | ✅ | ✅ |
| `insert_one_with_snapshot` | ✅ | ❌ | ❌ | ✅ |
 
The gap is narrower than "port the sqlite test." Rollback itself is already proven on MySQL and Postgres by the update-path tests, and both functions use the same transaction mechanism - copying would mostly re-prove InnoDB works.
 
The untested property: **does a unique-constraint violation raised inside an open transaction still parse to `SqlErr::UniqueConstraintViolation` after the rollback runs?** `insert_one_with_snapshot` rolls back first, then classifies (`store.rs:81-94`). `test_mysql_duplicate_insert_maps_to_duplicate_entry` only covers the non-transactional `insert_one`. Postgres is where this plausibly diverges - a failed statement poisons the transaction (`25P02`) and the error surfaces through a rollback the sqlite test never exercises in that shape.
 
### Acceptance criteria
 
- [ ] MySQL test asserts duplicate `list_id` classifies as `DuplicateEntry`
- [ ] Postgres test asserts the same
- [ ] Both assert the HTTP-layer result is 409, not 500
- [ ] If classification diverges on Postgres, the fix lands with the test