### PR TITLE
277 store error mapping and contract assertions

### DIFF
--- a/src/domain/service.rs
+++ b/src/domain/service.rs
@@ -79,6 +79,11 @@ impl Service {
         self.cert_provider.as_ref()
     }
 
+    /// Whether historical snapshot retention is enabled.
+    pub fn snapshots_enabled(&self) -> bool {
+        self.snapshot_repo.is_some()
+    }
+
     /// Create and publish a new status list record, enforcing uniqueness and size invariants.
     #[allow(clippy::too_many_arguments)]
     pub async fn publish_status_list(
@@ -119,36 +124,13 @@ impl Service {
             return Err(StatusListError::TooLarge);
         }
 
-        // No `find` pre-check: the primary key on `list_id` is the only check
-        // that is not a TOCTOU race, and every repository classifies the
-        // resulting violation as `AlreadyExists` — proven against SQLite, MySQL
-        // and Postgres by `assert_duplicate_list_id_is_conflict` (which covers
-        // both branches below), and by construction for the in-memory adapter.
-        // A pre-check would add a round trip to every publish and still have to
-        // defer to this path when a competing writer commits between the read
-        // and the insert.
-        //
-        // The trade is not free on the duplicate path: a rejected publish now
-        // costs BEGIN + failed INSERT + ROLLBACK instead of one SELECT, which on
-        // Postgres burns a transaction ID and leaves a dead tuple for autovacuum.
-        // That is the right way round — duplicates are the rare case, and the
-        // pre-check never actually prevented one.
-        //
-        // Only unique violations are classified. A foreign-key violation on
-        // `issuer` still surfaces as a generic backend error (500); that is
-        // unreachable in practice because authentication resolves the issuer's
-        // credential before this runs, so an unregistered issuer is rejected as
-        // 401 long before the insert.
-        match &self.snapshot_repo {
-            Some(_) => {
-                let snapshot = build_snapshot(&record, token_exp_secs);
-                self.status_list_repo
-                    .insert_with_snapshot(record.clone(), snapshot)
-                    .await?;
-            }
-            None => {
-                self.status_list_repo.insert(record.clone()).await?;
-            }
+        if self.snapshots_enabled() {
+            let snapshot = build_snapshot(&record, token_exp_secs);
+            self.status_list_repo
+                .insert_with_snapshot(record.clone(), snapshot)
+                .await?;
+        } else {
+            self.status_list_repo.insert(record.clone()).await?;
         }
         Ok(record)
     }
@@ -198,18 +180,15 @@ impl Service {
         let previous_updated_at = existing.updated_at;
         existing.updated_at = next_updated_at(previous_updated_at, current_unix_timestamp());
 
-        let landed = match &self.snapshot_repo {
-            Some(_) => {
-                let snapshot = build_snapshot(&existing, token_exp_secs);
-                self.status_list_repo
-                    .update_with_snapshot(existing.clone(), previous_updated_at, snapshot)
-                    .await?
-            }
-            None => {
-                self.status_list_repo
-                    .update(existing.clone(), previous_updated_at)
-                    .await?
-            }
+        let landed = if self.snapshots_enabled() {
+            let snapshot = build_snapshot(&existing, token_exp_secs);
+            self.status_list_repo
+                .update_with_snapshot(existing.clone(), previous_updated_at, snapshot)
+                .await?
+        } else {
+            self.status_list_repo
+                .update(existing.clone(), previous_updated_at)
+                .await?
         };
 
         if !landed {
@@ -342,12 +321,17 @@ fn build_snapshot(record: &StatusListRecord, token_exp_secs: u64) -> StatusListS
 }
 
 async fn invalidate_after_commit(cache: &dyn StatusListCache, list_id: &str) {
-    if let Err(error) = cache.invalidate(list_id).await {
-        tracing::warn!(
-            list_id = %list_id,
-            error = ?error,
-            "status list write committed, but cache invalidation failed; \
-             reads may be stale until the cache entry expires"
-        );
+    match cache.invalidate(list_id).await {
+        Ok(()) => {
+            tracing::debug!(list_id = %list_id, "invalidated cache entry after commit");
+        }
+        Err(error) => {
+            tracing::warn!(
+                list_id = %list_id,
+                error = ?error,
+                "status list write committed, but cache invalidation failed; \
+                 reads may be stale until the cache entry expires"
+            );
+        }
     }
 }

--- a/src/outbound/sql/models.rs
+++ b/src/outbound/sql/models.rs
@@ -105,6 +105,7 @@ pub(crate) mod status_list_history {
         pub snapshot_id: String,
         pub list_id: String,
         pub issuer: String,
+        #[sea_orm(column_type = "Json")]
         pub status_list: StatusList,
         pub sub: String,
         pub iat: i64,

--- a/src/outbound/sql/store.rs
+++ b/src/outbound/sql/store.rs
@@ -272,15 +272,15 @@ impl SeaOrmStore<StatusListRecord> {
             .map_err(|e| RepositoryError::UpdateError(e.to_string()))?;
 
         if result.rows_affected == 0 {
-            txn.rollback()
-                .await
-                .map_err(|e| RepositoryError::UpdateError(e.to_string()))?;
+            if let Err(e) = txn.rollback().await {
+                tracing::warn!(error = ?e, "rollback of empty conflict transaction failed");
+            }
             return Ok(false);
         }
 
         let history_active: status_list_history::ActiveModel = snapshot.into();
         if let Err(insert_err) = status_list_history::Entity::insert(history_active)
-            .exec(&txn)
+            .exec_without_returning(&txn)
             .await
         {
             txn.rollback().await.map_err(|rollback_err| {
@@ -350,9 +350,9 @@ impl SeaOrmStore<StatusListHistoryRecord> {
     pub async fn insert_one(&self, entity: StatusListHistoryRecord) -> Result<(), RepositoryError> {
         let active: status_list_history::ActiveModel = entity.into();
         status_list_history::Entity::insert(active)
-            .exec(&*self.db)
+            .exec_without_returning(&*self.db)
             .await
-            .map_err(|e| RepositoryError::InsertError(e.to_string()))?;
+            .map_err(map_insert_err)?;
         Ok(())
     }
 

--- a/src/outbound/sql/store.rs
+++ b/src/outbound/sql/store.rs
@@ -59,10 +59,15 @@ impl SeaOrmStore<StatusListRecord> {
         entity: StatusListRecord,
         snapshot: StatusListHistoryRecord,
     ) -> Result<(), RepositoryError> {
-        // Captured before `entity` is consumed below; only the contention test
-        // reads it.
         #[cfg(test)]
         let probed_list_id = entity.list_id.clone();
+
+        if snapshot.list_id != entity.list_id {
+            return Err(RepositoryError::InsertError(format!(
+                "snapshot list_id ({}) does not match entity list_id ({})",
+                snapshot.list_id, entity.list_id
+            )));
+        }
 
         let txn = self
             .db
@@ -227,6 +232,13 @@ impl SeaOrmStore<StatusListRecord> {
         expected_updated_at: i64,
         snapshot: StatusListHistoryRecord,
     ) -> Result<bool, RepositoryError> {
+        if snapshot.list_id != list_id || entity.list_id != list_id {
+            return Err(RepositoryError::UpdateError(format!(
+                "snapshot list_id ({}) or entity list_id ({}) does not match list_id ({})",
+                snapshot.list_id, entity.list_id, list_id
+            )));
+        }
+
         if entity.updated_at <= expected_updated_at {
             return Err(RepositoryError::UpdateError(format!(
                 "guarded update requires a strictly newer updated_at \


### PR DESCRIPTION
C4: debug assertion or an early RepositoryError. M4: exec_without_returning at all three sites. Cache log: report the actual outcome. Models: add the annotation.

A1: replace history: Option<Arc<H>> with snapshots_enabled: bool, or drop the flag entirely and let the repository decide. Settle this before opening the PR so a design discussion doesn't block four one-line fixes.