### PR TITLE
feat: update Redis integration and documentation for optional caching

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -102,8 +102,12 @@ APP_DATABASE__POOL__CONNECT_TIMEOUT_SECS=10
 APP_DATABASE__POOL__IDLE_TIMEOUT_SECS=600
 APP_DATABASE__POOL__MAX_LIFETIME_SECS=1800
 
-# Redis configuration
-APP_REDIS__URI=redis://redis:6379
+# Redis configuration (optional)
+# Redis is NOT required for status-list persistence or reads. It is only used
+# as a distributed certificate-material cache for multi-replica deployments
+# that use AWS S3 certificate storage with the 'redis' feature compiled.
+# Leave APP_REDIS__URI empty to disable Redis entirely.
+APP_REDIS__URI=
 APP_REDIS__REQUIRE_CLIENT_AUTH=false
 # TTL for the certificate cache in Redis.
 # Set to 0 to disable and always fetch from S3.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ server = ["history"]
 postgres = ["sea-orm?/sqlx-postgres", "history"]
 sqlite = ["sea-orm?/sqlx-sqlite", "history"]
 mysql = ["sea-orm?/sqlx-mysql", "history"]
+# Optional distributed certificate-material cache driver.
 redis = ["dep:redis"]
 aws = [
   "dep:aws-config",

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM builder-${TARGETARCH} AS builder
 ARG APP_NAME
 ARG TARGETPLATFORM
 ARG TARGETARCH
-ARG FEATURES="postgres,redis,aws,acme"
+ARG FEATURES="postgres,aws,acme"
 WORKDIR /app
 
 # Set the Rust target and build the application

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ For a detailed explanation of the architecture, see the [hexagonal architecture 
 Before running the server, ensure you have the following tools installed:
 
 - [Rust & Cargo](https://www.rust-lang.org/tools/install) (Latest stable).
-- A supported database backend: PostgreSQL, MySQL, or SQLite.
-- [Redis](https://redis.io/download): The in-memory data structure store used for caching.
+- A supported database backend: PostgreSQL, MySQL, or SQLite for persistent deployments. The default local mode uses in-memory repositories.
+- [Redis](https://redis.io/download) is optional and only needed when you enable the distributed certificate-material cache.
 - [Docker](https://www.docker.com/get-started/) (optional, for local testing).
 
 ### Run locally
@@ -65,12 +65,18 @@ The simplest way to run the project is with [docker compose](https://docs.docker
 docker compose up --build
 ```
 
-This command will pull all required images and start the server compiled with default compose features (`postgres,redis,aws,acme`).
+This command will pull all required images and start the server compiled with default compose features (`postgres,aws,acme`). Redis is not part of the default path.
 
 To pass custom Cargo feature flags during build, specify the `FEATURES` environment variable:
 
 ```sh
-FEATURES="mysql,redis,aws,acme" docker compose up --build
+FEATURES="mysql,aws,acme" docker compose --profile mysql up --build
+```
+
+To test the optional Redis certificate-material cache locally, enable the Redis profile, compile the Redis feature, and provide a Redis URI:
+
+```sh
+FEATURES="postgres,redis,aws,acme" APP_REDIS__URI="redis://redis:6379" docker compose --profile redis up --build
 ```
 
 #### Running Manually
@@ -100,12 +106,20 @@ The crate uses modular Cargo feature flags to gate optional production backend d
 To build with specific backend drivers, pass the matching feature flag(s):
 
 ```bash
-# Run with PostgreSQL and Redis support
+# Run with PostgreSQL and Redis support available
 cargo run --features postgres,redis
 
-# Run with all AWS and ACME production integrations
+# Run with all AWS and ACME production integrations, including the optional Redis cache driver
 cargo run --features postgres,redis,aws,acme
 ```
+
+## Redis Role
+
+Redis is not required for core status-list persistence or status-list reads. Status-list records are stored by the configured repository backend (`memory`, PostgreSQL, MySQL, or SQLite), and hot status-list reads are cached in-process by `MokaStatusListCache`.
+
+When compiled with the `redis` feature and configured with a non-empty `APP_REDIS__URI`, Redis is used only as an optional distributed cache for certificate material loaded from S3 by the ACME/AWS certificate manager path. This can help multi-replica deployments share certificate cache entries and reduce repeated object-storage reads. The tradeoff is an extra operational dependency: Redis credentials, TLS settings if used, availability monitoring, backups or persistence choices, and HA/upgrade complexity.
+
+For single-replica deployments, local development, tests, or deployments where certificate material reads are inexpensive, leave `APP_REDIS__URI` unset and omit the `redis` Cargo feature.
 
 For deployment guidance and backend tradeoffs, see [`docs/database-backends.md`](docs/database-backends.md).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
   redis:
     image: redis:8.6
     container_name: redis
+    profiles: ["redis"]
     ports:
       - 6379:6379
     networks:
@@ -91,7 +92,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        FEATURES: ${FEATURES:-postgres,redis,aws,acme}
+        FEATURES: ${FEATURES:-postgres,aws,acme}
     container_name: status-list-server
     env_file:
       - path: .env.template
@@ -108,13 +109,12 @@ services:
       APP_TELEMETRY__OTLP_ENDPOINT: "http://otel-collector:4317"
       APP_TELEMETRY__ENABLED: ${APP_TELEMETRY__ENABLED:-true}
       APP_TELEMETRY__SAMPLER_RATIO: ${APP_TELEMETRY__SAMPLER_RATIO:-1.0}
+      APP_REDIS__URI: ${APP_REDIS__URI:-}
     ports:
       - 8000:8000
     depends_on:
       db:
         condition: service_healthy
-      redis:
-        condition: service_started
       pebble:
         condition: service_started
       localstack:

--- a/docs/LOCAL_DEPLOYMENT.md
+++ b/docs/LOCAL_DEPLOYMENT.md
@@ -22,8 +22,7 @@ Passwords can be any non-empty string; reuse for convenience.
 ```bash
 kubectl create namespace local
 kubectl create secret generic statuslist-secret -n local \
-  --from-literal=postgres-password=postgres \
-  --from-literal=redis-password=redis
+  --from-literal=postgres-password=postgres
 ```
 
 ## 4. Deploy
@@ -39,10 +38,9 @@ helm install statuslist-local ./helm/chart -n local -f ./helm/chart/values-local
 kubectl get pods -n local
 ```
 
-Expect three components to reach `Running`:
+Expect these components to reach `Running`:
 
 - `statuslist-local-postgres-0`
-- `statuslist-local-redis-ha-*`
 - `statuslist-local-status-list-server-deployment-*`
 
 ## 6. Access the API
@@ -63,5 +61,9 @@ minikube stop
 ## Notes
 
 - `values-local.yaml` only overrides what differs from production defaults (NodePorts, disabled ingress/secret-store, lighter resources).
-- Redis TLS and AWS-specific resources remain disabled; no additional setup required.
+- Redis, Redis TLS, and AWS-specific resources remain disabled; no additional setup required.
 - If pods fail with `CreateContainerConfigError`, check that `statuslist-secret` exists in the `local` namespace.
+
+## Optional Redis Cache
+
+Redis is only useful here if you want to exercise the distributed certificate-material cache path. Add `--set redis-ha.enabled=true`, add `redis-password` to `statuslist-secret`, and run an application image built with the `redis` feature plus `APP_REDIS__URI` configured. The default local chart intentionally avoids that dependency.

--- a/docs/REDIS_TLS_SETUP.md
+++ b/docs/REDIS_TLS_SETUP.md
@@ -1,5 +1,7 @@
 # Redis TLS Setup with HAProxy Termination
 
+Redis is optional in status-list-server. Use this guide only for deployments that deliberately enable `redis-ha.enabled=true` and run an application image compiled with the `redis` feature for the distributed certificate-material cache. Status-list persistence and status-list reads do not require Redis.
+
 This document explains the Redis TLS configuration for the status-list-server deployment, including the challenges encountered and solutions implemented.
 
 ## Quick Start

--- a/docs/database-backends.md
+++ b/docs/database-backends.md
@@ -31,10 +31,10 @@ SQLite is not a distributed database, so it is not a good match for horizontally
 
 ## Compose Profiles
 
-`docker compose up` starts PostgreSQL by default and builds the container with `postgres,redis,aws,acme` features enabled. To run the MySQL service instead:
+`docker compose up` starts PostgreSQL by default and builds the container with `postgres,aws,acme` features enabled. To run the MySQL service instead:
 
 ```bash
-FEATURES="mysql,redis,aws,acme" docker compose --profile mysql up --build
+FEATURES="mysql,aws,acme" docker compose --profile mysql up --build
 ```
 
 There is no separate MariaDB service because MariaDB uses the same MySQL-driver path (`mysql://` URL). Connect to a MariaDB host by pointing `APP_DATABASE__URL` at your MariaDB instance on port 3306 (the default) and setting `APP_DATABASE__BACKEND=mysql`.
@@ -44,3 +44,9 @@ There is no separate MariaDB service because MariaDB uses the same MySQL-driver 
 - For high availability, prefer PostgreSQL or MySQL backed by a managed HA service or a replicated cluster.
 - Avoid SQLite for multi-replica production deployments.
 - If you need distributed storage semantics, use a database that already provides them rather than trying to layer them on top of SQLite.
+
+## Redis Is Not A Database Backend
+
+Redis is not used for status-list persistence or for the status-list read path. Reads use the configured database/repository plus the in-process Moka cache. The optional `redis` feature provides a distributed certificate-material cache for the AWS S3 certificate storage path when `APP_REDIS__URI` is set.
+
+Use Redis when multiple application replicas should share cached certificate material and reducing backend object-storage reads is worth the added Redis credentials, TLS, HA, and monitoring work. Leave it disabled for local, single-replica, and simple deployments.

--- a/helm/README.md
+++ b/helm/README.md
@@ -13,9 +13,9 @@ This guide provides instructions for deploying the Status List Server using the 
 This chart has the following dependencies:
 
 - **PostgreSQL**: A relational database for storing application data.
-- **Redis HA**: A high-availability Redis cluster for caching.
+- **Redis HA**: Optional high-availability Redis cluster for the distributed certificate-material cache.
 
-These dependencies are managed by the Helm chart and will be installed automatically.
+These dependencies are managed by the Helm chart. PostgreSQL is enabled by default; Redis HA is disabled by default and is installed only when `redis-ha.enabled=true`.
 
 ## Configuration
 
@@ -30,6 +30,26 @@ The following files are used to configure the deployment:
 - **`statuslist.image.tag`**: The Docker image tag.
 - **`postgres.persistence.enabled`**: Enable or disable persistent storage for PostgreSQL.
 - **`redis-ha.persistentVolume.enabled`**: Enable or disable persistent storage for Redis.
+- **`redis-ha.enabled`**: Enable the optional Redis HA dependency and application Redis environment variables.
+
+## Redis Role
+
+Redis is optional. The server does not use Redis for status-list persistence or status-list reads; those use the configured repository backend and the in-process Moka status-list cache. In this chart, Redis is intended only as a distributed certificate-material cache for multi-replica deployments that use the AWS S3 certificate storage path and compile the application with the `redis` feature.
+
+Keep Redis disabled for a simpler deployment. Enable it when sharing certificate cache entries across replicas and reducing object-storage reads is worth the extra Redis dependency, credentials, TLS configuration, monitoring, and HA operations.
+
+### No-Redis Deployment
+
+The default `chart/values.yaml` path keeps `redis-ha.enabled=false`, does not render Redis application env vars, does not render the Redis TLS sync CronJob, and does not require a `redis-password` secret key.
+
+```bash
+helm dependency update ./chart
+helm template statuslist ./chart --namespace statuslist
+```
+
+### Redis-Enabled Certificate Cache
+
+To enable Redis, use an application image built with `redis,aws,acme` features, set `redis-ha.enabled=true`, provide a `redis-password` in the configured secret or ExternalSecret, and keep `APP_REDIS__URI` unset in `statuslist.env` so the chart can generate it from the Redis HA service. Set `APP_REDIS__REQUIRE_CLIENT_AUTH` and Redis HAProxy TLS values only when your Redis endpoint requires them.
 
 ## Production Deployment Instructions
 
@@ -39,7 +59,7 @@ The following files are used to configure the deployment:
    kubectl create namespace statuslist
    ```
 
-2. **Create TLS secrets:**
+2. **Create TLS secrets, if Redis HAProxy TLS is enabled:**
 
    Refer to the [Redis TLS Setup Guide](../docs/REDIS_TLS_SETUP.md) for detailed instructions on creating the necessary TLS secrets for Redis and HAProxy.
 

--- a/helm/chart/Chart.lock
+++ b/helm/chart/Chart.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: redis-ha
   repository: https://dandydeveloper.github.io/charts
   version: 4.35.0
-digest: sha256:f1f581f7aee3669dcc25c5b46c7b4d1204621a53635973d48eb59b5266d00549
-generated: "2026-02-17T13:47:10.337741571+01:00"
+digest: sha256:a9fccbf9d263c8fc9716bb3451f46e55d8929c3f5a88bb53a87ca7b8494b16e9
+generated: "2026-08-05T09:24:21.284295274+01:00"

--- a/helm/chart/Chart.yaml
+++ b/helm/chart/Chart.yaml
@@ -11,3 +11,4 @@ dependencies:
   - name: redis-ha
     version: 4.35.0
     repository: https://dandydeveloper.github.io/charts
+    condition: redis-ha.enabled

--- a/helm/chart/templates/deployment.yaml
+++ b/helm/chart/templates/deployment.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.statuslist.enabled }}
+{{- $redisHA := index .Values "redis-ha" | default dict -}}
+{{- $redisHAEnabled := eq (default false (index $redisHA "enabled")) true -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -131,6 +133,7 @@ spec:
               value: {{ .Values.postgres.auth.database | quote }}
             - name: APP_DATABASE__URL
               value: "postgres://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@{{ .Release.Name }}-postgres.{{ .Release.Namespace }}.svc.cluster.local:5432/$(POSTGRES_DB)"
+            {{- if $redisHAEnabled }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -138,6 +141,7 @@ spec:
                   key: redis-password
             - name: APP_REDIS__URI
               value: {{ include "status-list-server-chart.redisUri" . | quote }}
+            {{- end }}
           volumeMounts:
             - name: tmp
               mountPath: /tmp

--- a/helm/chart/templates/external-secrets.yaml
+++ b/helm/chart/templates/external-secrets.yaml
@@ -7,6 +7,8 @@ metadata:
     {{- include "status-list-server-chart.labels" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
 spec:
+  {{- $redisHA := index .Values "redis-ha" | default dict }}
+  {{- $redisHAEnabled := eq (default false (index $redisHA "enabled")) true }}
   refreshInterval: {{ .Values.externalSecret.spec.refreshInterval }}
   secretStoreRef:
     name: {{ .Values.externalSecret.spec.secretStoreRef.name }}
@@ -16,9 +18,11 @@ spec:
     creationPolicy: {{ .Values.externalSecret.spec.target.creationPolicy }}
   data:
   {{- range .Values.externalSecret.spec.data }}
+    {{- if or (ne .secretKey "redis-password") $redisHAEnabled }}
     - secretKey: {{ .secretKey }}
       remoteRef:
         key: {{ .remoteRef.key }}
         property: {{ .remoteRef.property }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/helm/chart/templates/network-policy.yaml
+++ b/helm/chart/templates/network-policy.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.statuslist.networkPolicy.enabled }}
+{{- $redisHA := index .Values "redis-ha" | default dict -}}
+{{- $redisHAEnabled := eq (default false (index $redisHA "enabled")) true -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -32,10 +34,12 @@ spec:
     - ports:
         - port: 5432
           protocol: TCP
+        {{- if $redisHAEnabled }}
         - port: 6379
           protocol: TCP
         - port: 6380
           protocol: TCP
+        {{- end }}
       {{- with .Values.statuslist.networkPolicy.egressInternal }}
       to:
         {{- toYaml . | nindent 8 }}

--- a/helm/chart/templates/redis-ha-cert-sync.yaml
+++ b/helm/chart/templates/redis-ha-cert-sync.yaml
@@ -18,7 +18,7 @@ DNS / LB propagation is not instantaneous.
 {{- $redisHA := index .Values "redis-ha" | default dict -}}
 {{- $haproxy := index $redisHA "haproxy" | default dict -}}
 {{- $haproxyTls := index $haproxy "tls" | default dict -}}
-{{- if and (eq (default true (index $haproxy "enabled")) true) (eq (default false (index $haproxyTls "enabled")) true) }}
+{{- if and (eq (default false (index $redisHA "enabled")) true) (eq (default true (index $haproxy "enabled")) true) (eq (default false (index $haproxyTls "enabled")) true) }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/helm/chart/values-local.yaml
+++ b/helm/chart/values-local.yaml
@@ -16,18 +16,6 @@ statuslist:
           done
           echo "Postgres is up."
 
-    - name: wait-for-redis
-      image: busybox
-      command:
-        - "sh"
-        - "-c"
-        - |
-          echo "Waiting for Redis HAProxy..."
-          until nc -z {{ .Release.Name }}-redis-ha-haproxy.{{ .Release.Namespace }}.svc.cluster.local 6379; do
-            echo "Redis (haproxy) not ready. Retrying in 2s...";
-            sleep 2;
-          done
-          echo "Redis (haproxy) is up."
   image:
     pullPolicy: IfNotPresent
   service:

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -17,25 +17,6 @@ statuslist:
           done
           echo "Postgres is up."
 
-    - name: wait-for-redis
-      image: busybox:1.37
-      command:
-        - "sh"
-        - "-c"
-        - |
-          {{- if and (index .Values "redis-ha" "haproxy" "tls" "enabled") (index .Values "redis-ha" "externalDnsHostname") }}
-          echo "Waiting for Redis vanity DNS to resolve..."
-          until nslookup {{ index .Values "redis-ha" "externalDnsHostname" }} >/dev/null 2>&1; do
-            echo "{{ index .Values "redis-ha" "externalDnsHostname" }} not resolvable yet. Retrying in 2s...";
-            sleep 2;
-          done
-          echo "Vanity DNS resolved. Waiting for HAProxy (TLS) at 6379..."
-          {{- end }}
-          until nc -z {{ .Release.Name }}-redis-ha-haproxy.{{ .Release.Namespace }}.svc.cluster.local 6379; do
-            echo "Redis (haproxy) not ready. Retrying in 2s...";
-            sleep 2;
-          done
-          echo "Redis (haproxy) is up."
   replicaCount: 1
   image:
     repository: ghcr.io/adorsys/status-list-server
@@ -81,7 +62,6 @@ statuslist:
     # APP_SERVER__CERT__DNS__ACMEDNS__ACCOUNTS JSON, which holds every account password)
     # must come from a secret (see externalSecret below), not from plain env values.
     APP_SERVER__CERT__DNS__PROVIDER: "route53"
-    APP_REDIS__REQUIRE_CLIENT_AUTH: "false"
     APP_AWS__SECRETS_CACHE_TTL: "300"
     APP_AWS__S3_BUCKET: "status-list-adorsys"
     APP_AWS__S3_KEY_PREFIX: ""
@@ -122,7 +102,8 @@ statuslist:
     # When ingress is empty [], ANY source can reach the service port (port-only restriction).
     # Add podSelector/namespaceSelector/ipBlock entries to restrict sources.
     ingress: []
-    # Restrict egress for internal ports (5432, 6379, 6380) to specific destinations.
+    # Restrict egress for internal ports to specific destinations.
+    # PostgreSQL (5432) is always included; Redis ports (6379, 6380) are included only when redis-ha.enabled=true.
     # External ports (443, 53) are always allowed without destination restriction.
     egressInternal: []
   resources:
@@ -186,7 +167,7 @@ secretStore:
     region: eu-central-1
 
 redis-ha:
-  enabled: true
+  enabled: false
   externalDnsHostname: redis.eudi-adorsys.com
   resources:
     requests:
@@ -242,9 +223,6 @@ redis-ha:
         service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
         external-dns.alpha.kubernetes.io/hostname: redis.eudi-adorsys.com
         external-dns.alpha.kubernetes.io/delete: "true"
-
-redis:
-  enabled: true
 
 otelCollector:
   enabled: true

--- a/src/config.rs
+++ b/src/config.rs
@@ -546,6 +546,8 @@ impl DnsConfig {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct RedisConfig {
+    /// Redis connection URI. Leave empty to disable the optional Redis-backed
+    /// certificate-material cache, even when the `redis` feature is compiled.
     pub uri: SecretString,
     pub require_client_auth: bool,
     /// Cache TTL for Redis TLS certificates in seconds.
@@ -785,7 +787,7 @@ fn base_builder() -> Result<ConfigBuilder<DefaultState>, ConfigError> {
         .set_default("database.pool.connect_timeout_secs", 10u64)?
         .set_default("database.pool.idle_timeout_secs", 600u64)?
         .set_default("database.pool.max_lifetime_secs", 1800u64)?
-        .set_default("redis.uri", "redis://localhost:6379")?
+        .set_default("redis.uri", "")?
         .set_default("redis.require_client_auth", false)?
         .set_default("redis.cert_cache_ttl", 3600)?
         .set_default("aws.secrets_cache_ttl", 300)?
@@ -862,7 +864,7 @@ mod tests {
 
         assert_eq!(config.database.url.expose_secret(), expected_db_url);
         assert_eq!(config.database.backend, expected_db_backend);
-        assert_eq!(config.redis.uri.expose_secret(), "redis://localhost:6379");
+        assert_eq!(config.redis.uri.expose_secret(), "");
         assert!(!config.redis.require_client_auth);
         assert_eq!(config.server.cert.email, "admin@example.com");
         assert_eq!(

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -216,10 +216,17 @@ async fn build_state_impl(config: &AppConfig) -> EyeResult<BuildStateResult> {
 
                     #[cfg(feature = "redis")]
                     let cache_opt = if !config.redis.uri.expose_secret().is_empty() {
-                        if let Ok(redis_conn) = config.redis.start(None, None, None).await {
-                            Some(Redis::new(redis_conn).with_ttl(config.redis.cert_cache_ttl))
-                        } else {
-                            None
+                        match config.redis.start(None, None, None).await {
+                            Ok(redis_conn) => {
+                                Some(Redis::new(redis_conn).with_ttl(config.redis.cert_cache_ttl))
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    "Redis connection failed ({}); certificate cache disabled, falling back to direct S3",
+                                    e
+                                );
+                                None
+                            }
                         }
                     } else {
                         None


### PR DESCRIPTION
## Summary

- Make Redis explicitly optional across runtime defaults, Docker, Helm, and docs.
- Keep Redis as an opt-in distributed certificate-material cache for AWS/S3 + ACME multi-replica deployments.
- Update Helm so `redis-ha.enabled=false` renders a clean no-Redis deployment path with no Redis env vars, secret keys, init containers, cert-sync resources, or network-policy ports.

## Changes

- Changed default `redis.uri` to empty so Redis is disabled unless `APP_REDIS__URI` is set.
- Removed Redis from default Docker build/Compose feature set and put the Compose Redis service behind the `redis` profile.
- Added `condition: redis-ha.enabled` to the Helm Redis HA dependency and defaulted `redis-ha.enabled` to `false`.
- Guarded Helm Redis app env vars, ExternalSecret `redis-password`, Redis network-policy ports, and Redis TLS cert-sync resources behind Redis HA enablement.
- Updated README, Helm docs, local deployment docs, database backend docs, and Redis TLS docs to explain Redis’ role and tradeoffs.

## Verification

- `cargo check --no-default-features --features memory`
- `cargo check --workspace --all-targets --features memory,acme`
- `cargo check --workspace --all-targets --features memory,aws,acme,redis`
- `cargo test --no-default-features --features memory config::tests::test_default_config`
- `helm template statuslist ./helm/chart --namespace statuslist`
- `helm template statuslist ./helm/chart --namespace statuslist --set redis-ha.enabled=true`