### PR TITLE
292 compact duplicate test code in configrs

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -604,8 +604,8 @@ impl RedisConfig {
     }
 }
 
-impl Config {
-    pub fn load() -> Result<Self, ConfigError> {
+macro_rules! set_config_defaults {
+    ($builder:expr) => {{
         #[cfg(feature = "postgres")]
         let (default_db_url, default_db_backend) = (
             "postgres://postgres:postgres@localhost:5432/status-list",
@@ -631,13 +631,12 @@ impl Config {
             ("store", Option::<String>::None, Option::<String>::None);
 
         #[cfg(feature = "acme")]
-        let default_chain_cache_ttl = crate::utils::cert_manager::DEFAULT_CHAIN_CACHE_TTL.as_secs();
+        let default_chain_cache_ttl =
+            crate::utils::cert_manager::DEFAULT_CHAIN_CACHE_TTL.as_secs();
         #[cfg(not(feature = "acme"))]
         let default_chain_cache_ttl = 86400;
 
-        // Build the config
-        let config = ConfigLib::builder()
-            // Set default values
+        $builder
             .set_default("server.host", "localhost")?
             .set_default("server.domain", "localhost")?
             .set_default("server.port", 8000)?
@@ -683,6 +682,21 @@ impl Config {
             .set_default("limits.max_statuses_per_request", 5_000)?
             .set_default("limits.max_serialized_list_size", 1_048_576)? // 1 MiB
             .set_default("status_list.history_retention_secs", 7776000)? // 90 days
+    }};
+}
+
+impl Config {
+    /// Creates a [`config::ConfigBuilder`] pre-populated with default configuration values.
+    pub fn base_builder(
+    ) -> Result<config::ConfigBuilder<config::builder::DefaultState>, ConfigError> {
+        let builder = ConfigLib::builder();
+        let builder = set_config_defaults!(builder);
+        Ok(builder)
+    }
+
+    pub fn load() -> Result<Self, ConfigError> {
+        // Build the config
+        let config = Self::base_builder()?
             // Override config values via environment variables
             // The environment variables should be prefixed with 'APP_' and use '__' as a separator
             // Example: APP_REDIS__REQUIRE_CLIENT_AUTH=false

--- a/src/config.rs
+++ b/src/config.rs
@@ -835,7 +835,7 @@ mod tests {
         assert_eq!(config.database.pool.max_lifetime_secs, 1800);
     }
 
-    #[sealed_test]
+    #[test]
     fn test_base_builder_defaults() {
         let builder = Config::base_builder().expect("Failed to create base_builder");
         let config: Config = builder

--- a/src/config.rs
+++ b/src/config.rs
@@ -784,6 +784,19 @@ mod tests {
         assert_eq!(config.server.cert.dns.provider, None);
     }
 
+    #[sealed_test]
+    fn test_base_builder_defaults() {
+        let builder = Config::base_builder().expect("Failed to create base_builder");
+        let config: Config = builder
+            .build()
+            .expect("Failed to build config")
+            .try_deserialize()
+            .expect("Failed to deserialize config");
+
+        assert_eq!(config.server.host, "localhost");
+        assert_eq!(config.server.port, 8000);
+    }
+
     #[sealed_test(env = [
         ("APP_SERVER__AGGREGATION_URI", "https://example.com/aggregation"),
     ])]

--- a/src/config.rs
+++ b/src/config.rs
@@ -631,8 +631,7 @@ macro_rules! set_config_defaults {
             ("store", Option::<String>::None, Option::<String>::None);
 
         #[cfg(feature = "acme")]
-        let default_chain_cache_ttl =
-            crate::utils::cert_manager::DEFAULT_CHAIN_CACHE_TTL.as_secs();
+        let default_chain_cache_ttl = crate::utils::cert_manager::DEFAULT_CHAIN_CACHE_TTL.as_secs();
         #[cfg(not(feature = "acme"))]
         let default_chain_cache_ttl = 86400;
 
@@ -687,8 +686,8 @@ macro_rules! set_config_defaults {
 
 impl Config {
     /// Creates a [`config::ConfigBuilder`] pre-populated with default configuration values.
-    pub fn base_builder(
-    ) -> Result<config::ConfigBuilder<config::builder::DefaultState>, ConfigError> {
+    pub fn base_builder()
+    -> Result<config::ConfigBuilder<config::builder::DefaultState>, ConfigError> {
         let builder = ConfigLib::builder();
         let builder = set_config_defaults!(builder);
         Ok(builder)


### PR DESCRIPTION
The src/config.rs file contains significant code duplication between Config::load() and base_builder() (used for tests).

The base_builder() function (lines 700-789) duplicates all default values already set in Config::load() (lines 597-660). This means any configuration default change requires updating two places, which is error-prone and adds unnecessary code bloat.