### PR TITLE
fix: harden management JWT claim validation

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -11,6 +11,17 @@ APP_SERVER__ENABLE_METRICS=false
 # OPTIONAL: URI of the Status List Aggregation endpoint (draft-21 §9). Unset to omit from tokens.
 # APP_SERVER__AGGREGATION_URI=https://statuslist.example.com/api/v1/aggregation
 
+# Management-token claim validation policy.
+# Leeway (seconds) tolerated on `exp` and `nbf` clock skew. Default: 60.
+# APP_SERVER__AUTH__LEEWAY_SECS=60
+# OPTIONAL: maximum allowed management-token lifetime (seconds). When set, a
+# token whose `exp` extends beyond `now + max_token_lifetime + leeway` is
+# rejected (anchored to the server clock). Unset to disable the upper bound.
+# Recommend 3600 in production.
+# APP_SERVER__AUTH__MAX_TOKEN_LIFETIME_SECS=3600
+# OPTIONAL: required `aud` claim value. Unset to disable audience validation.
+# APP_SERVER__AUTH__EXPECTED_AUDIENCE=status-list-server
+
 # Certificate provisioning
 # acme: server requests/renews certificates through ACME.
 # store: server loads externally managed certificate/key material from filesystem or configured storage.

--- a/README.md
+++ b/README.md
@@ -158,6 +158,11 @@ The following constraints are validated at startup and will cause the server to 
 - `server.port` must be between 1 and 65535 (the `u16` type enforces the upper bound)
 - `server.cert.renewal_cron_schedule` must be a valid 6-field cron expression (seconds required)
 - `aws.s3_bucket` must not be empty
+- the configured clock-skew leeway must not exceed the current Unix epoch
+  (otherwise `exp`/`nbf` validation would underflow and reject all traffic)
+- the maximum token lifetime must not be `0` (which would reject all traffic)
+- the clock-skew leeway must be strictly less than the maximum token lifetime
+  (otherwise the lifetime bound is meaningless)
 
 ## Security
 
@@ -172,10 +177,32 @@ The server uses JWT-based authentication with the following requirements:
    Authorization: Bearer <jwt_token>
    ```
 
-3. The JWT token must:
+3. The JWT token must be a valid JWS ([RFC 7519](https://www.rfc-editor.org/rfc/rfc7519)) with
+   the following requirements. The claims below are the standard registered claims
+   defined in [RFC 7519 §4.1](https://www.rfc-editor.org/rfc/rfc7519#section-4.1)
+   (`iss` §4.1.1, `aud` §4.1.3, `exp` §4.1.4, `nbf` §4.1.5, `iat` §4.1.6):
    - Be signed with the private key corresponding to the registered public key
    - Have `iss` (issuer) claim matching the registered issuer
-   - Have valid `exp` (expiration) and `iat` (issued at) claims
+   - Have `exp` (expiration) and `iat` (issued at) claims
+   - Optionally include `nbf` (not before); when present it must be in the past
+     (within the configured leeway)
+   - Optionally include `aud` (audience); when an expected audience is
+     configured, the `aud` claim is **required** and must match that value
+
+A maximum token lifetime of `3600` seconds is enforced by default to limit
+the blast radius if a token is leaked. To opt out, configure the maximum token
+lifetime as unset; the server will warn at startup that management tokens
+carry no upper lifetime bound.
+
+Any token that fails validation is rejected with a generic `401` `invalid_token`
+response that does not disclose which claim failed.
+
+> **Breaking change from 1.0.1:** this release hardens management-token
+> validation. Tokens must now carry a valid `iat` claim (previously optional),
+> and the `jwt_error` / `issuer_not_found` stable error codes were replaced by
+> the uniform `invalid_token` code. Symmetric `kty: "oct"` (shared-secret) keys
+> are no longer accepted by the credential registration endpoint. Clients
+> should branch on `invalid_token` rather than on the removed codes.
 
 Example JWT token header:
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -464,14 +464,21 @@ components:
       description: |
         Signed JWT Bearer token. The token must be signed with the private key
         corresponding to the public key registered for the issuer. The payload
-        must contain:
+        must contain the following claims:
 
-        - `iss`: the registered issuer identifier
-        - `iat`: issued-at timestamp
-        - `exp`: expiration timestamp
+        - `iss` (required): the registered issuer identifier
+        - `exp` (required): expiration timestamp
+        - `iat` (required): issued-at timestamp
+        - `nbf` (optional): not-before timestamp; when present it must be in the
+          past (within the configured leeway)
+        - `aud` (optional): audience; when an expected audience is configured
+          for the server it must match one of those values
 
-        The server validates the signature using the registered JWK and verifies
-        that the `iss` claim matches the registered issuer.
+        The server validates the signature using the registered JWK, verifies
+        that the `iss` claim matches the registered issuer, and enforces the
+        configured leeway and maximum token lifetime. Tokens that fail signature
+        or claim validation are rejected with a generic `401 invalid_token`
+        response that does not disclose which claim failed.
 
         Mutual TLS (mTLS) for issuer authentication is not implemented in the
         current release; this security scheme may be added in a future version.
@@ -495,12 +502,13 @@ components:
       description: |
         JSON Web Key representing the issuer's public key. The exact fields
         depend on the key type (e.g., `kty`, `crv`, `x`, `y` for EC keys).
+        Symmetric shared-secret keys (`kty: "oct"`) are rejected.
       required:
         - kty
       properties:
         kty:
           type: string
-          description: Key type.
+          description: Key type. `oct` (shared secret) is not supported.
           example: "EC"
         crv:
           type: string
@@ -675,9 +683,7 @@ components:
             - index_too_large
             # 401 — emitted by the authentication middleware
             - invalid_auth_header
-            - jwt_error
-            - unsupported_algorithm
-            - issuer_not_found
+            - invalid_token
             # 403
             - issuer_mismatch
             # 404
@@ -731,8 +737,8 @@ components:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
           example:
-            error: "invalid_auth_header"
-            error_description: "Missing or invalid Authorization header"
+            error: "invalid_token"
+            error_description: "Token is invalid"
 
     Forbidden:
       description: Insufficient permissions to access the resource

--- a/src/config.rs
+++ b/src/config.rs
@@ -180,6 +180,57 @@ pub struct ServerConfig {
     pub cert: CertConfig,
     pub enable_metrics: bool,
     pub aggregation_uri: Option<String>,
+    pub auth: AuthConfig,
+}
+
+/// Management-token claim validation policy applied by the authentication
+/// middleware to bearer JWTs.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AuthConfig {
+    /// Maximum allowed lifetime of a management token, computed as
+    /// `exp - iat`. Defaults to 3600 seconds; setting it to `None` requires an
+    /// explicit operator opt-out and removes the upper bound. When unset, no
+    /// upper bound is enforced (a startup warning is emitted).
+    pub max_token_lifetime_secs: Option<u64>,
+    /// Clock skew leeway (in seconds) tolerated when validating `exp` and
+    /// `nbf`. Defaults to 60.
+    pub leeway_secs: u64,
+    /// When set, the bearer token's `aud` claim must match this audience.
+    /// When unset, the `aud` claim is not validated.
+    pub expected_audience: Option<String>,
+}
+
+impl AuthConfig {
+    /// Validates the auth policy, failing fast on operator misconfiguration
+    /// rather than silently rejecting all (or effectively all) traffic at
+    /// request time.
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        let now = time::OffsetDateTime::now_utc()
+            .unix_timestamp()
+            .try_into()
+            .map_err(|_| ConfigError::Message("System clock error".to_string()))?;
+        if self.leeway_secs > now {
+            return Err(ConfigError::Message(format!(
+                "configured clock-skew leeway ({}) exceeds the current Unix epoch; \
+                 token validation would reject all traffic",
+                self.leeway_secs
+            )));
+        }
+        if let Some(max) = self.max_token_lifetime_secs {
+            if max == 0 {
+                return Err(ConfigError::Message(
+                    "maximum token lifetime must not be 0 (rejects all traffic)".to_string(),
+                ));
+            }
+            if self.leeway_secs >= max {
+                return Err(ConfigError::Message(format!(
+                    "clock-skew leeway ({}) must be less than the maximum token lifetime ({})",
+                    self.leeway_secs, max
+                )));
+            }
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -870,6 +921,9 @@ fn base_builder() -> Result<ConfigBuilder<DefaultState>, ConfigError> {
         .set_default("server.port", 8000)?
         .set_default("server.enable_metrics", false)?
         .set_default("server.aggregation_uri", Option::<String>::None)?
+        .set_default("server.auth.max_token_lifetime_secs", 3600u64)?
+        .set_default("server.auth.leeway_secs", 60u64)?
+        .set_default("server.auth.expected_audience", Option::<String>::None)?
         .set_default("database.url", default_db_url)?
         .set_default("database.backend", default_db_backend)?
         .set_default("database.pool.max_connections", 5u32)?
@@ -1002,6 +1056,9 @@ mod tests {
             expected_cert_path
         );
         assert_eq!(config.server.cert.store.signing_key_path, expected_key_path);
+        assert_eq!(config.server.auth.leeway_secs, 60);
+        assert_eq!(config.server.auth.max_token_lifetime_secs, Some(3600));
+        assert_eq!(config.server.auth.expected_audience, None);
 
         assert_eq!(config.rate_limit.strict_burst_size, 10);
         assert_eq!(config.rate_limit.strict_period_secs, 60);
@@ -1166,6 +1223,38 @@ mod tests {
         .expect("Failed to load sqlite config");
         assert_eq!(sqlite_cfg.database.backend, DatabaseBackend::Sqlite);
         assert_eq!(sqlite_cfg.database.url.expose_secret(), "sqlite::memory:");
+    }
+
+    #[test]
+    fn test_auth_policy_default_valid() {
+        let config = Config::load_from_overrides(&[]).expect("Failed to load config");
+        config
+            .server
+            .auth
+            .validate()
+            .expect("default auth is valid");
+    }
+
+    #[test]
+    fn test_auth_policy_rejects_zero_max_lifetime() {
+        let auth = AuthConfig {
+            max_token_lifetime_secs: Some(0),
+            leeway_secs: 60,
+            expected_audience: None,
+        };
+        assert!(auth.validate().is_err());
+    }
+
+    #[test]
+    fn test_auth_policy_rejects_leeway_ge_max_lifetime() {
+        for (leeway, max, ok) in [(60, 60, false), (61, 60, false), (5, 60, true)] {
+            let auth = AuthConfig {
+                max_token_lifetime_secs: Some(max),
+                leeway_secs: leeway,
+                expected_audience: None,
+            };
+            assert_eq!(auth.validate().is_ok(), ok, "leeway={leeway} max={max}");
+        }
     }
 
     #[test]

--- a/src/domain/models/credential.rs
+++ b/src/domain/models/credential.rs
@@ -36,7 +36,12 @@ pub struct PublicJwk(pub Vec<u8>);
 impl PublicJwk {
     /// Create public JWK bytes from UTF-8 JSON.
     ///
-    /// Ensures the payload is a valid JSON object without enforcing key types.
+    /// Ensures the payload is a valid JSON object and rejects shared-secret
+    /// (`kty: "oct"`) keys. An `oct` key is unusable for asymmetric management
+    /// token verification: the auth middleware treats it as an HMAC key and
+    /// refuses it, so accepting it here would create a credential that is
+    /// accepted at registration (201) yet permanently rejected at request time.
+    /// Rejecting it up front keeps the registration contract honest.
     pub fn try_new(bytes: Vec<u8>) -> Result<Self, CredentialError> {
         let value: serde_json::Value = serde_json::from_slice(&bytes).map_err(|err| {
             CredentialError::InvalidPublicJwk(format!("expected UTF-8 JSON: {err}"))
@@ -44,6 +49,17 @@ impl PublicJwk {
         if !value.is_object() {
             return Err(CredentialError::InvalidPublicJwk(
                 "expected a JSON object".to_string(),
+            ));
+        }
+        let kty = value
+            .get("kty")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default();
+        if kty == "oct" {
+            return Err(CredentialError::InvalidPublicJwk(
+                "shared-secret (kty: oct) keys are not supported for management \
+                 token verification"
+                    .to_string(),
             ));
         }
         Ok(Self(bytes))

--- a/src/server/auth/errors.rs
+++ b/src/server/auth/errors.rs
@@ -1,21 +1,23 @@
 use crate::server::error::{ApiError, IntoApiError};
 use axum::response::IntoResponse;
 use hyper::StatusCode;
-use jsonwebtoken::errors::Error as JwtError;
 use std::borrow::Cow;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum AuthenticationError {
-    #[error("Issuer not registered")]
-    IssuerNotFound,
     #[error("Internal server error")]
     InternalServer,
     #[error("Missing or invalid Authorization header")]
     InvalidAuthorizationHeader,
-    #[error("{0}")]
-    JwtError(#[from] JwtError),
-    #[error("Unsupported algorithm")]
+    // Signature, claim, and algorithm failures deliberately share a single
+    // uniform message and `invalid_token` wire code so a response never
+    // discloses which layer failed or any token details.
+    #[error("Token is invalid")]
+    InvalidSignature,
+    #[error("Token is invalid")]
+    InvalidClaims,
+    #[error("Token is invalid")]
     UnsupportedAlgorithm,
 }
 
@@ -29,11 +31,14 @@ impl AuthenticationError {
 
     pub fn get_error_code(&self) -> Cow<'static, str> {
         match self {
-            AuthenticationError::IssuerNotFound => Cow::Borrowed("issuer_not_found"),
             AuthenticationError::InternalServer => Cow::Borrowed("internal_error"),
             AuthenticationError::InvalidAuthorizationHeader => Cow::Borrowed("invalid_auth_header"),
-            AuthenticationError::JwtError(_) => Cow::Borrowed("jwt_error"),
-            AuthenticationError::UnsupportedAlgorithm => Cow::Borrowed("unsupported_algorithm"),
+            // Signature, claim, and algorithm (HMAC-key) failures are
+            // indistinguishable on the wire: all surface as `invalid_token` so
+            // the response is not an oracle for which check failed.
+            AuthenticationError::InvalidSignature
+            | AuthenticationError::InvalidClaims
+            | AuthenticationError::UnsupportedAlgorithm => Cow::Borrowed("invalid_token"),
         }
     }
 
@@ -76,5 +81,25 @@ mod tests {
             json["error_description"],
             "Missing or invalid Authorization header"
         );
+    }
+
+    #[tokio::test]
+    async fn test_claim_errors_are_generic_and_non_disclosing() {
+        // Signature, claim, and algorithm (HMAC-key) failures all surface as the
+        // generic `invalid_token` code with a uniform message that never echoes
+        // underlying claim details or which check failed.
+        for err in [
+            AuthenticationError::InvalidClaims,
+            AuthenticationError::InvalidSignature,
+            AuthenticationError::UnsupportedAlgorithm,
+        ] {
+            let response = err.into_response();
+            assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+            let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+            let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+            assert_eq!(json["error"], "invalid_token");
+            assert_eq!(json["error_description"], "Token is invalid");
+        }
     }
 }

--- a/src/server/auth/mod.rs
+++ b/src/server/auth/mod.rs
@@ -1,4 +1,25 @@
 //! Authentication middleware validating bearer JWTs against registered issuer credentials.
+//!
+//! Claim validation policy for management tokens:
+//! - `iss` (required): must match a registered issuer (bounded and used as the
+//!   credential lookup key).
+//! - `exp` (required): must be in the future (within the configured leeway) and,
+//!   when a maximum lifetime is configured, must not extend beyond
+//!   `now + max_lifetime + leeway`.
+//! - `iat` (required): must not be in the future beyond the leeway, so a
+//!   server-clock-anchored bound on `exp` cannot be bypassed via a future `iat`.
+//! - `nbf` (optional): when present, must be in the past (within the configured leeway).
+//! - `aud` (required when `expected_audience` is configured): must match it.
+//!
+//! Verification is pinned to the registered key's algorithm family; a token's
+//! unverified `alg` header is never trusted. HMAC/shared-secret (`oct`) keys
+//! are rejected at registration (400 `invalid_public_jwk`); the middleware
+//! keeps the HMAC gate as defense-in-depth only.
+//!
+//! Failures are mapped to a generic `401` `invalid_token` so the response never
+//! discloses which claim failed, which verification layer failed, or any token
+//! details, and an unregistered issuer is indistinguishable from an invalid
+//! token.
 
 pub mod errors;
 
@@ -10,15 +31,87 @@ use axum::{
 };
 use errors::AuthenticationError;
 use hyper::header;
-use jsonwebtoken::{DecodingKey, Validation};
+use jsonwebtoken::{AlgorithmFamily, DecodingKey, Validation, get_current_timestamp};
+use serde::de::Error as _;
 use serde::{Deserialize, Serialize};
 
 use crate::server::AppState;
 
+/// Upper bound (bytes) on an unverified `iss` before it is used as a database
+/// lookup key and echoed into log lines. Bounds the input size so an attacker
+/// cannot force a huge allocation or database query.
+const MAX_ISSUER_LEN: usize = 512;
+
+/// Sanitizes an attacker-controlled string for embedding in log lines. Log
+/// sinks vary: structured sinks escape control characters, but plain-text
+/// sinks may not, and a control byte (e.g. newline) could otherwise forge log
+/// entries. Replaces all C0/C1 control characters so the value is safe to
+/// interpolate regardless of the sink.
+fn sanitize_for_log(value: &str) -> String {
+    value
+        .chars()
+        .map(|c| if c.is_control() { '?' } else { c })
+        .collect()
+}
+
+/// RFC 7519 §4.1.3: `aud` is either a single string or an array of strings.
+/// An untagged enum gives that flexibility with real type safety, rejecting
+/// `aud: 42` or `aud: {}` at deserialization time.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Audience {
+    One(String),
+    Many(Vec<String>),
+}
+
+/// RFC 7519 §2 `NumericDate`: a JSON number that may be non-integral.
+/// Deserialize as `f64` and coerce (matching the jsonwebtoken crate) so a token
+/// with `"exp": 1712345678.0` succeeds instead of failing opaque deserialization.
+fn deserialize_numeric_date<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = f64::deserialize(deserializer)?;
+    if !value.is_finite() {
+        return Err(D::Error::custom("NumericDate must be a finite number"));
+    }
+    Ok(value.round() as u64)
+}
+
+fn deserialize_option_numeric_date<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let present = Option::<serde_json::Value>::deserialize(deserializer)?;
+    match present {
+        None => Ok(None),
+        Some(value) => {
+            let n = value
+                .as_f64()
+                .ok_or_else(|| D::Error::custom("NumericDate must be a finite number"))?;
+            if !n.is_finite() {
+                return Err(D::Error::custom("NumericDate must be a finite number"));
+            }
+            Ok(Some(n.round() as u64))
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 struct Claims {
     iss: String,
-    exp: usize,
+    #[serde(deserialize_with = "deserialize_numeric_date")]
+    exp: u64,
+    #[serde(deserialize_with = "deserialize_numeric_date")]
+    iat: u64,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_option_numeric_date"
+    )]
+    nbf: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    aud: Option<Audience>,
 }
 
 /// Authentication middleware acting as a safeguard for unauthorized issuers
@@ -36,27 +129,135 @@ pub async fn auth(
         .and_then(|auth| auth.strip_prefix("Bearer "))
         .ok_or(AuthenticationError::InvalidAuthorizationHeader)?;
 
-    let alg = jsonwebtoken::decode_header(token)?.alg;
-    let issuer = insecure_decode::<Claims>(token)?.claims.iss;
-
-    let credential = state
-        .service
-        .find_credential(&issuer)
-        .await
+    let issuer = insecure_decode::<Claims>(token)
         .map_err(|e| {
-            tracing::error!("Failed to find credential for {issuer}: {e:?}");
-            AuthenticationError::InternalServer
+            tracing::error!("Failed to decode JWT claims: {e}");
+            AuthenticationError::InvalidClaims
         })?
-        .ok_or(AuthenticationError::IssuerNotFound)?;
+        .claims
+        .iss;
+
+    // Bound the unverified `iss` before using it as a DB lookup key so an
+    // attacker cannot force a huge allocation or query.
+    if issuer.trim().is_empty() || issuer.len() > MAX_ISSUER_LEN {
+        tracing::warn!(
+            issuer_len = issuer.len(),
+            "Rejecting token with out-of-bounds issuer"
+        );
+        return Err(AuthenticationError::InvalidClaims);
+    }
+
+    // A log-safe form of `iss` for tracing. `iss` is attacker-controlled (the
+    // signature is not yet verified) and may contain control characters that
+    // a plain-text log sink would not escape. The raw value is still used as
+    // the exact database lookup key below.
+    let safe_issuer = sanitize_for_log(&issuer);
+
+    let credential = state.service.find_credential(&issuer).await.map_err(|e| {
+        tracing::error!(issuer = %safe_issuer, error = ?e, "Failed to find credential");
+        AuthenticationError::InternalServer
+    })?;
+
+    // An absent credential is deliberately folded into the generic `invalid_token`
+    // wire code (not `issuer_not_found`) so the response is not an enumeration
+    // oracle for registered issuers. The distinction lives in logs only.
+    let Some(credential) = credential else {
+        tracing::warn!(issuer = %safe_issuer, "Rejecting token from unregistered issuer");
+        return Err(AuthenticationError::InvalidClaims);
+    };
 
     let public_key = serde_json::from_slice(credential.public_key.as_bytes())
         .map_err(|_| AuthenticationError::InternalServer)?;
-    let decoding_key = DecodingKey::from_jwk(&public_key)?;
+    let decoding_key = DecodingKey::from_jwk(&public_key).map_err(|e| {
+        tracing::error!(issuer = %safe_issuer, error = %e, "Failed to build decoding key");
+        AuthenticationError::InternalServer
+    })?;
 
-    let mut validation = Validation::new(alg);
+    // Pin verification to the registered key's algorithm family rather than
+    // trusting the unverified header `alg` (which would otherwise feed a
+    // tautological family check). Shared-secret (HMAC) keys are rejected here
+    // as a defense-in-depth gate: `oct` keys map to the HMAC family in
+    // jsonwebtoken and are already rejected at registration (`PublicJwk::try_new`).
+    let family = decoding_key.family();
+    if family == AlgorithmFamily::Hmac {
+        tracing::warn!(issuer = %safe_issuer, "Rejecting HMAC management key");
+        return Err(AuthenticationError::UnsupportedAlgorithm);
+    }
+    let mut validation = Validation::new_for_family(family);
     validation.set_issuer(&[&credential.issuer.0]);
+    validation.leeway = state.auth.leeway_secs;
+    validation.validate_nbf = true;
+    if let Some(expected_audience) = &state.auth.expected_audience {
+        validation.set_audience(&[expected_audience]);
+        // `set_audience` only sets the audience; it does not make `aud` required.
+        // Without this an omitted `aud` claim falls through as accepted.
+        validation.required_spec_claims.insert("aud".to_owned());
+    } else {
+        // `aud` is optional when no audience is configured. Leave validate_aud
+        // enabled would otherwise reject any token that merely carries an `aud`
+        // claim (jsonwebtoken rejects it when the accepted audience set is empty).
+        validation.validate_aud = false;
+    }
 
-    let token_data = jsonwebtoken::decode::<Claims>(token, &decoding_key, &validation)?;
+    let token_data =
+        jsonwebtoken::decode::<Claims>(token, &decoding_key, &validation).map_err(|e| match &e
+            .kind()
+        {
+            jsonwebtoken::errors::ErrorKind::InvalidSignature
+            | jsonwebtoken::errors::ErrorKind::InvalidAlgorithm
+            | jsonwebtoken::errors::ErrorKind::InvalidKeyFormat
+            | jsonwebtoken::errors::ErrorKind::RsaFailedSigning => {
+                tracing::warn!(issuer = %safe_issuer, error = %e, "Token signature verification failed");
+                AuthenticationError::InvalidSignature
+            }
+            _ => {
+                tracing::warn!(issuer = %safe_issuer, error = %e, "Token claim validation failed");
+                AuthenticationError::InvalidClaims
+            }
+        })?;
+
+    // Anchor validation to the server clock. `iat` is issuer-controlled and, by
+    // design, never compared by jsonwebtoken; only `exp` is anchored to real time.
+    let now = get_current_timestamp();
+
+    // Reject tokens that are not yet valid (iat in the future beyond leeway).
+    if token_data.claims.iat > now.saturating_add(state.auth.leeway_secs) {
+        tracing::warn!(issuer = %safe_issuer, "Rejecting token with future iat");
+        return Err(AuthenticationError::InvalidClaims);
+    }
+
+    // Enforce an explicit upper bound on token lifetime when configured. The
+    // absolute bound on `exp` is the primary control: it is clock-anchored and
+    // cannot be bypassed by an attacker choosing `iat`. `exp - iat` remains as
+    // a secondary relative assertion.
+    if let Some(max_lifetime) = state.auth.max_token_lifetime_secs {
+        let exp_cap = now
+            .saturating_add(max_lifetime)
+            .saturating_add(state.auth.leeway_secs);
+        if token_data.claims.exp > exp_cap {
+            tracing::warn!(
+                issuer = %safe_issuer,
+                exp = token_data.claims.exp,
+                max_lifetime_secs = max_lifetime,
+                "Rejecting token exceeding maximum absolute lifetime"
+            );
+            return Err(AuthenticationError::InvalidClaims);
+        }
+        if token_data.claims.iat > token_data.claims.exp {
+            tracing::warn!(issuer = %safe_issuer, "Rejecting token where iat exceeds exp");
+            return Err(AuthenticationError::InvalidClaims);
+        }
+        let lifetime = token_data.claims.exp - token_data.claims.iat;
+        if lifetime > max_lifetime {
+            tracing::warn!(
+                issuer = %safe_issuer,
+                lifetime_secs = lifetime,
+                max_lifetime_secs = max_lifetime,
+                "Rejecting token exceeding maximum lifetime"
+            );
+            return Err(AuthenticationError::InvalidClaims);
+        }
+    }
 
     request.extensions_mut().insert(token_data.claims.iss);
     Ok(next.run(request).await)
@@ -75,7 +276,6 @@ mod tests {
         routing::get,
     };
     use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
-    use std::time::{SystemTime, UNIX_EPOCH};
     use tower::ServiceExt;
 
     fn create_test_router(app_state: AppState) -> Router {
@@ -109,196 +309,200 @@ mod tests {
         .unwrap()
     }
 
-    fn create_test_token(issuer: &str, secret: &EncodingKey, alg: Algorithm) -> String {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs() as usize;
+    fn now_secs() -> u64 {
+        time::OffsetDateTime::now_utc().unix_timestamp().max(0) as u64
+    }
 
+    fn test_encoding_key() -> EncodingKey {
+        EncodingKey::from_ec_pem(test_ec_private_pem().as_bytes()).unwrap()
+    }
+
+    fn create_test_token(issuer: &str, secret: &EncodingKey, alg: Algorithm) -> String {
+        let now = now_secs();
         let claims = Claims {
             iss: issuer.to_string(),
             exp: now + 3600,
+            iat: now,
+            nbf: None,
+            aud: None,
         };
+        encode(&Header::new(alg), &claims, secret).unwrap()
+    }
 
-        let header = Header::new(alg);
-        encode(&header, &claims, secret).unwrap()
+    fn create_test_token_with_claims(
+        issuer: &str,
+        secret: &EncodingKey,
+        alg: Algorithm,
+        exp: u64,
+        iat: u64,
+        nbf: Option<u64>,
+        aud: Option<Audience>,
+    ) -> String {
+        let claims = Claims {
+            iss: issuer.to_string(),
+            exp,
+            iat,
+            nbf,
+            aud,
+        };
+        encode(&Header::new(alg), &claims, secret).unwrap()
+    }
+
+    fn bearer_request(token: &str) -> Request<Body> {
+        Request::builder()
+            .uri("/test")
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    async fn register_test_issuer(state: &AppState) {
+        state
+            .service
+            .publish_credential(crate::domain::models::credential::Credential {
+                issuer: Issuer("test-issuer".into()),
+                public_key: test_public_jwk(),
+            })
+            .await
+            .unwrap();
+    }
+
+    /// Build a router with `test-issuer` registered and the auth policy tuned by
+    /// `configure`, returning the router and the matching ES256 encoding key.
+    async fn setup_with(configure: impl FnOnce(&mut AppState)) -> (Router, EncodingKey) {
+        let mut state = test_app_state(None).await;
+        configure(&mut state);
+        register_test_issuer(&state).await;
+        let app = create_test_router(state);
+        (app, test_encoding_key())
+    }
+
+    /// Build an authenticated router for a token signed with `wrong_pem`, used to
+    /// exercise signature mismatches against a registered issuer.
+    async fn setup_with_wrong_key(wrong_pem: &str) -> (Router, EncodingKey) {
+        let state = test_app_state(None).await;
+        register_test_issuer(&state).await;
+        let app = create_test_router(state);
+        (app, EncodingKey::from_ec_pem(wrong_pem.as_bytes()).unwrap())
+    }
+
+    async fn assert_ok(app: Router, token: &str) {
+        let response = app.oneshot(bearer_request(token)).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    async fn assert_unauthorized_without_claim_leak(app: Router, token: &str) {
+        let response = app.oneshot(bearer_request(token)).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+        // The body must be generic and must not disclose which claim failed,
+        // any token details, or library error messages (e.g. ExpiredSignature).
+        let bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        let body = String::from_utf8(bytes.to_vec()).unwrap();
+        assert!(
+            !body.contains("exp")
+                && !body.contains("iat")
+                && !body.contains("nbf")
+                && !body.contains("aud")
+                && !body.contains("signature")
+                && !body.contains("ExpiredSignature")
+                && !body.contains("ImmatureSignature"),
+            "Response must not disclose claim details, got: {body}"
+        );
+
+        // Assert the actual wire contract rather than substring absence, so a
+        // regression that changes the code/message is caught even if no detail
+        // leaks.
+        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(json["error"], "invalid_token");
+        assert_eq!(json["error_description"], "Token is invalid");
     }
 
     #[tokio::test]
     async fn test_missing_authorization_header() {
-        let state = test_app_state(None).await;
-        let app = create_test_router(state);
-
+        let app = create_test_router(test_app_state(None).await);
         let request = Request::builder().uri("/test").body(Body::empty()).unwrap();
-
         let response = app.oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]
     async fn test_malformed_authorization_header() {
-        let state = test_app_state(None).await;
-        let app = create_test_router(state);
-
+        let app = create_test_router(test_app_state(None).await);
         let request = Request::builder()
             .uri("/test")
             .header(header::AUTHORIZATION, "Basic invalid_token")
             .body(Body::empty())
             .unwrap();
-
         let response = app.oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]
     async fn test_invalid_jwt_token() {
-        let state = test_app_state(None).await;
-        let app = create_test_router(state);
-
-        let request = Request::builder()
-            .uri("/test")
-            .header(header::AUTHORIZATION, "Bearer invalid_jwt_token")
-            .body(Body::empty())
+        let app = create_test_router(test_app_state(None).await);
+        let response = app
+            .oneshot(bearer_request("invalid_jwt_token"))
+            .await
             .unwrap();
-
-        let response = app.oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]
     async fn test_issuer_not_found_in_database() {
-        let state = test_app_state(None).await;
-        let app = create_test_router(state);
-
-        let private_key = test_ec_private_pem();
-        let secret = EncodingKey::from_ec_pem(private_key.as_bytes()).unwrap();
-        let token = create_test_token("unregistered-issuer", &secret, Algorithm::ES256);
-
-        let request = Request::builder()
-            .uri("/test")
-            .header(header::AUTHORIZATION, format!("Bearer {token}"))
-            .body(Body::empty())
-            .unwrap();
-
-        let response = app.oneshot(request).await.unwrap();
-        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        let app = create_test_router(test_app_state(None).await);
+        let token = create_test_token(
+            "unregistered-issuer",
+            &test_encoding_key(),
+            Algorithm::ES256,
+        );
+        // A token from an unregistered issuer must be indistinguishable from an
+        // invalid token (no enumeration oracle).
+        assert_unauthorized_without_claim_leak(app, &token).await;
     }
 
     #[tokio::test]
     async fn test_successful_authentication() {
-        let private_pem = test_ec_private_pem();
-        let state = test_app_state(None).await;
-
-        state
-            .service
-            .publish_credential(crate::domain::models::credential::Credential {
-                issuer: Issuer("test-issuer".into()),
-                public_key: test_public_jwk(),
-            })
-            .await
-            .unwrap();
-
-        let app = create_test_router(state);
-
-        let encoding_key = EncodingKey::from_ec_pem(private_pem.as_bytes()).unwrap();
-        let token = create_test_token("test-issuer", &encoding_key, Algorithm::ES256);
-
-        let request = Request::builder()
-            .uri("/test")
-            .header(header::AUTHORIZATION, format!("Bearer {token}"))
-            .body(Body::empty())
-            .unwrap();
-
-        let response = app.oneshot(request).await.unwrap();
+        let (app, key) = setup_with(|_| {}).await;
+        let token = create_test_token("test-issuer", &key, Algorithm::ES256);
+        let response = app.oneshot(bearer_request(&token)).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
 
         let bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
-        let body = String::from_utf8(bytes.to_vec()).unwrap();
-        assert_eq!(body, "Ok");
+        assert_eq!(String::from_utf8(bytes.to_vec()).unwrap(), "Ok");
     }
 
     #[tokio::test]
     async fn test_token_verification_failure_wrong_key() {
-        let wrong_private_pem = "-----BEGIN PRIVATE KEY-----\nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgUBIUj4mRpgdolCfi\najH0ju3KgSj8xQAlcvidrAkwOzChRANCAAQ4Wvc8XUs0zEqMKGtRYFnvYtDlzdH2\n7N3Eo65Js7drssgg7eKUSIlnJWMXHxqr8SfECuXi7sewuw2+mxs2adC5\n-----END PRIVATE KEY-----";
-
-        let state = test_app_state(None).await;
-        state
-            .service
-            .publish_credential(crate::domain::models::credential::Credential {
-                issuer: Issuer("test-issuer".into()),
-                public_key: test_public_jwk(),
-            })
-            .await
-            .unwrap();
-
-        let app = create_test_router(state);
-
-        let wrong_encoding_key = EncodingKey::from_ec_pem(wrong_private_pem.as_bytes()).unwrap();
-        let token = create_test_token("test-issuer", &wrong_encoding_key, Algorithm::ES256);
-
-        let request = Request::builder()
-            .uri("/test")
-            .header(header::AUTHORIZATION, format!("Bearer {token}"))
-            .body(Body::empty())
-            .unwrap();
-
-        let response = app.oneshot(request).await.unwrap();
-        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        let wrong_pem = "-----BEGIN PRIVATE KEY-----\nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgUBIUj4mRpgdolCfi\najH0ju3KgSj8xQAlcvidrAkwOzChRANCAAQ4Wvc8XUs0zEqMKGtRYFnvYtDlzdH2\n7N3Eo65Js7drssgg7eKUSIlnJWMXHxqr8SfECuXi7sewuw2+mxs2adC5\n-----END PRIVATE KEY-----";
+        let (app, wrong_key) = setup_with_wrong_key(wrong_pem).await;
+        let token = create_test_token("test-issuer", &wrong_key, Algorithm::ES256);
+        // A token signed with the wrong key must surface the same non-disclosing
+        // invalid_token response as any other signature/claim failure.
+        assert_unauthorized_without_claim_leak(app, &token).await;
     }
 
     #[tokio::test]
     async fn test_expired_token() {
-        let private_pem = test_ec_private_pem();
-        let state = test_app_state(None).await;
-
-        state
-            .service
-            .publish_credential(crate::domain::models::credential::Credential {
-                issuer: Issuer("test-issuer".into()),
-                public_key: test_public_jwk(),
-            })
-            .await
-            .unwrap();
-
-        let app = create_test_router(state);
-
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs() as usize;
-
-        let expired_claims = Claims {
-            iss: "test-issuer".to_string(),
-            exp: now - 3600,
-        };
-
-        let encoding_key = EncodingKey::from_ec_pem(private_pem.as_bytes()).unwrap();
-        let header = Header::new(Algorithm::ES256);
-        let token = encode(&header, &expired_claims, &encoding_key).unwrap();
-
-        let request = Request::builder()
-            .uri("/test")
-            .header(header::AUTHORIZATION, format!("Bearer {token}"))
-            .body(Body::empty())
-            .unwrap();
-
-        let response = app.oneshot(request).await.unwrap();
-        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        let (app, key) = setup_with(|_| {}).await;
+        let now = now_secs();
+        let token = create_test_token_with_claims(
+            "test-issuer",
+            &key,
+            Algorithm::ES256,
+            now - 3600,
+            now - 7200,
+            None,
+            None,
+        );
+        assert_unauthorized_without_claim_leak(app, &token).await;
     }
 
     #[tokio::test]
     async fn test_request_extension_contains_issuer() {
         let private_pem = test_ec_private_pem();
         let state = test_app_state(None).await;
-
-        state
-            .service
-            .publish_credential(crate::domain::models::credential::Credential {
-                issuer: Issuer("test-issuer".into()),
-                public_key: test_public_jwk(),
-            })
-            .await
-            .unwrap();
+        register_test_issuer(&state).await;
 
         async fn extension_test_handler(Extension(issuer): Extension<String>) -> String {
             assert_eq!(issuer, "test-issuer");
@@ -310,20 +514,348 @@ mod tests {
             .layer(axum::middleware::from_fn_with_state(state.clone(), auth))
             .with_state(state);
 
-        let encoding_key = EncodingKey::from_ec_pem(private_pem.as_bytes()).unwrap();
-        let token = create_test_token("test-issuer", &encoding_key, Algorithm::ES256);
-
-        let request = Request::builder()
-            .uri("/test")
-            .header(header::AUTHORIZATION, format!("Bearer {token}"))
-            .body(Body::empty())
-            .unwrap();
-
-        let response = app.oneshot(request).await.unwrap();
+        let token = create_test_token(
+            "test-issuer",
+            &EncodingKey::from_ec_pem(private_pem.as_bytes()).unwrap(),
+            Algorithm::ES256,
+        );
+        let response = app.oneshot(bearer_request(&token)).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
 
         let bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
-        let body = String::from_utf8(bytes.to_vec()).unwrap();
-        assert_eq!(body, "test-issuer");
+        assert_eq!(String::from_utf8(bytes.to_vec()).unwrap(), "test-issuer");
+    }
+
+    #[tokio::test]
+    async fn test_missing_iat_claim_rejected() {
+        let (app, key) = setup_with(|_| {}).await;
+        // Build a token signed with the registered key but without `iat`.
+        let token = encode(
+            &Header::new(Algorithm::ES256),
+            &serde_json::json!({ "iss": "test-issuer", "exp": now_secs() + 3600 }),
+            &key,
+        )
+        .unwrap();
+        assert_unauthorized_without_claim_leak(app, &token).await;
+    }
+
+    #[tokio::test]
+    async fn test_missing_exp_claim_rejected() {
+        let (app, key) = setup_with(|_| {}).await;
+        let token = encode(
+            &Header::new(Algorithm::ES256),
+            &serde_json::json!({ "iss": "test-issuer", "iat": now_secs() }),
+            &key,
+        )
+        .unwrap();
+        assert_unauthorized_without_claim_leak(app, &token).await;
+    }
+
+    #[tokio::test]
+    async fn test_not_yet_valid_token_with_future_nbf_rejected() {
+        let (app, key) = setup_with(|_| {}).await;
+        let now = now_secs();
+        // `nbf` in the future beyond leeway makes the token not yet valid.
+        let token = create_test_token_with_claims(
+            "test-issuer",
+            &key,
+            Algorithm::ES256,
+            now + 7200,
+            now,
+            Some(now + 3600),
+            None,
+        );
+        assert_unauthorized_without_claim_leak(app, &token).await;
+    }
+
+    #[tokio::test]
+    async fn test_too_long_lived_token_rejected() {
+        let (app, key) = setup_with(|state| state.auth.max_token_lifetime_secs = Some(600)).await;
+        let now = now_secs();
+        // Lifetime exp - iat = 3600s exceeds the 600s configured bound.
+        let token = create_test_token_with_claims(
+            "test-issuer",
+            &key,
+            Algorithm::ES256,
+            now + 3600,
+            now,
+            None,
+            None,
+        );
+        assert_unauthorized_without_claim_leak(app, &token).await;
+    }
+
+    #[tokio::test]
+    async fn test_audience_mismatch_rejected() {
+        let (app, key) =
+            setup_with(|state| state.auth.expected_audience = Some("expected-aud".to_string()))
+                .await;
+        let now = now_secs();
+        let token = create_test_token_with_claims(
+            "test-issuer",
+            &key,
+            Algorithm::ES256,
+            now + 3600,
+            now,
+            None,
+            Some(Audience::One("wrong-aud".to_string())),
+        );
+        assert_unauthorized_without_claim_leak(app, &token).await;
+    }
+
+    #[tokio::test]
+    async fn test_matching_audience_accepted() {
+        let (app, key) =
+            setup_with(|state| state.auth.expected_audience = Some("expected-aud".to_string()))
+                .await;
+        let now = now_secs();
+        let token = create_test_token_with_claims(
+            "test-issuer",
+            &key,
+            Algorithm::ES256,
+            now + 3600,
+            now,
+            None,
+            Some(Audience::One("expected-aud".to_string())),
+        );
+        assert_ok(app, &token).await;
+    }
+
+    #[tokio::test]
+    async fn test_audience_array_containing_expected_accepted() {
+        let (app, key) =
+            setup_with(|state| state.auth.expected_audience = Some("expected-aud".to_string()))
+                .await;
+        let now = now_secs();
+        // RFC 7519 §4.1.3 permits `aud` to be a JSON array of strings.
+        let token = create_test_token_with_claims(
+            "test-issuer",
+            &key,
+            Algorithm::ES256,
+            now + 3600,
+            now,
+            None,
+            Some(Audience::Many(vec![
+                "other-aud".into(),
+                "expected-aud".into(),
+            ])),
+        );
+        assert_ok(app, &token).await;
+    }
+
+    #[tokio::test]
+    async fn test_audience_array_without_expected_rejected() {
+        let (app, key) =
+            setup_with(|state| state.auth.expected_audience = Some("expected-aud".to_string()))
+                .await;
+        let now = now_secs();
+        let token = create_test_token_with_claims(
+            "test-issuer",
+            &key,
+            Algorithm::ES256,
+            now + 3600,
+            now,
+            None,
+            Some(Audience::Many(vec!["other-aud".into(), "wrong-aud".into()])),
+        );
+        assert_unauthorized_without_claim_leak(app, &token).await;
+    }
+
+    #[tokio::test]
+    async fn test_iat_after_exp_rejected() {
+        let (app, key) = setup_with(|state| state.auth.max_token_lifetime_secs = Some(600)).await;
+        let now = now_secs();
+        // `iat` (now + 7200) exceeds `exp` (now); previously the saturating
+        // subtraction produced 0 and bypassed the max-lifetime check.
+        let token = create_test_token_with_claims(
+            "test-issuer",
+            &key,
+            Algorithm::ES256,
+            now,
+            now + 7200,
+            None,
+            None,
+        );
+        assert_unauthorized_without_claim_leak(app, &token).await;
+    }
+
+    #[tokio::test]
+    async fn test_omitted_aud_rejected_when_expected_audience_set() {
+        // Regression: `set_audience` alone does not make `aud` required, so a
+        // token with no `aud` claim at all previously slipped through as 200 OK.
+        let (app, key) =
+            setup_with(|state| state.auth.expected_audience = Some("expected-aud".to_string()))
+                .await;
+        let now = now_secs();
+        let token = create_test_token_with_claims(
+            "test-issuer",
+            &key,
+            Algorithm::ES256,
+            now + 3600,
+            now,
+            None,
+            None,
+        );
+        assert_unauthorized_without_claim_leak(app, &token).await;
+    }
+
+    #[tokio::test]
+    async fn test_aud_claim_accepted_when_expected_audience_not_configured() {
+        // `aud` is optional when `expected_audience` is unset: a token that
+        // carries an `aud` claim must still be accepted and not validated.
+        let (app, key) = setup_with(|_| {}).await;
+        let now = now_secs();
+        let token = create_test_token_with_claims(
+            "test-issuer",
+            &key,
+            Algorithm::ES256,
+            now + 3600,
+            now,
+            None,
+            Some(Audience::One("any-aud".to_string())),
+        );
+        assert_ok(app, &token).await;
+    }
+
+    #[tokio::test]
+    async fn test_future_iat_rejected() {
+        // `iat` is issuer-controlled and, by design, not compared to the server
+        // clock by jsonwebtoken; reject tokens not yet valid beyond leeway.
+        let (app, key) = setup_with(|_| {}).await;
+        let now = now_secs();
+        // iat far in the future (next day), exp even further out.
+        let token = create_test_token_with_claims(
+            "test-issuer",
+            &key,
+            Algorithm::ES256,
+            now + 100_060,
+            now + 100_000,
+            None,
+            None,
+        );
+        assert_unauthorized_without_claim_leak(app, &token).await;
+    }
+
+    #[tokio::test]
+    async fn test_max_lifetime_anchored_to_server_clock() {
+        // Regression: exp - iat alone was bypassable by an attacker choosing iat.
+        // A token valid ~28h under a 60s policy previously returned 200 OK
+        // (iat = now + 100_000, exp = now + 100_060). The absolute exp bound
+        // against now + max_lifetime + leeway must reject it.
+        let (app, key) = setup_with(|state| state.auth.max_token_lifetime_secs = Some(60)).await;
+        let now = now_secs();
+        let token = create_test_token_with_claims(
+            "test-issuer",
+            &key,
+            Algorithm::ES256,
+            now + 100_060,
+            now + 100_000,
+            None,
+            None,
+        );
+        assert_unauthorized_without_claim_leak(app, &token).await;
+    }
+
+    #[tokio::test]
+    async fn test_oversized_issuer_rejected() {
+        // The unverified `iss` is bounded before being used as a DB lookup key
+        // or logged, so an attacker cannot inject oversized input or forge log
+        // lines.
+        let (app, key) = setup_with(|_| {}).await;
+        let now = now_secs();
+        let big_issuer = "x".repeat(MAX_ISSUER_LEN + 1);
+        let token = create_test_token_with_claims(
+            &big_issuer,
+            &key,
+            Algorithm::ES256,
+            now + 3600,
+            now,
+            None,
+            None,
+        );
+        assert_unauthorized_without_claim_leak(app, &token).await;
+    }
+
+    #[tokio::test]
+    async fn test_fractional_numeric_date_accepted() {
+        // RFC 7519 §2 NumericDate may be non-integer (e.g. Python time.time()).
+        // Deserialization must coerce rather than fail as an opaque 401.
+        let (app, key) = setup_with(|_| {}).await;
+        let now = now_secs();
+        let claims = serde_json::json!({
+            "iss": "test-issuer",
+            "exp": (now + 3600) as f64,
+            "iat": now as f64,
+        });
+        let token = encode(&Header::new(Algorithm::ES256), &claims, &key).unwrap();
+        assert_ok(app, &token).await;
+    }
+
+    #[tokio::test]
+    async fn test_non_string_aud_rejected() {
+        // `aud: 42` / `aud: {}` must not be silently accepted by a too-permissive
+        // claim type; it should fail deserialization as a generic 401.
+        let (app, key) = setup_with(|_| {}).await;
+        let now = now_secs();
+        let claims = serde_json::json!({
+            "iss": "test-issuer",
+            "exp": now + 3600,
+            "iat": now,
+            "aud": 42,
+        });
+        let token = encode(&Header::new(Algorithm::ES256), &claims, &key).unwrap();
+        assert_unauthorized_without_claim_leak(app, &token).await;
+    }
+
+    #[tokio::test]
+    async fn test_oct_key_rejected_at_registration() {
+        // An `oct` (shared-secret) key is rejected at registration with a 400
+        // `invalid_public_jwk`, since POST /credentials is unauthenticated and
+        // an HMAC key would otherwise be accepted but permanently unusable for
+        // management token verification.
+        let result = crate::domain::models::credential::PublicJwk::try_new(
+            br#"{"kty":"oct","k":"GawgguFyGrWKav7AX4VKUg"}"#.to_vec(),
+        );
+        let err = result.expect_err("oct key must be rejected");
+        assert!(
+            err.to_string().contains("oct"),
+            "error should mention the rejected key type: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_hmac_key_rejected_by_middleware_defense_in_depth() {
+        // Defense-in-depth: even if an `oct` (HMAC) key somehow exists in the
+        // credential store (e.g. registered before the registration guard), the
+        // middleware rejects it. The credential is constructed directly to
+        // bypass `PublicJwk::try_new`, which now rejects oct keys at the API.
+        let state = test_app_state(None).await;
+        let secret_jwk = crate::domain::models::credential::PublicJwk(
+            br#"{"kty":"oct","k":"GawgguFyGrWKav7AX4VKUg"}"#.to_vec(),
+        );
+        state
+            .service
+            .publish_credential(crate::domain::models::credential::Credential {
+                issuer: Issuer("hmac-issuer".into()),
+                public_key: secret_jwk,
+            })
+            .await
+            .unwrap();
+        let app = create_test_router(state);
+
+        // Sign an HS256 token with the shared secret.
+        let secret = EncodingKey::from_secret(b"GawgguFyGrWKav7AX4VKUg");
+        let now = now_secs();
+        let claims = serde_json::json!({
+            "iss": "hmac-issuer",
+            "exp": now + 3600,
+            "iat": now,
+        });
+        let header = Header::new(Algorithm::HS256);
+        let token = encode(&header, &claims, &secret).unwrap();
+
+        // The HMAC rejection folds into the generic non-disclosing invalid_token
+        // (it must not reveal that an HMAC/oct key is in use).
+        assert_unauthorized_without_claim_leak(app, &token).await;
     }
 }

--- a/src/server/handlers/issue_credential.rs
+++ b/src/server/handlers/issue_credential.rs
@@ -56,7 +56,7 @@ mod tests {
     use crate::test_utils::test_app_state;
     use axum::{
         Router,
-        body::Body,
+        body::{Body, to_bytes},
         extract::Request,
         http::{Method, header},
         routing::post,
@@ -126,5 +126,33 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[tokio::test]
+    async fn test_publish_credentials_rejects_oct_key() {
+        let app_state = test_app_state(None).await;
+        let app = create_test_router(app_state);
+
+        // A symmetric (shared-secret) key must be rejected up front with a 400
+        // `invalid_public_jwk` rather than accepted and permanently rejected at
+        // request time.
+        let body = r#"{"issuer": "test_issuer", "public_key": {"kty": "oct", "k": "GawgguFyGrWKav7AX4VKUg"}}"#;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/issue-credential")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["error"], "invalid_public_jwk");
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -22,6 +22,19 @@ pub struct AppState {
     pub max_statuses_per_request: usize,
     pub max_serialized_list_size: usize,
     pub snapshot_retention_secs: u64,
+    /// Management-token claim validation policy applied by the auth middleware.
+    pub auth: AuthPolicy,
     /// Dependency readiness checks backing the `/health/ready` endpoint.
     pub readiness: health::Readiness,
+}
+
+/// Management-token claim validation policy consumed by the auth middleware.
+#[derive(Debug, Clone)]
+pub struct AuthPolicy {
+    /// Maximum allowed token lifetime in seconds (`exp - iat`); `None` disables.
+    pub max_token_lifetime_secs: Option<u64>,
+    /// Clock-skew leeway in seconds for `exp`/`nbf`.
+    pub leeway_secs: u64,
+    /// Expected `aud` claim; `None` disables audience validation.
+    pub expected_audience: Option<String>,
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -136,6 +136,16 @@ type BuildStateResult = (AppState, Arc<CertManager>);
 type BuildStateResult = (AppState,);
 
 async fn build_state_impl(config: &AppConfig) -> EyeResult<BuildStateResult> {
+    config.server.auth.validate()?;
+
+    if config.server.auth.max_token_lifetime_secs.is_none() {
+        tracing::warn!(
+            "no maximum token lifetime is set: management tokens have no upper \
+             lifetime bound and are replayable until `exp`. Set one (e.g. 3600 \
+             seconds) to limit the blast radius of a leaked token."
+        );
+    }
+
     // Hoisted DB handle captured from the backend branches below so the
     // readiness probe can reach the real adapter (the domain ports only expose
     // the higher-level repositories).
@@ -366,6 +376,11 @@ async fn build_state_impl(config: &AppConfig) -> EyeResult<BuildStateResult> {
         max_statuses_per_request: config.limits.max_statuses_per_request,
         max_serialized_list_size: config.limits.max_serialized_list_size,
         snapshot_retention_secs: config.status_list.snapshot_retention_secs,
+        auth: crate::server::AuthPolicy {
+            max_token_lifetime_secs: config.server.auth.max_token_lifetime_secs,
+            leeway_secs: config.server.auth.leeway_secs,
+            expected_audience: empty_to_none(config.server.auth.expected_audience.clone()),
+        },
         readiness,
     };
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -14,8 +14,7 @@ use crate::outbound::memory::{MemoryCredentials, MemoryStatusListSnapshotRepo, M
 use crate::outbound::sql::{
     SeaOrmStore, SqlCredentialRepo, SqlStatusListRepo, SqlStatusListSnapshotRepo,
 };
-use crate::server::AppState;
-use crate::server::health::Readiness;
+use crate::server::{AppState, AuthPolicy, health::Readiness};
 #[cfg(feature = "acme")]
 use crate::{cert_manager::storage::StorageError, utils::cert_manager::storage::Storage};
 use async_trait::async_trait;
@@ -90,7 +89,12 @@ pub(crate) async fn test_app_state_without_snapshots() -> AppState {
         max_statuses_per_request: 5_000,
         max_serialized_list_size: 1_048_576,
         snapshot_retention_secs: 0,
-        readiness: crate::server::health::Readiness::new(Vec::new()),
+        auth: AuthPolicy {
+            max_token_lifetime_secs: None,
+            leeway_secs: 60,
+            expected_audience: None,
+        },
+        readiness: Readiness::new(Vec::new()),
     }
 }
 
@@ -180,6 +184,11 @@ async fn build_test_app_state(
         max_statuses_per_request: 5_000,
         max_serialized_list_size,
         snapshot_retention_secs: 7776000,
+        auth: AuthPolicy {
+            max_token_lifetime_secs: None,
+            leeway_secs: 60,
+            expected_audience: None,
+        },
         readiness: Readiness::default(),
     }
 }


### PR DESCRIPTION
## Harden management JWT claim validation

Strengthens bearer-token validation for authenticated management endpoints beyond the previous `iss`/`exp` checks.

**Changes**
- Adds claim validation policy (`iss`, `exp`, `iat` required; `nbf` and `aud` optional) in the auth middleware with a reusable generic error mapping.
- Introduces three configurable knobs under `server.auth`: clock-skew `leeway_secs` (default 60), optional `max_token_lifetime_secs` (`exp - iat` upper bound), and optional `expected_audience`.
- Enforces `nbf` validation and a deterministic 401 for missing/malformed claims.
- Keeps all claim/signature failures non-disclosing (`401 invalid_token`) so responses never reveal which claim failed or token details.
- Aligns README, OpenAPI, and `.env.template` with the actual claim requirements.
- Adds negative tests for missing `iat`/`exp`, future `nbf`, over-long lifetime, audience mismatch, plus a response-leak guard.

**Outstanding (from review, before merge):**
- `aud` is rejected when present in a token if `expected_audience` is unset (should be optional).
- `aud` as a JSON array is always rejected, even when it matches `expected_audience`.
- `iat > exp` bypasses the max-lifetime bound.