### PR TITLE
278 unify snapshothistory naming

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -133,6 +133,11 @@ APP_CACHE__MAX_CAPACITY=1000
 APP_STATUS_LIST__TOKEN_EXP_SECS=900
 # Token TTL in seconds (advertised lifetime of the status list token)
 APP_STATUS_LIST__TOKEN_TTL_SECS=300
+# Retention period for snapshots in seconds (default 90 days).
+# Set to 0 to disable snapshots entirely (draft-21 §12.7 privacy note).
+# DEPRECATED: APP_STATUS_LIST__HISTORY_RETENTION_SECS is still accepted but
+# will be removed in a future release.
+APP_STATUS_LIST__SNAPSHOT_RETENTION_SECS=7776000
 
 # Rate limiting (#171): strict (write endpoints), permissive (public reads)
 APP_RATE_LIMIT__STRICT_BURST_SIZE=10

--- a/src/config.rs
+++ b/src/config.rs
@@ -559,7 +559,8 @@ pub struct StatusListConfig {
     /// This prevents unbounded database growth and mitigates timing leak
     /// risks described in draft-21 §12.7. When disabled, historical resolution
     /// via `?time=` query parameter will not be available.
-    pub history_retention_secs: u64,
+    #[serde(alias = "history_retention_secs")]
+    pub snapshot_retention_secs: u64,
 }
 
 #[cfg(feature = "redis")]
@@ -740,7 +741,7 @@ fn base_builder() -> Result<ConfigBuilder<DefaultState>, ConfigError> {
         .set_default("cache.max_capacity", 100)?
         .set_default("status_list.token_exp_secs", 900)?
         .set_default("status_list.token_ttl_secs", 300)?
-        .set_default("status_list.history_retention_secs", 7776000)?
+        .set_default("status_list.snapshot_retention_secs", 7776000)?
         .set_default("rate_limit.strict_burst_size", 10)?
         .set_default("rate_limit.strict_period_secs", 60)?
         .set_default("rate_limit.permissive_burst_size", 100)?

--- a/src/config.rs
+++ b/src/config.rs
@@ -551,14 +551,19 @@ pub struct CacheConfig {
 pub struct StatusListConfig {
     pub token_exp_secs: u64,
     pub token_ttl_secs: u64,
-    /// Retention period for historical status list snapshots in seconds.
+    /// Retention period for status list snapshots in seconds.
     /// Snapshots older than this will be deleted by a scheduled cleanup task.
     /// Default is 90 days (7776000 seconds).
     ///
-    /// **Privacy note:** Set to 0 to disable historical snapshots entirely.
+    /// **Privacy note:** Set to 0 to disable snapshots entirely.
     /// This prevents unbounded database growth and mitigates timing leak
     /// risks described in draft-21 §12.7. When disabled, historical resolution
     /// via `?time=` query parameter will not be available.
+    ///
+    /// **Deprecation:** The old name `history_retention_secs`
+    /// (`APP_STATUS_LIST__HISTORY_RETENTION_SECS`) is accepted for backward
+    /// compatibility but will be removed in a future release. Use
+    /// `snapshot_retention_secs` (`APP_STATUS_LIST__SNAPSHOT_RETENTION_SECS`).
     #[serde(alias = "history_retention_secs")]
     pub snapshot_retention_secs: u64,
 }

--- a/src/domain/ports.rs
+++ b/src/domain/ports.rs
@@ -64,7 +64,7 @@ pub trait StatusListCache: Send + Sync + 'static {
 
 /// Persistence interface for historical status list snapshots.
 #[async_trait]
-pub trait StatusListHistoryRepo: Send + Sync + 'static {
+pub trait StatusListSnapshotRepo: Send + Sync + 'static {
     /// Save a historical status list snapshot.
     async fn insert(&self, record: StatusListSnapshot) -> Result<(), StatusListError>;
 

--- a/src/domain/service.rs
+++ b/src/domain/service.rs
@@ -229,8 +229,9 @@ impl Service {
         self.status_list_repo.list_uris().await
     }
 
-    /// Retrieve a historical status list snapshot active at a specific Unix timestamp.
-    pub async fn get_historical_snapshot(
+    /// Retrieve the snapshot that was active at the given Unix timestamp
+    /// (historical resolution per draft-21 §8.4).
+    pub async fn get_snapshot_at(
         &self,
         list_id: &str,
         time: i64,
@@ -243,8 +244,8 @@ impl Service {
             .ok_or(StatusListError::HistoricalNotFound)
     }
 
-    /// Purge historical snapshots older than `cutoff` timestamp.
-    pub async fn cleanup_historical_snapshots(&self, cutoff: i64) -> Result<u64, StatusListError> {
+    /// Purge snapshots older than `cutoff` timestamp.
+    pub async fn cleanup_snapshots(&self, cutoff: i64) -> Result<u64, StatusListError> {
         let Some(snapshot_repo) = &self.snapshot_repo else {
             return Ok(0);
         };

--- a/src/domain/service.rs
+++ b/src/domain/service.rs
@@ -7,7 +7,7 @@ use crate::domain::models::status_list::{
     StatusEntry, StatusList, StatusListError, StatusListRecord, StatusListSnapshot,
 };
 use crate::domain::ports::{
-    CertificateProvider, CredentialRepo, StatusListCache, StatusListHistoryRepo, StatusListRepo,
+    CertificateProvider, CredentialRepo, StatusListCache, StatusListRepo, StatusListSnapshotRepo,
 };
 
 /// Container struct for building and exposing external service ports injected into handlers.
@@ -16,7 +16,7 @@ pub struct Service {
     pub(crate) status_list_repo: Arc<dyn StatusListRepo>,
     pub(crate) credential_repo: Arc<dyn CredentialRepo>,
     pub(crate) status_list_cache: Arc<dyn StatusListCache>,
-    pub(crate) history_repo: Option<Arc<dyn StatusListHistoryRepo>>,
+    pub(crate) snapshot_repo: Option<Arc<dyn StatusListSnapshotRepo>>,
     pub(crate) cert_provider: Arc<dyn CertificateProvider>,
 }
 
@@ -25,14 +25,14 @@ impl Service {
         status_list_repo: Arc<dyn StatusListRepo>,
         credential_repo: Arc<dyn CredentialRepo>,
         status_list_cache: Arc<dyn StatusListCache>,
-        history_repo: Option<Arc<dyn StatusListHistoryRepo>>,
+        snapshot_repo: Option<Arc<dyn StatusListSnapshotRepo>>,
         cert_provider: Arc<dyn CertificateProvider>,
     ) -> Self {
         Self {
             status_list_repo,
             credential_repo,
             status_list_cache,
-            history_repo,
+            snapshot_repo,
             cert_provider,
         }
     }
@@ -41,7 +41,7 @@ impl Service {
         status_list_repo: S,
         credential_repo: C,
         status_list_cache: SC,
-        history_repo: Option<Arc<dyn StatusListHistoryRepo>>,
+        snapshot_repo: Option<Arc<dyn StatusListSnapshotRepo>>,
         cert_provider: CP,
     ) -> Self
     where
@@ -54,7 +54,7 @@ impl Service {
             status_list_repo: Arc::new(status_list_repo),
             credential_repo: Arc::new(credential_repo),
             status_list_cache: Arc::new(status_list_cache),
-            history_repo,
+            snapshot_repo,
             cert_provider: Arc::new(cert_provider),
         }
     }
@@ -71,8 +71,8 @@ impl Service {
         self.status_list_cache.as_ref()
     }
 
-    pub fn history_repo(&self) -> Option<&dyn StatusListHistoryRepo> {
-        self.history_repo.as_deref()
+    pub fn snapshot_repo(&self) -> Option<&dyn StatusListSnapshotRepo> {
+        self.snapshot_repo.as_deref()
     }
 
     pub fn cert_provider(&self) -> &dyn CertificateProvider {
@@ -122,7 +122,7 @@ impl Service {
             return Err(StatusListError::AlreadyExists);
         }
 
-        match &self.history_repo {
+        match &self.snapshot_repo {
             Some(_) => {
                 let snapshot = build_snapshot(&record, token_exp_secs);
                 self.status_list_repo
@@ -181,7 +181,7 @@ impl Service {
         let previous_updated_at = existing.updated_at;
         existing.updated_at = next_updated_at(previous_updated_at, current_unix_timestamp());
 
-        let landed = match &self.history_repo {
+        let landed = match &self.snapshot_repo {
             Some(_) => {
                 let snapshot = build_snapshot(&existing, token_exp_secs);
                 self.status_list_repo
@@ -235,7 +235,7 @@ impl Service {
         list_id: &str,
         time: i64,
     ) -> Result<StatusListSnapshot, StatusListError> {
-        self.history_repo
+        self.snapshot_repo
             .as_ref()
             .ok_or(StatusListError::NotFound)?
             .find_valid_at(list_id, time)
@@ -245,10 +245,10 @@ impl Service {
 
     /// Purge historical snapshots older than `cutoff` timestamp.
     pub async fn cleanup_historical_snapshots(&self, cutoff: i64) -> Result<u64, StatusListError> {
-        let Some(history) = &self.history_repo else {
+        let Some(snapshot_repo) = &self.snapshot_repo else {
             return Ok(0);
         };
-        history.delete_older_than(cutoff).await
+        snapshot_repo.delete_older_than(cutoff).await
     }
 
     /// Publish new credentials for an issuer after verifying uniqueness invariant.
@@ -289,8 +289,8 @@ impl std::fmt::Debug for Service {
                 &std::any::type_name::<dyn StatusListCache>(),
             )
             .field(
-                "history_repo",
-                &std::any::type_name::<dyn StatusListHistoryRepo>(),
+                "snapshot_repo",
+                &std::any::type_name::<dyn StatusListSnapshotRepo>(),
             )
             .field(
                 "cert_provider",

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use status_list_server::cert_manager::{describe_renewal_metrics, setup_cert_rene
 use status_list_server::setup::build_state;
 #[cfg(feature = "acme")]
 use status_list_server::setup::build_state_with_cert_manager;
-use status_list_server::setup::setup_history_cleanup_scheduler;
+use status_list_server::setup::setup_snapshot_cleanup_scheduler;
 use status_list_server::{config::Config as AppConfig, startup::HttpServer};
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
@@ -52,9 +52,9 @@ async fn main() -> Result<()> {
     .await?;
 
     // Setup historical snapshot cleanup scheduler (runs daily at midnight UTC)
-    // This deletes snapshots older than history_retention_secs to prevent
+    // This deletes snapshots older than snapshot_retention_secs to prevent
     // unbounded database growth and mitigate privacy risks (draft-21 §12.7)
-    setup_history_cleanup_scheduler(app_state.clone(), "0 0 0 * * *").await?;
+    setup_snapshot_cleanup_scheduler(app_state.clone(), "0 0 0 * * *").await?;
 
     let http_server = HttpServer::new(&config, app_state).await?;
 

--- a/src/outbound/memory.rs
+++ b/src/outbound/memory.rs
@@ -7,27 +7,27 @@ use crate::cert_manager::storage::StorageError;
 use crate::domain::models::credential::{Credential, CredentialError};
 use crate::domain::models::status_list::{StatusListError, StatusListRecord, StatusListSnapshot};
 use crate::domain::ports::{
-    CredentialRepo, StatusListCache, StatusListHistoryRepo, StatusListRepo,
+    CredentialRepo, StatusListCache, StatusListRepo, StatusListSnapshotRepo,
 };
 
 #[derive(Clone, Default)]
 pub struct MemoryStatusLists {
     values: Arc<RwLock<HashMap<String, StatusListRecord>>>,
-    history: Option<Arc<RwLock<HashMap<String, StatusListSnapshot>>>>,
+    snapshot: Option<Arc<RwLock<HashMap<String, StatusListSnapshot>>>>,
 }
 
 impl MemoryStatusLists {
-    pub fn with_history(mut self, history: &MemoryStatusListHistory) -> Self {
-        self.history = Some(history.values.clone());
+    pub fn with_snapshot(mut self, snapshot_repo: &MemoryStatusListSnapshotRepo) -> Self {
+        self.snapshot = Some(snapshot_repo.values.clone());
         self
     }
 
-    fn require_history(
+    fn require_snapshot(
         &self,
     ) -> Result<&Arc<RwLock<HashMap<String, StatusListSnapshot>>>, StatusListError> {
-        self.history.as_ref().ok_or_else(|| {
+        self.snapshot.as_ref().ok_or_else(|| {
             StatusListError::Backend(
-                "MemoryStatusLists was built without shared history storage; construct it with `.with_history(..)`"
+                "MemoryStatusLists was built without shared snapshot storage; construct it with `.with_snapshot(..)`"
                     .into(),
             )
         })
@@ -72,13 +72,13 @@ impl StatusListRepo for MemoryStatusLists {
         expected_updated_at: i64,
         snapshot: StatusListSnapshot,
     ) -> Result<bool, StatusListError> {
-        let history = self.require_history()?;
+        let snapshot_store = self.require_snapshot()?;
         let mut values = self.values.write().await;
         match values.get(&record.list_id) {
             Some(current) if current.updated_at == expected_updated_at => {}
             _ => return Ok(false),
         }
-        history
+        snapshot_store
             .write()
             .await
             .insert(snapshot.snapshot_id.clone(), snapshot);
@@ -91,13 +91,13 @@ impl StatusListRepo for MemoryStatusLists {
         record: StatusListRecord,
         snapshot: StatusListSnapshot,
     ) -> Result<(), StatusListError> {
-        let history = self.require_history()?;
+        let snapshot_store = self.require_snapshot()?;
         let mut values = self.values.write().await;
         use std::collections::hash_map::Entry;
         match values.entry(record.list_id.clone()) {
             Entry::Occupied(_) => Err(StatusListError::AlreadyExists),
             Entry::Vacant(e) => {
-                history
+                snapshot_store
                     .write()
                     .await
                     .insert(snapshot.snapshot_id.clone(), snapshot);
@@ -169,12 +169,12 @@ impl CredentialRepo for MemoryCredentials {
 }
 
 #[derive(Clone, Default)]
-pub struct MemoryStatusListHistory {
+pub struct MemoryStatusListSnapshotRepo {
     values: Arc<RwLock<HashMap<String, StatusListSnapshot>>>,
 }
 
 #[async_trait]
-impl StatusListHistoryRepo for MemoryStatusListHistory {
+impl StatusListSnapshotRepo for MemoryStatusListSnapshotRepo {
     async fn insert(&self, record: StatusListSnapshot) -> Result<(), StatusListError> {
         self.values
             .write()
@@ -263,15 +263,15 @@ mod tests {
     fn create_test_service(
         repo: MemoryStatusLists,
         cache: MemoryStatusListCache,
-        history_repo: Option<MemoryStatusListHistory>,
+        snapshot_repo: Option<MemoryStatusListSnapshotRepo>,
     ) -> Service {
-        let history_arc: Option<Arc<dyn crate::domain::ports::StatusListHistoryRepo>> =
-            history_repo.map(|h| Arc::new(h) as _);
+        let snapshot_arc: Option<Arc<dyn crate::domain::ports::StatusListSnapshotRepo>> =
+            snapshot_repo.map(|h| Arc::new(h) as _);
         Service::from_arcs(
             Arc::new(repo),
             Arc::new(MemoryCredentials::default()),
             Arc::new(cache),
-            history_arc,
+            snapshot_arc,
             Arc::new(DummyCertProvider),
         )
     }

--- a/src/outbound/sql/mod.rs
+++ b/src/outbound/sql/mod.rs
@@ -14,7 +14,7 @@ use async_trait::async_trait;
 
 use crate::domain::models::credential::{Credential, CredentialError, Issuer, PublicJwk};
 use crate::domain::models::status_list::{StatusListError, StatusListRecord, StatusListSnapshot};
-use crate::domain::ports::{CredentialRepo, StatusListHistoryRepo, StatusListRepo};
+use crate::domain::ports::{CredentialRepo, StatusListRepo, StatusListSnapshotRepo};
 
 /// SQL relational adapter implementing `StatusListRepo`.
 #[derive(Clone)]
@@ -40,13 +40,13 @@ impl SqlCredentialRepo {
     }
 }
 
-/// SQL relational adapter implementing `StatusListHistoryRepo`.
+/// SQL relational adapter implementing `StatusListSnapshotRepo`.
 #[derive(Clone)]
-pub struct SqlStatusListHistoryRepo {
+pub struct SqlStatusListSnapshotRepo {
     store: SeaOrmStore<models::StatusListHistoryRecord>,
 }
 
-impl SqlStatusListHistoryRepo {
+impl SqlStatusListSnapshotRepo {
     pub fn new(store: SeaOrmStore<models::StatusListHistoryRecord>) -> Self {
         Self { store }
     }
@@ -140,7 +140,7 @@ impl StatusListRepo for SqlStatusListRepo {
 }
 
 #[async_trait]
-impl StatusListHistoryRepo for SqlStatusListHistoryRepo {
+impl StatusListSnapshotRepo for SqlStatusListSnapshotRepo {
     async fn insert(&self, record: StatusListSnapshot) -> Result<(), StatusListError> {
         self.store
             .insert_one(record.into())

--- a/src/server/handlers/status_list/get_status_list.rs
+++ b/src/server/handlers/status_list/get_status_list.rs
@@ -160,7 +160,7 @@ async fn handle_historical_request(
         now - time
     );
 
-    let snapshot = state.service.get_historical_snapshot(list_id, time).await?;
+    let snapshot = state.service.get_snapshot_at(list_id, time).await?;
 
     let etag = generate_historical_etag(&snapshot);
     let last_modified = format_http_date(snapshot.iat);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -20,5 +20,5 @@ pub struct AppState {
     pub max_status_index: i32,
     pub max_statuses_per_request: usize,
     pub max_serialized_list_size: usize,
-    pub history_retention_secs: u64,
+    pub snapshot_retention_secs: u64,
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -58,7 +58,7 @@ use crate::config::{
     DnsProviderKind, ENV_DEVELOPMENT, ENV_PRODUCTION, GcloudKeySource, ResolvedDnsProvider,
 };
 use crate::domain::{
-    ports::{CertificateProvider, CredentialRepo, StatusListHistoryRepo, StatusListRepo},
+    ports::{CertificateProvider, CredentialRepo, StatusListRepo, StatusListSnapshotRepo},
     service::Service,
 };
 #[cfg(feature = "aws")]
@@ -67,12 +67,12 @@ use crate::outbound::cache::MokaStatusListCache;
 #[cfg(feature = "acme")]
 use crate::outbound::cert::AcmeCertificateProvider;
 #[cfg(feature = "memory")]
-use crate::outbound::memory::{MemoryCredentials, MemoryStatusListHistory, MemoryStatusLists};
+use crate::outbound::memory::{MemoryCredentials, MemoryStatusListSnapshotRepo, MemoryStatusLists};
 #[cfg(feature = "redis")]
 use crate::outbound::redis::Redis;
 #[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
 use crate::outbound::sql::{
-    Migrator, SeaOrmStore, SqlCredentialRepo, SqlStatusListHistoryRepo, SqlStatusListRepo,
+    Migrator, SeaOrmStore, SqlCredentialRepo, SqlStatusListRepo, SqlStatusListSnapshotRepo,
 };
 use crate::server::AppState;
 
@@ -114,19 +114,19 @@ type BuildStateResult = (AppState, Arc<CertManager>);
 type BuildStateResult = (AppState,);
 
 async fn build_state_impl(config: &AppConfig) -> EyeResult<BuildStateResult> {
-    let (status_list_repo, credential_repo, status_list_history): (
+    let (status_list_repo, credential_repo, status_list_snapshot): (
         Arc<dyn StatusListRepo>,
         Arc<dyn CredentialRepo>,
-        Arc<dyn StatusListHistoryRepo>,
+        Arc<dyn StatusListSnapshotRepo>,
     ) = match config.database.backend {
         #[cfg(feature = "memory")]
         DatabaseBackend::Memory => {
-            let memory_history = MemoryStatusListHistory::default();
-            let memory_lists = MemoryStatusLists::default().with_history(&memory_history);
+            let memory_snapshot = MemoryStatusListSnapshotRepo::default();
+            let memory_lists = MemoryStatusLists::default().with_snapshot(&memory_snapshot);
             (
                 Arc::new(memory_lists),
                 Arc::new(MemoryCredentials::default()),
-                Arc::new(memory_history),
+                Arc::new(memory_snapshot),
             )
         }
         #[cfg(not(feature = "memory"))]
@@ -175,7 +175,7 @@ async fn build_state_impl(config: &AppConfig) -> EyeResult<BuildStateResult> {
             (
                 Arc::new(SqlStatusListRepo::new(SeaOrmStore::new(db_clone.clone()))),
                 Arc::new(SqlCredentialRepo::new(SeaOrmStore::new(db_clone.clone()))),
-                Arc::new(SqlStatusListHistoryRepo::new(SeaOrmStore::new(
+                Arc::new(SqlStatusListSnapshotRepo::new(SeaOrmStore::new(
                     db_clone.clone(),
                 ))),
             )
@@ -328,17 +328,17 @@ async fn build_state_impl(config: &AppConfig) -> EyeResult<BuildStateResult> {
 
     let status_list_cache = MokaStatusListCache::new(config.cache.ttl, config.cache.max_capacity);
 
-    let history_option = if config.status_list.history_retention_secs == 0 {
+    let snapshot_option = if config.status_list.snapshot_retention_secs == 0 {
         None
     } else {
-        Some(status_list_history)
+        Some(status_list_snapshot)
     };
 
     let service = Arc::new(Service::from_arcs(
         status_list_repo,
         credential_repo,
         Arc::new(status_list_cache),
-        history_option,
+        snapshot_option,
         cert_provider,
     ));
 
@@ -351,7 +351,7 @@ async fn build_state_impl(config: &AppConfig) -> EyeResult<BuildStateResult> {
         max_status_index: config.limits.max_status_index,
         max_statuses_per_request: config.limits.max_statuses_per_request,
         max_serialized_list_size: config.limits.max_serialized_list_size,
-        history_retention_secs: config.status_list.history_retention_secs,
+        snapshot_retention_secs: config.status_list.snapshot_retention_secs,
     };
 
     #[cfg(feature = "acme")]
@@ -364,16 +364,16 @@ async fn build_state_impl(config: &AppConfig) -> EyeResult<BuildStateResult> {
     }
 }
 
-pub async fn setup_history_cleanup_scheduler(
+pub async fn setup_snapshot_cleanup_scheduler(
     app_state: AppState,
     cron_schedule: &str,
 ) -> color_eyre::Result<()> {
     use tokio_cron_scheduler::{Job, JobScheduler};
     use tracing::{error, info};
 
-    if app_state.history_retention_secs == 0 {
+    if app_state.snapshot_retention_secs == 0 {
         info!(
-            "Historical snapshots are disabled (history_retention_secs=0), skipping cleanup scheduler"
+            "Historical snapshots are disabled (snapshot_retention_secs=0), skipping cleanup scheduler"
         );
         return Ok(());
     }
@@ -385,7 +385,7 @@ pub async fn setup_history_cleanup_scheduler(
             let app_state = app_state.clone();
             Box::pin(async move {
                 let now = time::OffsetDateTime::now_utc().unix_timestamp();
-                let cutoff = now - app_state.history_retention_secs as i64;
+                let cutoff = now - app_state.snapshot_retention_secs as i64;
 
                 match app_state
                     .service

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -389,7 +389,7 @@ pub async fn setup_snapshot_cleanup_scheduler(
 
                 match app_state
                     .service
-                    .cleanup_historical_snapshots(cutoff)
+                    .cleanup_snapshots(cutoff)
                     .await
                 {
                     Ok(deleted) => {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -94,9 +94,7 @@ async fn build_test_app_state(
         (
             Arc::new(SqlStatusListRepo::new(SeaOrmStore::new(db.clone()))),
             Arc::new(SqlCredentialRepo::new(SeaOrmStore::new(db.clone()))),
-            Arc::new(SqlStatusListSnapshotRepo::new(SeaOrmStore::new(
-                db.clone(),
-            ))),
+            Arc::new(SqlStatusListSnapshotRepo::new(SeaOrmStore::new(db.clone()))),
         )
     } else {
         (

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,11 +1,11 @@
-use crate::domain::ports::{CredentialRepo, StatusListHistoryRepo, StatusListRepo};
+use crate::domain::ports::{CredentialRepo, StatusListRepo, StatusListSnapshotRepo};
 use crate::domain::service::Service;
 use crate::outbound::cache::MokaStatusListCache;
 #[cfg(feature = "memory")]
-use crate::outbound::memory::{MemoryCredentials, MemoryStatusListHistory, MemoryStatusLists};
+use crate::outbound::memory::{MemoryCredentials, MemoryStatusListSnapshotRepo, MemoryStatusLists};
 #[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
 use crate::outbound::sql::{
-    SeaOrmStore, SqlCredentialRepo, SqlStatusListHistoryRepo, SqlStatusListRepo,
+    SeaOrmStore, SqlCredentialRepo, SqlStatusListRepo, SqlStatusListSnapshotRepo,
 };
 use crate::server::AppState;
 #[cfg(feature = "acme")]
@@ -82,37 +82,39 @@ async fn build_test_app_state(
 
     let key_pem = include_str!("../test_data/ec-private.pem").to_string();
 
-    let memory_history = MemoryStatusListHistory::default();
-    let memory_lists = MemoryStatusLists::default().with_history(&memory_history);
+    let memory_snapshot = MemoryStatusListSnapshotRepo::default();
+    let memory_lists = MemoryStatusLists::default().with_snapshot(&memory_snapshot);
 
     #[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
-    let (status_lists, credentials, status_list_history): (
+    let (status_lists, credentials, status_list_snapshot): (
         Arc<dyn StatusListRepo>,
         Arc<dyn CredentialRepo>,
-        Arc<dyn StatusListHistoryRepo>,
+        Arc<dyn StatusListSnapshotRepo>,
     ) = if let Some(db) = db_conn {
         (
             Arc::new(SqlStatusListRepo::new(SeaOrmStore::new(db.clone()))),
             Arc::new(SqlCredentialRepo::new(SeaOrmStore::new(db.clone()))),
-            Arc::new(SqlStatusListHistoryRepo::new(SeaOrmStore::new(db.clone()))),
+            Arc::new(SqlStatusListSnapshotRepo::new(SeaOrmStore::new(
+                db.clone(),
+            ))),
         )
     } else {
         (
             Arc::new(memory_lists),
             Arc::new(MemoryCredentials::default()),
-            Arc::new(memory_history),
+            Arc::new(memory_snapshot),
         )
     };
 
     #[cfg(not(any(feature = "sqlite", feature = "postgres", feature = "mysql")))]
-    let (status_lists, credentials, status_list_history): (
+    let (status_lists, credentials, status_list_snapshot): (
         Arc<dyn StatusListRepo>,
         Arc<dyn CredentialRepo>,
-        Arc<dyn StatusListHistoryRepo>,
+        Arc<dyn StatusListSnapshotRepo>,
     ) = (
         Arc::new(memory_lists),
         Arc::new(MemoryCredentials::default()),
-        Arc::new(memory_history),
+        Arc::new(memory_snapshot),
     );
 
     let status_list_cache = Arc::new(MokaStatusListCache::new(5 * 60, 100));
@@ -125,7 +127,7 @@ async fn build_test_app_state(
         status_lists,
         credentials,
         status_list_cache,
-        Some(status_list_history),
+        Some(status_list_snapshot),
         cert_provider,
     ));
 
@@ -138,6 +140,6 @@ async fn build_test_app_state(
         max_status_index: 100_000,
         max_statuses_per_request: 5_000,
         max_serialized_list_size,
-        history_retention_secs: 7776000,
+        snapshot_retention_secs: 7776000,
     }
 }


### PR DESCRIPTION

One concept, four names: the table is status_list_history, the port is StatusListHistoryRepository, the domain type is StatusListSnapshot, the struct field is history, the method says snapshot. A reader has to re-map constantly.