### PR TITLE
fix(helm): production-ready Helm chart — IRSA, HAProxy TLS bootstrap, OTEL disabled

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -7,6 +7,138 @@ This guide provides instructions for deploying the Status List Server using the 
 - Kubernetes cluster (e.g., AWS EKS)
 - Helm 3 installed
 - `kubectl` configured to connect to your cluster
+- [External Secrets Operator](https://external-secrets.io/) installed in the cluster (this chart creates a `SecretStore`/`ExternalSecret` that depends on the ESO CRDs and controller already running)
+- Two AWS IAM prerequisites configured **before** installing the chart — see [AWS IAM Prerequisites (IRSA)](#aws-iam-prerequisites-irsa) below
+- The Postgres and Redis StatefulSets use `ReadWriteOnce` EBS-backed PVCs (`storageClass: high-performance` / `gp3` by default). On multi-AZ node groups with cluster-autoscaler, an EBS volume is zone-locked to whichever AZ its pod first schedules in; if the node group later scales down/rotates and no nodes remain in that AZ, the pod will be stuck `Pending` with `didn't match PersistentVolume's node affinity`. Either pin a minimum node count per AZ used by these StatefulSets, or be prepared to recreate the PVC (data loss) / restore from backup if a volume becomes stranded.
+
+## AWS IAM Prerequisites (IRSA)
+
+This chart relies on two independent IAM roles associated via IRSA (IAM Roles for Service Accounts). Both must exist and be correctly scoped before `helm install`, or the corresponding pods will fail to start.
+
+### 1. External Secrets Operator's IRSA role
+
+Used by ESO to pull secrets from AWS Secrets Manager into Kubernetes. Must be attached to the role bound to ESO's ServiceAccount (e.g. `external-secrets-role`).
+
+Add this permission to the existing ESO role (or create a new one if it doesn't exist):
+
+```bash
+aws iam put-role-policy \
+  --role-name external-secrets-role \
+  --policy-name statuslist-secrets-read \
+  --policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "ReadStatusListSecret",
+        "Effect": "Allow",
+        "Action": ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"],
+        "Resource": "arn:aws:secretsmanager:eu-central-1:982081049921:secret:statuslist-secret-PUwXi1"
+      }
+    ]
+  }' \
+  --region eu-central-1
+```
+
+The `statuslist-secret` in AWS Secrets Manager must contain keys `POSTGRES_PASSWORD` and `REDIS_PASSWORD` as referenced under `externalSecret.spec.data` in `values.yaml`.
+
+### 2. Application's own IRSA role
+
+Used by the `status-list-server` pod to authenticate to AWS S3 (for TLS certificate storage) and Route53 (for ACME DNS-01 challenges) via the default AWS SDK credential chain. Values needed for the steps below:
+
+- AWS account ID: `982081049921`
+- Region: `eu-central-1`
+- EKS cluster name: `datev-wallet-cluster`
+- EKS OIDC provider ID: see `aws eks describe-cluster --name datev-wallet-cluster --region eu-central-1 --query 'cluster.identity.oidc.issuer'`
+- S3 bucket: `status-list-adorsys`
+- ServiceAccount name: `statuslist-status-list-server` (namespace: `statuslist`)
+
+**Step 1 — Verify the cluster has OIDC enabled:**
+
+```bash
+aws eks describe-cluster --name datev-wallet-cluster --region eu-central-1 --query 'cluster.identity.oidc.issuer' --output text
+```
+
+If it returns a URL like `https://oidc.eks.eu-central-1.amazonaws.com/id/XXXXXXXX`, the cluster is ready. If it returns empty, run:
+
+```bash
+aws eks associate-iam-oidc-provider \
+  --cluster-name datev-wallet-cluster \
+  --region eu-central-1 \
+  --no-verify-ssl
+```
+
+**Step 2 — Create the IAM role:**
+
+```bash
+aws iam create-role \
+  --role-name statuslist-app-role \
+  --description "IRSA role for status-list-server app (S3 + Route53)" \
+  --assume-role-policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Principal": {
+          "Federated": "arn:aws:iam::982081049921:oidc-provider/oidc.eks.eu-central-1.amazonaws.com/id/<YOUR_OIDC_PROVIDER_ID>"
+        },
+        "Action": "sts:AssumeRoleWithWebIdentity",
+        "Condition": {
+          "StringEquals": {
+            "oidc.eks.eu-central-1.amazonaws.com/id/<YOUR_OIDC_PROVIDER_ID>:sub": "system:serviceaccount:statuslist:statuslist-status-list-server"
+          }
+        }
+      }
+    ]
+  }' \
+  --region eu-central-1
+```
+
+Replace `<YOUR_OIDC_PROVIDER_ID>` with your EKS cluster's OIDC provider ID (output from Step 1 — extract the part after `/id/`).
+
+**Step 3 — Attach S3 and Route53 permissions:**
+
+```bash
+aws iam put-role-policy \
+  --role-name statuslist-app-role \
+  --policy-name StatusListAppPolicy \
+  --policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "S3BucketAccess",
+        "Effect": "Allow",
+        "Action": ["s3:ListBucket"],
+        "Resource": "arn:aws:s3:::status-list-adorsys"
+      },
+      {
+        "Sid": "S3ObjectAccess",
+        "Effect": "Allow",
+        "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
+        "Resource": "arn:aws:s3:::status-list-adorsys/*"
+      },
+      {
+        "Sid": "Route53Access",
+        "Effect": "Allow",
+        "Action": ["route53:GetChange", "route53:ListResourceRecordSets", "route53:ChangeResourceRecordSets"],
+        "Resource": "arn:aws:route53:::hostedzone/*"
+      }
+    ]
+  }' \
+  --region eu-central-1
+```
+
+**Step 4 — Enable IRSA in values.yaml**
+
+The `values.yaml` ships with `serviceAccount.annotations` commented out. Uncomment and fill in your role ARN (or supply it via `--set` during install):
+
+```yaml
+serviceAccount:
+  create: true
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::982081049921:role/statuslist-app-role"
+```
+
+The app authenticates using the AWS SDK's default credential chain (WebIdentityToken via IRSA) — no static credentials are mounted into the pod.
 
 ## Chart Dependencies
 
@@ -42,6 +174,8 @@ The following files are used to configure the deployment:
 2. **Create TLS secrets:**
 
    Refer to the [Redis TLS Setup Guide](../docs/REDIS_TLS_SETUP.md) for detailed instructions on creating the necessary TLS secrets for Redis and HAProxy.
+
+   The `statuslist-haproxy-tls` secret consumed by the Redis HAProxy Deployment is derived automatically from `statuslist-tls` by a `pre-install`/`pre-upgrade` Helm hook Job (`redis-cert-sync-bootstrap-<revision>`), and kept in sync afterwards by a weekly `redis-cert-sync` CronJob whenever cert-manager rotates the wildcard certificate. You do not need to create `statuslist-haproxy-tls` manually, but `statuslist-tls` must already exist (issued by cert-manager via the Ingress, or created manually per the guide above) before the hook Job can succeed — the hook retries with backoff if it isn't ready yet.
 
 3. **Deploy the chart:**
 

--- a/helm/chart/templates/_helpers.tpl
+++ b/helm/chart/templates/_helpers.tpl
@@ -63,6 +63,50 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Shared shell script that syncs the HAProxy TLS secret (statuslist-haproxy-tls)
+from the main wildcard certificate secret (statuslist-tls). Used by both the
+post-install/post-upgrade bootstrap Job (immediate first sync) and the
+periodic CronJob (renewal after cert-manager rotates the certificate).
+*/}}
+{{- define "status-list-server-chart.redisCertSyncScript" -}}
+set -euo pipefail
+
+NS="${NAMESPACE:-{{ .Release.Namespace }}}"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+echo "Fetching base certificate from secret statuslist-tls in namespace ${NS}..."
+kubectl get secret statuslist-tls -n "${NS}" -o jsonpath='{.data.tls\.crt}' | base64 -d > "${TMP_DIR}/tls.crt"
+kubectl get secret statuslist-tls -n "${NS}" -o jsonpath='{.data.tls\.key}' | base64 -d > "${TMP_DIR}/tls.key"
+
+cat "${TMP_DIR}/tls.crt" "${TMP_DIR}/tls.key" > "${TMP_DIR}/redis.pem"
+
+# If the HAProxy secret exists, compare the current redis.pem with the new one.
+if kubectl get secret statuslist-haproxy-tls -n "${NS}" >/dev/null 2>&1; then
+  echo "Existing statuslist-haproxy-tls secret found, comparing redis.pem..."
+  kubectl get secret statuslist-haproxy-tls -n "${NS}" -o jsonpath='{.data.redis\.pem}' | base64 -d > "${TMP_DIR}/existing-redis.pem" || true
+
+  if [ -s "${TMP_DIR}/existing-redis.pem" ] && cmp -s "${TMP_DIR}/redis.pem" "${TMP_DIR}/existing-redis.pem"; then
+    echo "Redis HAProxy certificate is already up to date. No changes applied."
+    exit 0
+  fi
+else
+  echo "statuslist-haproxy-tls secret does not exist yet. It will be created."
+fi
+
+echo "Applying updated statuslist-haproxy-tls secret..."
+kubectl create secret generic statuslist-haproxy-tls \
+  -n "${NS}" \
+  --from-file=redis.pem="${TMP_DIR}/redis.pem" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+echo "Redis HAProxy TLS secret synced successfully. Restarting HAProxy deployment to pick up new certificate..."
+kubectl rollout restart deploy/{{ .Release.Name }}-redis-ha-haproxy -n "${NS}" 2>/dev/null || echo "HAProxy deployment not found yet, skipping restart (it will pick up the secret on its own startup)."
+
+echo "Redis HAProxy deployment restart triggered."
+{{- end }}
+
+{{/*
 Resolve the Redis connection URI based on chart values.
 */}}
 {{- define "status-list-server-chart.redisUri" -}}

--- a/helm/chart/templates/deployment.yaml
+++ b/helm/chart/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         {{- include "status-list-server-chart.labels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "status-list-server-chart.serviceAccountName" . }}
       {{- with .Values.statuslist.initContainers }}
       initContainers:
         {{- range $ic := . }}
@@ -90,10 +91,6 @@ spec:
             {{- if .Values.secretStore.enabled }}
             - name: APP_AWS__REGION
               value: {{ .Values.secretStore.aws.region | quote }}
-            - name: AWS_SHARED_CREDENTIALS_FILE
-              value: /home/nobody/.aws/credentials
-            - name: AWS_CONFIG_FILE
-              value: /home/nobody/.aws/config
             {{- end }}
             - name: POSTGRES_DB
               value: {{ .Values.postgres.auth.database | quote }}
@@ -109,11 +106,6 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
-          {{- if .Values.secretStore.enabled }}
-            - name: aws-credentials-volume
-              mountPath: /home/nobody/.aws
-              readOnly: true
-          {{- end }}
         {{- if and .Values.otelCollector.enabled .Values.otelCollector.sidecar.enabled }}
         - name: otel-collector
           image: {{ .Values.otelCollector.sidecar.image.repository }}:{{ .Values.otelCollector.sidecar.image.tag }}
@@ -137,11 +129,6 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
-      {{- if .Values.secretStore.enabled }}
-        - name: aws-credentials-volume
-          secret:
-            secretName: aws-credentials-secret
-      {{- end }}
       {{- if and .Values.otelCollector.enabled .Values.otelCollector.sidecar.enabled }}
         - name: otel-collector-config
           configMap:

--- a/helm/chart/templates/redis-ha-cert-sync.yaml
+++ b/helm/chart/templates/redis-ha-cert-sync.yaml
@@ -11,8 +11,16 @@ We:
   - Compare against the existing redis.pem in statuslist-haproxy-tls (if any)
   - Only apply a new secret if redis.pem has actually changed
 
-The CronJob is scheduled infrequently, because certificates change rarely and
-DNS / LB propagation is not instantaneous.
+Two workloads share the sync script (see the
+"status-list-server-chart.redisCertSyncScript" helper):
+
+  1. A post-install/post-upgrade Helm hook Job that runs the sync immediately,
+     so statuslist-haproxy-tls exists before the redis-ha-haproxy Deployment's
+     first rollout instead of waiting for the CronJob's first scheduled run
+     (which can be up to a week away on a fresh install).
+  2. A CronJob, scheduled infrequently because certificates change rarely and
+     DNS / LB propagation is not instantaneous, that keeps the secret in sync
+     whenever cert-manager rotates the wildcard certificate later on.
 */ -}}
 
 {{- $redisHA := index .Values "redis-ha" | default dict -}}
@@ -41,7 +49,10 @@ rules:
     resourceNames:
       - statuslist-tls
       - statuslist-haproxy-tls
-    verbs: ["get", "create", "update", "patch"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
   - apiGroups: ["apps"]
     resources: ["deployments"]
     resourceNames:
@@ -64,6 +75,78 @@ subjects:
     name: redis-cert-sync-sa
     namespace: {{ .Release.Namespace }}
 ---
+# Bootstrap Job: runs on every install/upgrade so statuslist-haproxy-tls
+# exists immediately, instead of waiting for the CronJob's first scheduled
+# trigger. Helm hook weight/deletion policy ensures it runs before the rest
+# of the release (in particular before the haproxy Deployment tries to mount
+# the secret) and is cleaned up automatically after it succeeds.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redis-cert-sync-bootstrap-{{ .Release.Revision }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "status-list-server-chart.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  # statuslist-tls is issued asynchronously by cert-manager via the Ingress
+  # (DNS-01 challenge), so on a brand new domain/cluster it may not exist
+  # yet when this hook runs. Retry with backoff for a while; if the
+  # certificate still isn't ready by the time retries are exhausted, the
+  # weekly redis-cert-sync CronJob (or `helm upgrade` to re-run this hook)
+  # will pick it up once cert-manager finishes issuing it.
+  backoffLimit: 10
+  template:
+    metadata:
+      labels:
+        {{- include "status-list-server-chart.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: redis-cert-sync-sa
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      containers:
+        - name: redis-cert-sync-bootstrap
+          image: bitnami/kubectl:latest
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          command:
+            - /bin/bash
+            - -c
+            - |
+              {{- include "status-list-server-chart.redisCertSyncScript" . | nindent 14 }}
+---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -74,7 +157,9 @@ metadata:
 spec:
   # Run once per week at Sunday 00:00 UTC.
   # Certificates are long-lived and cert-manager renews well before expiry,
-  # so a weekly sync is sufficient while keeping cluster noise low.
+  # so a weekly sync is sufficient while keeping cluster noise low. The
+  # bootstrap Job above (pre-install/pre-upgrade hook) handles the initial
+  # sync so this schedule only needs to catch later certificate rotations.
   schedule: "0 0 * * 0"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
@@ -95,9 +180,12 @@ spec:
             fsGroup: 65534
             seccompProfile:
               type: RuntimeDefault
+          volumes:
+            - name: tmp
+              emptyDir: {}
           containers:
             - name: redis-cert-sync
-              image: bitnami/kubectl:1.31
+              image: bitnami/kubectl:latest
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
@@ -117,43 +205,12 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
               command:
                 - /bin/bash
                 - -c
                 - |
-                  set -euo pipefail
-
-                  NS="${NAMESPACE:-{{ .Release.Namespace }}}"
-                  TMP_DIR="$(mktemp -d)"
-                  trap 'rm -rf "$TMP_DIR"' EXIT
-
-                  echo "Fetching base certificate from secret statuslist-tls in namespace ${NS}..."
-                  kubectl get secret statuslist-tls -n "${NS}" -o jsonpath='{.data.tls\.crt}' | base64 -d > "${TMP_DIR}/tls.crt"
-                  kubectl get secret statuslist-tls -n "${NS}" -o jsonpath='{.data.tls\.key}' | base64 -d > "${TMP_DIR}/tls.key"
-
-                  cat "${TMP_DIR}/tls.crt" "${TMP_DIR}/tls.key" > "${TMP_DIR}/redis.pem"
-
-                  # If the HAProxy secret exists, compare the current redis.pem with the new one.
-                  if kubectl get secret statuslist-haproxy-tls -n "${NS}" >/dev/null 2>&1; then
-                    echo "Existing statuslist-haproxy-tls secret found, comparing redis.pem..."
-                    kubectl get secret statuslist-haproxy-tls -n "${NS}" -o jsonpath='{.data.redis\.pem}' | base64 -d > "${TMP_DIR}/existing-redis.pem" || true
-
-                    if [ -s "${TMP_DIR}/existing-redis.pem" ] && cmp -s "${TMP_DIR}/redis.pem" "${TMP_DIR}/existing-redis.pem"; then
-                      echo "Redis HAProxy certificate is already up to date. No changes applied."
-                      exit 0
-                    fi
-                  else
-                    echo "statuslist-haproxy-tls secret does not exist yet. It will be created."
-                  fi
-
-                  echo "Applying updated statuslist-haproxy-tls secret..."
-                  kubectl create secret generic statuslist-haproxy-tls \
-                    -n "${NS}" \
-                    --from-file=redis.pem="${TMP_DIR}/redis.pem" \
-                    --dry-run=client -o yaml | kubectl apply -f -
-
-                  echo "Redis HAProxy TLS secret synced successfully. Restarting HAProxy deployment to pick up new certificate..."
-                  kubectl rollout restart deploy/{{ .Release.Name }}-redis-ha-haproxy -n "${NS}"
-
-                  echo "Redis HAProxy deployment restart triggered."
+                  {{- include "status-list-server-chart.redisCertSyncScript" . | nindent 18 }}
 {{- end }}

--- a/helm/chart/templates/serviceaccount.yaml
+++ b/helm/chart/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "status-list-server-chart.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "status-list-server-chart.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -99,9 +99,13 @@ statuslist:
     APP_LIMITS__MAX_STATUSES_PER_REQUEST: "5000"
     APP_LIMITS__MAX_SERIALIZED_LIST_SIZE: "1048576"
     # Telemetry / OpenTelemetry
-    APP_TELEMETRY__ENVIRONMENT: "production"
+    # NOTE: The deployed image was built from an older source version that included
+    # OpenTelemetry (opentelemetry_sdk). Since the telemetry endpoint (localhost:4317)
+    # is not actually running in this deployment (no OTEL collector is deployed), these
+    # errors would flood the logs whenever telemetry is enabled.
+    # Set to false until the image is rebuilt from the current source (no telemetry).
+    APP_TELEMETRY__ENABLED: "false"
     APP_TELEMETRY__OTLP_ENDPOINT: "http://localhost:4317"
-    APP_TELEMETRY__ENABLED: "true"
     APP_TELEMETRY__SAMPLER_RATIO: "1.0"
   livenessProbe:
     httpGet:
@@ -186,6 +190,19 @@ secretStore:
   enabled: true
   aws:
     region: eu-central-1
+
+# ServiceAccount used by the status-list-server pods. On EKS, annotate this
+# ServiceAccount with an IRSA role ARN (eks.amazonaws.com/role-arn) so the AWS
+# SDK inside the app can authenticate via the default credential chain
+# (WebIdentityToken) without any mounted static credentials. The IAM role
+# must grant access to Secrets Manager (for the ACME DNS/cert secrets it
+# manages at runtime) and S3 (APP_AWS__S3_BUCKET), scoped to this workload
+# only.
+serviceAccount:
+  create: true
+  name: ""
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::982081049921:role/statuslist-app-role"
 
 redis-ha:
   enabled: true


### PR DESCRIPTION
## Summary

Hardens the Helm chart for production EKS deployment by fixing several independent issues found during live cluster debugging.

### Changes

| File | Change |
|------|--------|
| `templates/deployment.yaml` | Removed broken `aws-credentials-secret` mount + env vars; set `serviceAccountName` |
| `templates/serviceaccount.yaml` | **New** — creates ServiceAccount with IRSA annotation support |
| `templates/redis-ha-cert-sync.yaml` | Added `post-install` helm hook Job for immediate HAProxy TLS secret bootstrap; fixed RBAC `create secrets` rule; added `/tmp` emptyDir; image `bitnami/kubectl:latest` |
| `templates/_helpers.tpl` | Factored shared `redisCertSyncScript` helper |
| `values.yaml` | IRSA `serviceAccount` block; `APP_TELEMETRY__ENABLED: false` |
| `README.md` | IRSA step-by-step with all AWS CLI commands; EBS AZ stranding warning; ACME cert bootstrap lifecycle |

### What was fixed

1. **aws-credentials-secret never existed** — no template created it; removed entirely. App now uses IRSA (`eks.amazonaws.com/role-arn`) which the Rust AWS SDK handles via WebIdentityToken automatically.

2. **HAProxy `statuslist-haproxy-tls` bootstrap gap** — fresh `helm install` would wait up to a week for the CronJob's first Sunday trigger. Added a `post-install` hook Job (weight `-5`) that runs the same sync script immediately, sealing the secret before HAProxy starts.

3. **RBAC fix** — Kubernetes RBAC does not allow `resourceNames` on `create`/`patch`/`update`. Split into two rules: one for named resources with `get`/`patch`, one unrestricted for `create`.

4. **OTEL error flood** — `APP_TELEMETRY__ENABLED: true` with no OTEL collector at `localhost:4317` floods logs every 5 seconds. Disabled until the deployed image is rebuilt from current source.

5. **README prerequisites** — documented IRSA step-by-step, ESO IAM requirements, EBS `WaitForFirstConsumer` zone-stranding risk.

### Infrastructure pre-requisites still outside the chart

- ESO IRSA role (read access to `statuslist-secret` in Secrets Manager) — see README step 1
- App IRSA role (`statuslist-app-role` created independently) — see README step 2
- Cluster OIDC already enabled on `datev-wallet-cluster`