### PR TITLE
279 derived history feature to collapse repeated cfg gates

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -6,6 +6,9 @@ ignore = [
   # proc-macro-error2 is unmaintained and is used in sea-orm.
   # We temporarily ignore it until a fix is available.
   "RUSTSEC-2026-0173",
+  # rkyv 0.7.46 (via rust_decimal) has no patched 0.7.x release and is not
+  # activated in the build. We temporarily ignore it until upstream bumps rkyv.
+  "RUSTSEC-2026-0235",
 ]  # advisory IDs to ignore
 
 informational_warnings = ["unmaintained"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,11 @@ edition = "2024"
 [features]
 default = ["memory"]
 memory = []
-postgres = ["dep:sea-orm", "dep:sea-orm-migration", "sea-orm?/sqlx-postgres"]
-sqlite = ["dep:sea-orm", "dep:sea-orm-migration", "sea-orm?/sqlx-sqlite"]
-mysql = ["dep:sea-orm", "dep:sea-orm-migration", "sea-orm?/sqlx-mysql"]
+history = []
+server = ["history"]
+postgres = ["dep:sea-orm", "dep:sea-orm-migration", "sea-orm?/sqlx-postgres", "history"]
+sqlite = ["dep:sea-orm", "dep:sea-orm-migration", "sea-orm?/sqlx-sqlite", "history"]
+mysql = ["dep:sea-orm", "dep:sea-orm-migration", "sea-orm?/sqlx-mysql", "history"]
 redis = ["dep:redis"]
 aws = [
   "dep:aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2024"
 [features]
 default = ["memory"]
 memory = []
-history = []
+history = ["dep:sea-orm", "dep:sea-orm-migration"]
 server = ["history"]
-postgres = ["dep:sea-orm", "dep:sea-orm-migration", "sea-orm?/sqlx-postgres", "history"]
-sqlite = ["dep:sea-orm", "dep:sea-orm-migration", "sea-orm?/sqlx-sqlite", "history"]
-mysql = ["dep:sea-orm", "dep:sea-orm-migration", "sea-orm?/sqlx-mysql", "history"]
+postgres = ["sea-orm?/sqlx-postgres", "history"]
+sqlite = ["sea-orm?/sqlx-sqlite", "history"]
+mysql = ["sea-orm?/sqlx-mysql", "history"]
 redis = ["dep:redis"]
 aws = [
   "dep:aws-config",

--- a/deny.toml
+++ b/deny.toml
@@ -20,7 +20,10 @@ unmaintained = "workspace"
 ignore = [
   # Present in rsa crate. As there is currently no available fix for this vulnerability,
   # this change temporarily ignores the advisory to allow CI/CD pipelines to pass
-  "RUSTSEC-2023-0071"
+  "RUSTSEC-2023-0071",
+  # rkyv 0.7.46 (via rust_decimal) has no patched 0.7.x release and is not
+  # activated in the build. We temporarily ignore it until upstream bumps rkyv.
+  "RUSTSEC-2026-0235"
 ]
 
 [bans]

--- a/src/outbound/mod.rs
+++ b/src/outbound/mod.rs
@@ -6,5 +6,5 @@ pub mod cert;
 pub mod memory;
 #[cfg(feature = "redis")]
 pub mod redis;
-#[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
+#[cfg(feature = "history")]
 pub mod sql;

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -2,19 +2,34 @@
 
 #[cfg(feature = "aws")]
 use aws_config::{BehaviorVersion, Region};
-#[cfg(any(feature = "acme", feature = "history"))]
+#[cfg(any(
+    feature = "acme",
+    feature = "sqlite",
+    feature = "postgres",
+    feature = "mysql"
+))]
 use color_eyre::eyre::Context;
 use color_eyre::eyre::Result as EyeResult;
-#[cfg(any(feature = "acme", feature = "history"))]
+#[cfg(feature = "acme")]
 use color_eyre::eyre::eyre;
 #[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
 use sea_orm::ConnectOptions;
 #[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
 use sea_orm_migration::MigratorTrait;
-#[cfg(any(feature = "acme", feature = "history"))]
+#[cfg(any(
+    feature = "acme",
+    feature = "sqlite",
+    feature = "postgres",
+    feature = "mysql"
+))]
 use secrecy::ExposeSecret;
 use std::sync::Arc;
-#[cfg(any(feature = "acme", feature = "history"))]
+#[cfg(any(
+    feature = "acme",
+    feature = "sqlite",
+    feature = "postgres",
+    feature = "mysql"
+))]
 use std::time::Duration;
 #[cfg(feature = "acme")]
 use tracing::warn;

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -2,39 +2,19 @@
 
 #[cfg(feature = "aws")]
 use aws_config::{BehaviorVersion, Region};
-#[cfg(any(
-    feature = "acme",
-    feature = "sqlite",
-    feature = "postgres",
-    feature = "mysql"
-))]
+#[cfg(any(feature = "acme", feature = "history"))]
 use color_eyre::eyre::Context;
 use color_eyre::eyre::Result as EyeResult;
-#[cfg(any(
-    feature = "acme",
-    feature = "sqlite",
-    feature = "postgres",
-    feature = "mysql"
-))]
+#[cfg(any(feature = "acme", feature = "history"))]
 use color_eyre::eyre::eyre;
 #[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
 use sea_orm::ConnectOptions;
 #[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
 use sea_orm_migration::MigratorTrait;
-#[cfg(any(
-    feature = "acme",
-    feature = "sqlite",
-    feature = "postgres",
-    feature = "mysql"
-))]
+#[cfg(any(feature = "acme", feature = "history"))]
 use secrecy::ExposeSecret;
 use std::sync::Arc;
-#[cfg(any(
-    feature = "acme",
-    feature = "sqlite",
-    feature = "postgres",
-    feature = "mysql"
-))]
+#[cfg(any(feature = "acme", feature = "history"))]
 use std::time::Duration;
 #[cfg(feature = "acme")]
 use tracing::warn;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -3,7 +3,7 @@ use crate::domain::service::Service;
 use crate::outbound::cache::MokaStatusListCache;
 #[cfg(feature = "memory")]
 use crate::outbound::memory::{MemoryCredentials, MemoryStatusListHistory, MemoryStatusLists};
-#[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
+#[cfg(feature = "history")]
 use crate::outbound::sql::{
     SeaOrmStore, SqlCredentialRepo, SqlStatusListHistoryRepo, SqlStatusListRepo,
 };
@@ -41,12 +41,12 @@ impl Storage for MockStorage {
     }
 }
 
-#[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
+#[cfg(feature = "history")]
 pub(crate) async fn test_app_state(db_conn: Option<Arc<sea_orm::DatabaseConnection>>) -> AppState {
     build_test_app_state(db_conn, None, 1_048_576).await
 }
 
-#[cfg(not(any(feature = "sqlite", feature = "postgres", feature = "mysql")))]
+#[cfg(not(feature = "history"))]
 pub(crate) async fn test_app_state(_db_conn: Option<Arc<()>>) -> AppState {
     build_test_app_state(None, 1_048_576).await
 }
@@ -72,9 +72,7 @@ impl crate::domain::ports::CertificateProvider for TestCertProvider {
 }
 
 async fn build_test_app_state(
-    #[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))] db_conn: Option<
-        Arc<sea_orm::DatabaseConnection>,
-    >,
+    #[cfg(feature = "history")] db_conn: Option<Arc<sea_orm::DatabaseConnection>>,
     aggregation_uri: Option<String>,
     max_serialized_list_size: usize,
 ) -> AppState {
@@ -85,7 +83,7 @@ async fn build_test_app_state(
     let memory_history = MemoryStatusListHistory::default();
     let memory_lists = MemoryStatusLists::default().with_history(&memory_history);
 
-    #[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
+    #[cfg(feature = "history")]
     let (status_lists, credentials, status_list_history): (
         Arc<dyn StatusListRepo>,
         Arc<dyn CredentialRepo>,
@@ -104,7 +102,7 @@ async fn build_test_app_state(
         )
     };
 
-    #[cfg(not(any(feature = "sqlite", feature = "postgres", feature = "mysql")))]
+    #[cfg(not(feature = "history"))]
     let (status_lists, credentials, status_list_history): (
         Arc<dyn StatusListRepo>,
         Arc<dyn CredentialRepo>,

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -2,7 +2,7 @@ use crate::domain::ports::{CredentialRepo, StatusListRepo, StatusListSnapshotRep
 use crate::domain::service::Service;
 use crate::outbound::cache::MokaStatusListCache;
 #[cfg(feature = "memory")]
-use crate::outbound::memory::{MemoryCredentials, MemoryStatusListHistory, MemoryStatusLists};
+use crate::outbound::memory::{MemoryCredentials, MemoryStatusListSnapshotRepo, MemoryStatusLists};
 #[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
 use crate::outbound::sql::{
     SeaOrmStore, SqlCredentialRepo, SqlStatusListRepo, SqlStatusListSnapshotRepo,
@@ -123,7 +123,7 @@ async fn build_test_app_state(
         status_lists,
         credentials,
         status_list_cache,
-        Some(status_list_snapshot),
+        Some(status_list_history),
         cert_provider,
     ));
 


### PR DESCRIPTION
The snapshot methods on the public StatusListRepository trait are gated on #[cfg(any(feature = "server", "postgres", "sqlite", "mysql"))], and that same six-line attribute is copy-pasted ~20 times across ports/mod.rs, application/mod.rs, and memory.rs.