### PR TITLE
Implement SQL-backed certificate storage for certificate management

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,13 @@ The Status List Server is provisioned with a cryptographic certificate that is e
 - Filesystem store inputs may be PEM text or raw DER. Storage-backed store inputs may be PEM text or base64/base64url-encoded DER. Private keys must be PKCS#8 in PEM or DER form.
 - The renewal cron schedule is configured with `server.cert.renewal_cron_schedule`. For store provisioning, each scheduled run reloads the configured source and refreshes persisted material only when it changed.
 
+**Certificate Storage Backends:**
+
+- `server.cert.store.certificate_storage` selects where managed certificate chain data is stored. Supported values are `memory`, `sql`, and, with the `aws` feature, `aws_s3`.
+- `server.cert.store.secrets_storage` selects where signing keys and ACME account material are stored. Supported values are `memory`, `sql`, and, with the `aws` feature, `aws_secrets_manager`.
+- Set either or both values to `sql` to use the configured SeaORM database (`postgres`, `mysql`, or `sqlite`) through the `certificate_storage` table. This is a portable fallback for small deployments, local environments, and installations that cannot operate separate object-storage or secrets-manager services.
+- Prefer a dedicated secrets manager such as AWS Secrets Manager for production signing keys when you need secret-specific access controls, rotation workflows, audit logs, envelope encryption, or separation from the application database backup/restore path. SQL-backed secret storage inherits the security posture of the database, so restrict database access and protect backups accordingly.
+
 **Certificate Manager Builder Defaults:**
 
 - `CertManager::builder()` defaults to ACME provisioning.

--- a/docs/database-backends.md
+++ b/docs/database-backends.md
@@ -29,6 +29,26 @@ Best for local development, fast unit and integration tests, and simple single-n
 
 SQLite is not a distributed database, so it is not a good match for horizontally scaled production storage. For in-memory tests, use a shared-cache URI such as `sqlite::memory:?cache=shared` and a single-connection pool.
 
+## SQL-Backed Certificate Storage
+
+When the `acme` feature is enabled together with one of the SeaORM database
+features, certificate-manager storage can use the application database:
+
+```sh
+APP_SERVER__CERT__STORE__CERTIFICATE_STORAGE=sql
+APP_SERVER__CERT__STORE__SECRETS_STORAGE=sql
+```
+
+This creates and uses the `certificate_storage` table for certificate chains,
+ACME account state and signing keys. It is useful for small installations,
+development, and provider-neutral deployments that do not have object storage or
+a dedicated secrets manager available.
+
+For production signing keys, prefer a dedicated secrets manager when you need
+secret-specific IAM, audit logging, rotation, envelope encryption, or blast
+radius separation from database users and backups. If SQL storage is used for
+secrets, protect database credentials and backups as secret material.
+
 ## Compose Profiles
 
 `docker compose up` starts PostgreSQL by default and builds the container with `postgres,redis,aws,acme` features enabled. To run the MySQL service instead:

--- a/src/config.rs
+++ b/src/config.rs
@@ -203,6 +203,10 @@ pub struct CertConfig {
 pub struct CertStoreConfig {
     pub source: String,
     #[serde(default)]
+    pub certificate_storage: Option<String>,
+    #[serde(default)]
+    pub secrets_storage: Option<String>,
+    #[serde(default)]
     pub certificate_path: Option<String>,
     #[serde(default)]
     pub signing_key_path: Option<String>,
@@ -805,6 +809,11 @@ fn base_builder() -> Result<ConfigBuilder<DefaultState>, ConfigError> {
         .set_default("server.cert.chain_cache_ttl", default_chain_cache_ttl)?
         .set_default("server.cert.renewal_cron_schedule", "0 0 0 * * *")?
         .set_default("server.cert.store.source", "filesystem")?
+        .set_default(
+            "server.cert.store.certificate_storage",
+            Option::<String>::None,
+        )?
+        .set_default("server.cert.store.secrets_storage", Option::<String>::None)?
         .set_default("server.cert.store.certificate_path", default_cert_path)?
         .set_default("server.cert.store.signing_key_path", default_key_path)?
         .set_default("server.cert.store.certificate_key", Option::<String>::None)?
@@ -1393,6 +1402,8 @@ mod tests {
             ("status_list.token_ttl_secs", "600"),
             ("server.cert.renewal_cron_schedule", "0 0 12 * * *"),
             ("server.cert.dns_challenge_server_url", "http://pebble:8055"),
+            ("server.cert.store.certificate_storage", "sql"),
+            ("server.cert.store.secrets_storage", "sql"),
             ("server.cert.store.certificate_path", "/certs/tls.crt"),
             ("server.cert.store.signing_key_path", "/certs/tls.key"),
         ])
@@ -1415,6 +1426,14 @@ mod tests {
         assert_eq!(
             config.server.cert.store.signing_key_path.as_deref(),
             Some("/certs/tls.key")
+        );
+        assert_eq!(
+            config.server.cert.store.certificate_storage.as_deref(),
+            Some("sql")
+        );
+        assert_eq!(
+            config.server.cert.store.secrets_storage.as_deref(),
+            Some("sql")
         );
     }
 

--- a/src/outbound/sql/README.md
+++ b/src/outbound/sql/README.md
@@ -68,7 +68,7 @@ secrets storage is selected.
 | Column        | Type   | Null | Key | Description                                      |
 | ------------- | ------ | ---- | --- | ------------------------------------------------ |
 | `storage_key` | TEXT   | NO   | PK  | Storage key used by the certificate manager      |
-| `value`       | TEXT   | NO   |     | Opaque stored value; may contain secret material  |
+| `value`       | TEXT   | NO   |     | Opaque stored value; may contain secret material |
 | `metadata`    | JSON   | YES  |     | Optional provider metadata for future extensions |
 | `created_at`  | BIGINT | NO   |     | UNIX timestamp when the row was created          |
 | `updated_at`  | BIGINT | NO   |     | UNIX timestamp when the row was last updated     |

--- a/src/outbound/sql/README.md
+++ b/src/outbound/sql/README.md
@@ -60,6 +60,25 @@ Stores historical status list snapshots for time-travel queries.
 | ----------------------------------- | ---------------------------------- |
 | `idx_status_list_history_list_time` | `list_id, valid_from, valid_until` |
 
+### `certificate_storage`
+
+Stores certificate-manager key/value material when SQL-backed certificate or
+secrets storage is selected.
+
+| Column        | Type   | Null | Key | Description                                      |
+| ------------- | ------ | ---- | --- | ------------------------------------------------ |
+| `storage_key` | TEXT   | NO   | PK  | Storage key used by the certificate manager      |
+| `value`       | TEXT   | NO   |     | Opaque stored value; may contain secret material  |
+| `metadata`    | JSON   | YES  |     | Optional provider metadata for future extensions |
+| `created_at`  | BIGINT | NO   |     | UNIX timestamp when the row was created          |
+| `updated_at`  | BIGINT | NO   |     | UNIX timestamp when the row was last updated     |
+
+The `value` column can hold signing keys and ACME account material. Do not log
+it, expose it in diagnostics, or grant read access to this table more broadly
+than you would grant access to signing keys. Use this backend when a portable
+single-database deployment is more important than secret-manager features. Use a
+dedicated secrets manager for stronger key isolation, rotation and audit needs.
+
 ## Entity Relationship Diagram
 
 ```mermaid
@@ -82,6 +101,13 @@ erDiagram
         BIGINT valid_from "Start timestamp"
         BIGINT valid_until "End timestamp"
         BIGINT created_at "Creation timestamp"
+    }
+    certificate_storage {
+        TEXT storage_key PK "Storage key"
+        TEXT value "Opaque certificate or secret value"
+        JSON metadata "Optional metadata"
+        BIGINT created_at "Creation timestamp"
+        BIGINT updated_at "Last update timestamp"
     }
     credentials ||--|{ status_lists : "issuer (ON DELETE CASCADE, ON UPDATE CASCADE)"
     status_lists ||--|{ status_list_history : "list_id (ON DELETE CASCADE)"

--- a/src/outbound/sql/cert_storage.rs
+++ b/src/outbound/sql/cert_storage.rs
@@ -1,0 +1,225 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use sea_orm::{ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, Set};
+
+use crate::cert_manager::storage::{Storage, StorageError};
+
+use super::models::certificate_storage;
+
+/// SeaORM-backed certificate-manager storage.
+///
+/// This adapter stores opaque string values in the application database. It is
+/// suitable for certificate chains, ACME account state and signing keys when a
+/// separate object store or secrets manager is unavailable. It deliberately
+/// avoids logging stored values.
+#[derive(Clone)]
+pub struct SqlCertificateStorage {
+    db: Arc<DatabaseConnection>,
+}
+
+impl SqlCertificateStorage {
+    pub fn new(db: Arc<DatabaseConnection>) -> Self {
+        Self { db }
+    }
+}
+
+#[async_trait]
+impl Storage for SqlCertificateStorage {
+    #[tracing::instrument(skip(self, value), fields(db.system = "sea-orm"))]
+    async fn store(&self, key: &str, value: &str) -> Result<(), StorageError> {
+        let now = time::OffsetDateTime::now_utc().unix_timestamp();
+        let active = certificate_storage::ActiveModel {
+            key: Set(key.to_string()),
+            value: Set(value.to_string()),
+            metadata: Set(None),
+            created_at: Set(now),
+            updated_at: Set(now),
+        };
+
+        certificate_storage::Entity::insert(active)
+            .on_conflict(
+                sea_orm::sea_query::OnConflict::column(certificate_storage::Column::Key)
+                    .update_columns([
+                        certificate_storage::Column::Value,
+                        certificate_storage::Column::UpdatedAt,
+                    ])
+                    .to_owned(),
+            )
+            .exec_without_returning(&*self.db)
+            .await
+            .map_err(|e| StorageError::Sql(e.to_string()))?;
+        Ok(())
+    }
+
+    #[tracing::instrument(skip(self), fields(db.system = "sea-orm"))]
+    async fn load(&self, key: &str) -> Result<Option<String>, StorageError> {
+        certificate_storage::Entity::find_by_id(key)
+            .one(&*self.db)
+            .await
+            .map(|row| row.map(|row| row.value))
+            .map_err(|e| StorageError::Sql(e.to_string()))
+    }
+
+    #[tracing::instrument(skip(self, value), fields(db.system = "sea-orm"))]
+    async fn update(&self, key: &str, value: &str) -> Result<(), StorageError> {
+        let now = time::OffsetDateTime::now_utc().unix_timestamp();
+        let existing = certificate_storage::Entity::find_by_id(key)
+            .one(&*self.db)
+            .await
+            .map_err(|e| StorageError::Sql(e.to_string()))?;
+
+        if let Some(existing) = existing {
+            let mut active: certificate_storage::ActiveModel = existing.into();
+            active.value = Set(value.to_string());
+            active.updated_at = Set(now);
+            active
+                .update(&*self.db)
+                .await
+                .map_err(|e| StorageError::Sql(e.to_string()))?;
+        } else {
+            self.store(key, value).await?;
+        }
+        Ok(())
+    }
+
+    #[tracing::instrument(skip(self), fields(db.system = "sea-orm"))]
+    async fn delete(&self, key: &str) -> Result<(), StorageError> {
+        certificate_storage::Entity::delete_many()
+            .filter(certificate_storage::Column::Key.eq(key))
+            .exec(&*self.db)
+            .await
+            .map_err(|e| StorageError::Sql(e.to_string()))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(any(feature = "sqlite", feature = "mysql", feature = "postgres-tests"))]
+    use super::*;
+    #[cfg(any(feature = "sqlite", feature = "mysql", feature = "postgres-tests"))]
+    use sea_orm::{ConnectionTrait, FromQueryResult, Statement};
+    #[cfg(feature = "sqlite")]
+    use sea_orm_migration::MigratorTrait;
+
+    #[cfg(feature = "mysql")]
+    use crate::outbound::sql::test_containers::mysql_helpers;
+    #[cfg(feature = "postgres-tests")]
+    use crate::outbound::sql::test_containers::postgres_helpers;
+
+    #[cfg(feature = "sqlite")]
+    async fn sqlite_connection() -> Arc<DatabaseConnection> {
+        let mut opt = sea_orm::ConnectOptions::new("sqlite::memory:");
+        opt.max_connections(1);
+        opt.map_sqlx_sqlite_opts(|o| o.foreign_keys(true));
+        let db = sea_orm::Database::connect(opt)
+            .await
+            .expect("Failed to connect to SQLite");
+        crate::outbound::sql::Migrator::up(&db, None)
+            .await
+            .expect("Failed to run migrations on SQLite");
+        Arc::new(db)
+    }
+
+    #[cfg(any(feature = "sqlite", feature = "mysql", feature = "postgres-tests"))]
+    async fn assert_storage_contract(db: Arc<DatabaseConnection>) {
+        let storage = SqlCertificateStorage::new(db.clone());
+
+        assert_eq!(storage.load("missing").await.unwrap(), None);
+
+        storage.store("signing-key", "first-secret").await.unwrap();
+        assert_eq!(
+            storage.load("signing-key").await.unwrap().as_deref(),
+            Some("first-secret")
+        );
+
+        storage.store("signing-key", "second-secret").await.unwrap();
+        assert_eq!(
+            storage.load("signing-key").await.unwrap().as_deref(),
+            Some("second-secret")
+        );
+
+        storage.update("signing-key", "third-secret").await.unwrap();
+        assert_eq!(
+            storage.load("signing-key").await.unwrap().as_deref(),
+            Some("third-secret")
+        );
+
+        storage.update("new-key", "new-secret").await.unwrap();
+        assert_eq!(
+            storage.load("new-key").await.unwrap().as_deref(),
+            Some("new-secret")
+        );
+
+        storage.delete("signing-key").await.unwrap();
+        storage.delete("signing-key").await.unwrap();
+        assert_eq!(storage.load("signing-key").await.unwrap(), None);
+    }
+
+    #[cfg(any(feature = "sqlite", feature = "mysql", feature = "postgres-tests"))]
+    #[derive(Debug, FromQueryResult)]
+    struct StoredRow {
+        storage_key: String,
+        value: String,
+        metadata: Option<serde_json::Value>,
+        created_at: i64,
+        updated_at: i64,
+    }
+
+    #[cfg(any(feature = "sqlite", feature = "mysql", feature = "postgres-tests"))]
+    async fn assert_schema_shape(db: Arc<DatabaseConnection>) {
+        let backend = db.get_database_backend();
+        let sql = match backend {
+            sea_orm::DatabaseBackend::Postgres => {
+                "SELECT storage_key, value, metadata, created_at, updated_at \
+                 FROM certificate_storage WHERE storage_key = $1"
+            }
+            _ => {
+                "SELECT storage_key, value, metadata, created_at, updated_at \
+                 FROM certificate_storage WHERE storage_key = ?"
+            }
+        };
+        let row = StoredRow::find_by_statement(Statement::from_sql_and_values(
+            backend,
+            sql,
+            vec!["new-key".into()],
+        ))
+        .one(db.as_ref())
+        .await
+        .expect("schema query failed")
+        .expect("stored row should exist");
+
+        assert_eq!(row.storage_key, "new-key");
+        assert_eq!(row.value, "new-secret");
+        assert!(row.metadata.is_none());
+        assert!(row.created_at > 0);
+        assert!(row.updated_at >= row.created_at);
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn test_sqlite_certificate_storage_contract() {
+        let db = sqlite_connection().await;
+        assert_storage_contract(db.clone()).await;
+        assert_schema_shape(db).await;
+    }
+
+    #[cfg(feature = "mysql")]
+    #[tokio::test]
+    async fn test_mysql_certificate_storage_contract() {
+        let test_db = mysql_helpers::MysqlTestDb::start().await;
+        let db = test_db.connection().await;
+        assert_storage_contract(db.clone()).await;
+        assert_schema_shape(db).await;
+    }
+
+    #[cfg(feature = "postgres-tests")]
+    #[tokio::test]
+    async fn test_postgres_certificate_storage_contract() {
+        let test_db = postgres_helpers::postgres_connection().await;
+        let db = test_db.db;
+        assert_storage_contract(db.clone()).await;
+        assert_schema_shape(db).await;
+    }
+}

--- a/src/outbound/sql/migrations.rs
+++ b/src/outbound/sql/migrations.rs
@@ -13,6 +13,7 @@ impl MigratorTrait for Migrator {
             Box::new(add_updated_at::Migration),
             Box::new(status_list_history::Migration),
             Box::new(status_list_history_exp_index::Migration),
+            Box::new(certificate_storage::Migration),
         ]
     }
 }
@@ -29,7 +30,12 @@ fn pin_innodb_on_mysql(manager: &SchemaManager<'_>, stmt: &mut TableCreateStatem
 
 /// Tables that must use InnoDB for transactional guarantees and foreign key enforcement.
 /// Extend this list if new transactional tables are added.
-const INNODB_REQUIRED_TABLES: &[&str] = &["credentials", "status_lists", "status_list_history"];
+const INNODB_REQUIRED_TABLES: &[&str] = &[
+    "credentials",
+    "status_lists",
+    "status_list_history",
+    "certificate_storage",
+];
 
 /// Queries `information_schema.TABLES` after migrations and refuses to boot if
 /// any of the critical tables (`credentials`, `status_lists`, `status_list_history`) are not
@@ -523,6 +529,73 @@ pub(crate) mod status_list_history_exp_index {
         Exp,
     }
 }
+
+/// Generic key/value table for certificate-manager storage.
+pub(crate) mod certificate_storage {
+    use super::*;
+
+    pub(crate) struct Migration;
+
+    impl MigrationName for Migration {
+        fn name(&self) -> &str {
+            "m20260805_000001_certificate_storage"
+        }
+    }
+
+    #[async_trait::async_trait]
+    #[allow(elided_lifetimes_in_paths)]
+    impl MigrationTrait for Migration {
+        async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+            let mut storage = Table::create();
+            storage
+                .table(CertificateStorage::Table)
+                .if_not_exists()
+                .col(
+                    ColumnDef::new(CertificateStorage::StorageKey)
+                        .string()
+                        .not_null()
+                        .primary_key(),
+                )
+                .col(ColumnDef::new(CertificateStorage::Value).text().not_null())
+                .col(ColumnDef::new(CertificateStorage::Metadata).json().null())
+                .col(
+                    ColumnDef::new(CertificateStorage::CreatedAt)
+                        .big_integer()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(CertificateStorage::UpdatedAt)
+                        .big_integer()
+                        .not_null(),
+                );
+            pin_innodb_on_mysql(manager, &mut storage);
+            manager.create_table(storage).await
+        }
+
+        #[allow(elided_lifetimes_in_paths)]
+        async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+            manager
+                .drop_table(
+                    Table::drop()
+                        .if_exists()
+                        .table(CertificateStorage::Table)
+                        .to_owned(),
+                )
+                .await
+        }
+    }
+
+    #[derive(Iden)]
+    enum CertificateStorage {
+        Table,
+        StorageKey,
+        Value,
+        Metadata,
+        CreatedAt,
+        UpdatedAt,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/outbound/sql/mod.rs
+++ b/src/outbound/sql/mod.rs
@@ -1,5 +1,6 @@
 //! Relational database outbound adapters implementing domain ports via SeaORM.
 
+mod cert_storage;
 mod error;
 mod migrations;
 mod models;
@@ -9,6 +10,7 @@ mod store;
 #[cfg(test)]
 pub(crate) mod test_containers;
 
+pub use cert_storage::SqlCertificateStorage;
 pub use error::RepositoryError;
 pub use migrations::Migrator;
 pub(crate) use migrations::verify_innodb_engines;

--- a/src/outbound/sql/models.rs
+++ b/src/outbound/sql/models.rs
@@ -119,6 +119,34 @@ pub(crate) mod status_list_history {
 
 pub(crate) type StatusListHistoryRecord = status_list_history::Model;
 
+// Generic key/value storage for certificate chains, ACME account data and
+// signing material. Callers must not log `value`; the SQL storage adapter keeps
+// tracing fields to key/backend metadata only.
+#[allow(unreachable_pub)]
+pub(crate) mod certificate_storage {
+    use super::*;
+
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Serialize, Deserialize)]
+    #[sea_orm(table_name = "certificate_storage")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false, column_name = "storage_key")]
+        pub key: String,
+        #[sea_orm(column_type = "Text")]
+        pub value: String,
+        #[sea_orm(column_type = "Json", nullable)]
+        pub metadata: Option<serde_json::Value>,
+        /// Unix timestamp (seconds) when the row was first created.
+        pub created_at: i64,
+        /// Unix timestamp (seconds) when the row was last updated.
+        pub updated_at: i64,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 // Persisted JSON shape of a status list column.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, FromJsonQueryResult)]
 pub struct StatusList {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -13,7 +13,7 @@ use color_eyre::eyre::Result as EyeResult;
 #[cfg(feature = "acme")]
 use color_eyre::eyre::eyre;
 #[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
-use sea_orm::ConnectOptions;
+use sea_orm::{ConnectOptions, DatabaseConnection};
 #[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
 use sea_orm_migration::MigratorTrait;
 #[cfg(any(
@@ -67,8 +67,8 @@ use crate::outbound::memory::{MemoryCredentials, MemoryStatusListSnapshotRepo, M
 use crate::outbound::redis::Redis;
 #[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
 use crate::outbound::sql::{
-    Migrator, SeaOrmStore, SqlCredentialRepo, SqlStatusListRepo, SqlStatusListSnapshotRepo,
-    verify_innodb_engines,
+    Migrator, SeaOrmStore, SqlCertificateStorage, SqlCredentialRepo, SqlStatusListRepo,
+    SqlStatusListSnapshotRepo, verify_innodb_engines,
 };
 use crate::server::AppState;
 
@@ -110,6 +110,9 @@ type BuildStateResult = (AppState, Arc<CertManager>);
 type BuildStateResult = (AppState,);
 
 async fn build_state_impl(config: &AppConfig) -> EyeResult<BuildStateResult> {
+    #[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
+    let mut sql_db_for_cert_storage: Option<Arc<DatabaseConnection>> = None;
+
     let (status_list_repo, credential_repo, status_list_snapshot): (
         Arc<dyn StatusListRepo>,
         Arc<dyn CredentialRepo>,
@@ -174,6 +177,7 @@ async fn build_state_impl(config: &AppConfig) -> EyeResult<BuildStateResult> {
             )?;
 
             let db_clone = Arc::new(db);
+            sql_db_for_cert_storage = Some(db_clone.clone());
             (
                 Arc::new(SqlStatusListRepo::new(SeaOrmStore::new(db_clone.clone()))),
                 Arc::new(SqlCredentialRepo::new(SeaOrmStore::new(db_clone.clone()))),
@@ -199,66 +203,13 @@ async fn build_state_impl(config: &AppConfig) -> EyeResult<BuildStateResult> {
         let app_env = std::env::var("APP_ENV").unwrap_or(ENV_DEVELOPMENT.to_string());
         let cert_domains = [config.server.domain.as_str()];
         let (cert_storage, secrets_storage): (Box<dyn Storage>, Box<dyn Storage>) = {
-            #[cfg(feature = "aws")]
+            #[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
             {
-                if config
-                    .server
-                    .cert
-                    .store
-                    .source
-                    .eq_ignore_ascii_case("aws_secrets_manager")
-                    || !config.aws.s3_bucket.is_empty()
-                {
-                    let aws_config = aws_config::defaults(BehaviorVersion::latest())
-                        .region(Region::new(config.aws.region.clone()))
-                        .load()
-                        .await;
-
-                    #[cfg(feature = "redis")]
-                    let cache_opt = if !config.redis.uri.expose_secret().is_empty() {
-                        if let Ok(redis_conn) = config.redis.start(None, None, None).await {
-                            Some(Redis::new(redis_conn).with_ttl(config.redis.cert_cache_ttl))
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
-                    };
-                    #[cfg(not(feature = "redis"))]
-                    let cache_opt = None;
-
-                    let s3 = AwsS3::new(
-                        &aws_config,
-                        &config.aws.s3_bucket,
-                        &config.aws.region,
-                        &config.aws.s3_key_prefix,
-                    );
-                    let cert_st: Box<dyn Storage> = match cache_opt {
-                        Some(c) => Box::new(s3.with_cache(c)),
-                        None => Box::new(s3),
-                    };
-
-                    let secrets_st: Box<dyn Storage> = Box::new(
-                        AwsSecretsManager::new(
-                            &aws_config,
-                            Duration::from_secs(config.aws.secrets_cache_ttl),
-                        )
-                        .await?,
-                    );
-                    (cert_st, secrets_st)
-                } else {
-                    (
-                        Box::new(MemoryStorage::default()),
-                        Box::new(MemoryStorage::default()),
-                    )
-                }
+                build_certificate_storages(config, sql_db_for_cert_storage.clone()).await?
             }
-            #[cfg(not(feature = "aws"))]
+            #[cfg(not(any(feature = "sqlite", feature = "postgres", feature = "mysql")))]
             {
-                (
-                    Box::new(MemoryStorage::default()),
-                    Box::new(MemoryStorage::default()),
-                )
+                build_certificate_storages(config).await?
             }
         };
 
@@ -424,6 +375,283 @@ fn acme_dns_credentials(account: &crate::config::AcmeDnsAccount) -> AcmeDnsCrede
 }
 
 #[cfg(feature = "acme")]
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum CertificateStorageKind {
+    Memory,
+    Sql,
+    AwsS3,
+    AwsSecretsManager,
+}
+
+#[cfg(feature = "acme")]
+fn storage_kind_from_config(
+    explicit: Option<&str>,
+    source: &str,
+    is_secret_storage: bool,
+    aws_defaults_enabled: bool,
+) -> EyeResult<CertificateStorageKind> {
+    let Some(raw) = explicit else {
+        if source.eq_ignore_ascii_case("sql") {
+            return Ok(CertificateStorageKind::Sql);
+        }
+        if aws_defaults_enabled {
+            return Ok(if is_secret_storage {
+                CertificateStorageKind::AwsSecretsManager
+            } else {
+                CertificateStorageKind::AwsS3
+            });
+        }
+        return Ok(CertificateStorageKind::Memory);
+    };
+
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "memory" => Ok(CertificateStorageKind::Memory),
+        "sql" | "database" => Ok(CertificateStorageKind::Sql),
+        "aws_s3" | "s3" | "object_storage" if !is_secret_storage => {
+            Ok(CertificateStorageKind::AwsS3)
+        }
+        "aws_secrets_manager" | "secrets_manager" if is_secret_storage => {
+            Ok(CertificateStorageKind::AwsSecretsManager)
+        }
+        other => {
+            let setting = if is_secret_storage {
+                "server.cert.store.secrets_storage"
+            } else {
+                "server.cert.store.certificate_storage"
+            };
+            Err(eyre!(
+                "unsupported {setting} value '{other}'; expected 'memory', 'sql'{}",
+                if is_secret_storage {
+                    ", or 'aws_secrets_manager'"
+                } else {
+                    ", or 'aws_s3'"
+                }
+            ))
+        }
+    }
+}
+
+#[cfg(all(
+    feature = "acme",
+    any(feature = "sqlite", feature = "postgres", feature = "mysql")
+))]
+async fn build_certificate_storages(
+    config: &AppConfig,
+    sql_db: Option<Arc<DatabaseConnection>>,
+) -> EyeResult<(Box<dyn Storage>, Box<dyn Storage>)> {
+    let source = config.server.cert.store.source.as_str();
+    #[cfg(feature = "aws")]
+    let aws_defaults_enabled =
+        source.eq_ignore_ascii_case("aws_secrets_manager") || !config.aws.s3_bucket.is_empty();
+    #[cfg(not(feature = "aws"))]
+    let aws_defaults_enabled = false;
+
+    let cert_kind = storage_kind_from_config(
+        config.server.cert.store.certificate_storage.as_deref(),
+        source,
+        false,
+        aws_defaults_enabled,
+    )?;
+    let secrets_kind = storage_kind_from_config(
+        config.server.cert.store.secrets_storage.as_deref(),
+        source,
+        true,
+        aws_defaults_enabled,
+    )?;
+
+    if [cert_kind, secrets_kind].contains(&CertificateStorageKind::Sql) && sql_db.is_none() {
+        return Err(eyre!(
+            "SQL certificate storage requires database.backend to be postgres, mysql, or sqlite"
+        ));
+    }
+
+    #[cfg(not(feature = "aws"))]
+    if [cert_kind, secrets_kind].iter().any(|kind| {
+        matches!(
+            kind,
+            CertificateStorageKind::AwsS3 | CertificateStorageKind::AwsSecretsManager
+        )
+    }) {
+        return Err(eyre!(
+            "AWS certificate storage was selected, but the 'aws' feature flag was not compiled in"
+        ));
+    }
+
+    #[cfg(feature = "aws")]
+    let aws_config = if [cert_kind, secrets_kind].iter().any(|kind| {
+        matches!(
+            kind,
+            CertificateStorageKind::AwsS3 | CertificateStorageKind::AwsSecretsManager
+        )
+    }) {
+        Some(
+            aws_config::defaults(BehaviorVersion::latest())
+                .region(Region::new(config.aws.region.clone()))
+                .load()
+                .await,
+        )
+    } else {
+        None
+    };
+
+    let build_sql_storage = || -> Box<dyn Storage> {
+        Box::new(SqlCertificateStorage::new(
+            sql_db
+                .as_ref()
+                .expect("validated SQL certificate storage connection")
+                .clone(),
+        ))
+    };
+
+    let cert_storage: Box<dyn Storage> = match cert_kind {
+        CertificateStorageKind::Memory => Box::new(MemoryStorage::default()),
+        CertificateStorageKind::Sql => build_sql_storage(),
+        CertificateStorageKind::AwsS3 => {
+            #[cfg(feature = "aws")]
+            {
+                let aws_config = aws_config
+                    .as_ref()
+                    .expect("AWS config is loaded for AWS storage");
+                #[cfg(feature = "redis")]
+                let cache_opt = if !config.redis.uri.expose_secret().is_empty() {
+                    if let Ok(redis_conn) = config.redis.start(None, None, None).await {
+                        Some(Redis::new(redis_conn).with_ttl(config.redis.cert_cache_ttl))
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+                #[cfg(not(feature = "redis"))]
+                let cache_opt = None;
+
+                let s3 = AwsS3::new(
+                    aws_config,
+                    &config.aws.s3_bucket,
+                    &config.aws.region,
+                    &config.aws.s3_key_prefix,
+                );
+                match cache_opt {
+                    Some(c) => Box::new(s3.with_cache(c)),
+                    None => Box::new(s3),
+                }
+            }
+            #[cfg(not(feature = "aws"))]
+            unreachable!("AWS storage checked above")
+        }
+        CertificateStorageKind::AwsSecretsManager => {
+            return Err(eyre!(
+                "server.cert.store.certificate_storage cannot use aws_secrets_manager; use aws_s3, sql, or memory"
+            ));
+        }
+    };
+
+    let secrets_storage: Box<dyn Storage> = match secrets_kind {
+        CertificateStorageKind::Memory => Box::new(MemoryStorage::default()),
+        CertificateStorageKind::Sql => build_sql_storage(),
+        CertificateStorageKind::AwsSecretsManager => {
+            #[cfg(feature = "aws")]
+            {
+                let aws_config = aws_config
+                    .as_ref()
+                    .expect("AWS config is loaded for AWS storage");
+                Box::new(
+                    AwsSecretsManager::new(
+                        aws_config,
+                        Duration::from_secs(config.aws.secrets_cache_ttl),
+                    )
+                    .await?,
+                )
+            }
+            #[cfg(not(feature = "aws"))]
+            unreachable!("AWS storage checked above")
+        }
+        CertificateStorageKind::AwsS3 => {
+            return Err(eyre!(
+                "server.cert.store.secrets_storage cannot use aws_s3; use aws_secrets_manager, sql, or memory"
+            ));
+        }
+    };
+
+    Ok((cert_storage, secrets_storage))
+}
+
+#[cfg(all(
+    feature = "acme",
+    not(any(feature = "sqlite", feature = "postgres", feature = "mysql"))
+))]
+async fn build_certificate_storages(
+    config: &AppConfig,
+) -> EyeResult<(Box<dyn Storage>, Box<dyn Storage>)> {
+    let source = config.server.cert.store.source.as_str();
+    #[cfg(feature = "aws")]
+    let aws_defaults_enabled =
+        source.eq_ignore_ascii_case("aws_secrets_manager") || !config.aws.s3_bucket.is_empty();
+    #[cfg(not(feature = "aws"))]
+    let aws_defaults_enabled = false;
+
+    let cert_kind = storage_kind_from_config(
+        config.server.cert.store.certificate_storage.as_deref(),
+        source,
+        false,
+        aws_defaults_enabled,
+    )?;
+    let secrets_kind = storage_kind_from_config(
+        config.server.cert.store.secrets_storage.as_deref(),
+        source,
+        true,
+        aws_defaults_enabled,
+    )?;
+
+    if [cert_kind, secrets_kind].contains(&CertificateStorageKind::Sql) {
+        return Err(eyre!(
+            "SQL certificate storage was selected, but no SeaORM database feature was compiled in"
+        ));
+    }
+
+    #[cfg(feature = "aws")]
+    {
+        if [cert_kind, secrets_kind]
+            == [
+                CertificateStorageKind::AwsS3,
+                CertificateStorageKind::AwsSecretsManager,
+            ]
+        {
+            let aws_config = aws_config::defaults(BehaviorVersion::latest())
+                .region(Region::new(config.aws.region.clone()))
+                .load()
+                .await;
+            let cert_storage: Box<dyn Storage> = Box::new(AwsS3::new(
+                &aws_config,
+                &config.aws.s3_bucket,
+                &config.aws.region,
+                &config.aws.s3_key_prefix,
+            ));
+            let secrets_storage: Box<dyn Storage> = Box::new(
+                AwsSecretsManager::new(
+                    &aws_config,
+                    Duration::from_secs(config.aws.secrets_cache_ttl),
+                )
+                .await?,
+            );
+            return Ok((cert_storage, secrets_storage));
+        }
+    }
+
+    if cert_kind == CertificateStorageKind::Memory && secrets_kind == CertificateStorageKind::Memory
+    {
+        Ok((
+            Box::new(MemoryStorage::default()),
+            Box::new(MemoryStorage::default()),
+        ))
+    } else {
+        Err(eyre!(
+            "the selected certificate storage combination requires the matching database or aws feature flag"
+        ))
+    }
+}
+
+#[cfg(feature = "acme")]
 fn store_certificate_strategy(config: &AppConfig) -> EyeResult<Option<StoreProvisioningStrategy>> {
     let cert_config = &config.server.cert;
     if cert_config
@@ -468,6 +696,30 @@ fn store_certificate_strategy(config: &AppConfig) -> EyeResult<Option<StoreProvi
                 signing_key_path,
             )))
         }
+        source if source.eq_ignore_ascii_case("storage") || source.eq_ignore_ascii_case("sql") => {
+            let certificate_key = cert_config
+                .store
+                .certificate_key
+                .as_deref()
+                .ok_or_else(|| {
+                    eyre!(
+                        "server.cert.store.certificate_key is required for storage-backed store provisioning"
+                    )
+                })?;
+            let signing_key_key = cert_config
+                .store
+                .signing_key_key
+                .as_deref()
+                .ok_or_else(|| {
+                    eyre!(
+                        "server.cert.store.signing_key_key is required for storage-backed store provisioning"
+                    )
+                })?;
+            Ok(Some(StoreProvisioningStrategy::storage(
+                certificate_key,
+                signing_key_key,
+            )))
+        }
         source if source.eq_ignore_ascii_case("aws_secrets_manager") => {
             let certificate_key = cert_config
                 .store
@@ -493,7 +745,7 @@ fn store_certificate_strategy(config: &AppConfig) -> EyeResult<Option<StoreProvi
             )))
         }
         unsupported => Err(eyre!(
-            "unsupported certificate store source '{unsupported}'; expected 'filesystem' or 'aws_secrets_manager'"
+            "unsupported certificate store source '{unsupported}'; expected 'filesystem', 'storage', 'sql', or 'aws_secrets_manager'"
         )),
     }
 }

--- a/src/utils/cert_manager/storage.rs
+++ b/src/utils/cert_manager/storage.rs
@@ -18,6 +18,9 @@ pub enum StorageError {
 
     #[error("Bucket {0} is unavailable")]
     BucketUnavailable(String),
+
+    #[error("SQL storage error: {0}")]
+    Sql(String),
 }
 
 /// Abstract interface for storage backends used by the certificate manager.


### PR DESCRIPTION
Implemented the SQL-backed certificate-manager storage fallback.

What changed:
- Added `SqlCertificateStorage` implementing the `Storage` trait with SeaORM in [cert_storage.rs](/home/boris/adorsys-gis/status-list-server/src/outbound/sql/cert_storage.rs:10).
- Added `certificate_storage` schema/model/migration with `storage_key`, `value`, `metadata`, `created_at`, `updated_at` in [migrations.rs](/home/boris/adorsys-gis/status-list-server/src/outbound/sql/migrations.rs:533) and [models.rs](/home/boris/adorsys-gis/status-list-server/src/outbound/sql/models.rs:119).
- Wired startup selection for certificate and secrets storage via:
  - `server.cert.store.certificate_storage = "sql"`
  - `server.cert.store.secrets_storage = "sql"`
- Preserved redaction posture by skipping stored values in tracing spans.
- Fixed `store.source = "storage"` so it actually uses the configured certificate/secrets storage split.
- Documented SQL storage tradeoffs in [README.md](/home/boris/adorsys-gis/status-list-server/README.md:201), [database-backends.md](/home/boris/adorsys-gis/status-list-server/docs/database-backends.md:32), and [src/outbound/sql/README.md](/home/boris/adorsys-gis/status-list-server/src/outbound/sql/README.md:63).

Verification:
- `cargo test --features sqlite,acme outbound::sql::cert_storage::tests::test_sqlite_certificate_storage_contract` passed.
- `cargo check --workspace --all-targets --features postgres,acme` passed.
- `cargo check --workspace --all-targets --features mysql,acme` passed.
- `cargo check --workspace --all-targets --all-features` passed.
- `cargo test --workspace --all-targets --features sqlite,acme` passed when rerun outside the sandbox: `246 passed`.
- `cargo nextest ...` could not be run because `cargo-nextest` is not installed in this environment.