### PR TITLE
338 compact config tests in srcconfigrs

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -836,11 +836,27 @@ mod tests {
     use secrecy::ExposeSecret;
 
     #[test]
-    fn test_default_config() {
-        let config = Config::load_from_overrides(&[]).expect("Failed to load config");
+    fn test_config_loading() {
+        // 1. Default configuration loading & helper methods
+        let config = Config::load_from_overrides(&[]).expect("Failed to load default config");
 
         assert_eq!(config.server.host, "localhost");
         assert_eq!(config.server.port, 8000);
+        assert_eq!(config.server.cert.email, "admin@example.com");
+        assert_eq!(
+            config.server.cert.acme_directory_url,
+            "https://acme-v02.api.letsencrypt.org/directory"
+        );
+        assert_eq!(config.aws.region, "us-east-1");
+        assert_eq!(config.aws.s3_bucket, "status-list-adorsys");
+        assert_eq!(config.aws.s3_key_prefix, "");
+        assert_eq!(config.status_list.token_exp_secs, 900);
+        assert_eq!(config.status_list.token_ttl_secs, 300);
+        assert_eq!(config.server.cert.renewal_cron_schedule, "0 0 0 * * *");
+        assert_eq!(config.server.cert.dns_challenge_server_url, None);
+        assert_eq!(config.server.aggregation_uri, None);
+
+        // Feature-gated default database expectations
         #[cfg(feature = "postgres")]
         let (expected_db_url, expected_db_backend) = (
             "postgres://postgres:postgres@localhost:5432/status-list",
@@ -864,18 +880,7 @@ mod tests {
         assert_eq!(config.database.backend, expected_db_backend);
         assert_eq!(config.redis.uri.expose_secret(), "redis://localhost:6379");
         assert!(!config.redis.require_client_auth);
-        assert_eq!(config.server.cert.email, "admin@example.com");
-        assert_eq!(
-            config.server.cert.acme_directory_url,
-            "https://acme-v02.api.letsencrypt.org/directory"
-        );
-        assert_eq!(config.aws.region, "us-east-1");
-        assert_eq!(config.aws.s3_bucket, "status-list-adorsys");
-        assert_eq!(config.aws.s3_key_prefix, "");
-        assert_eq!(config.status_list.token_exp_secs, 900);
-        assert_eq!(config.status_list.token_ttl_secs, 300);
-        assert_eq!(config.server.cert.renewal_cron_schedule, "0 0 0 * * *");
-        assert_eq!(config.server.cert.dns_challenge_server_url, None);
+
         #[cfg(feature = "acme")]
         let (expected_strategy, expected_cert_path, expected_key_path) =
             ("acme", Option::<String>::None, Option::<String>::None);
@@ -889,7 +894,7 @@ mod tests {
             expected_cert_path
         );
         assert_eq!(config.server.cert.store.signing_key_path, expected_key_path);
-        assert_eq!(config.server.aggregation_uri, None);
+
         assert_eq!(config.rate_limit.strict_burst_size, 10);
         assert_eq!(config.rate_limit.strict_period_secs, 60);
         assert_eq!(config.rate_limit.permissive_burst_size, 100);
@@ -898,32 +903,159 @@ mod tests {
         assert_eq!(config.limits.max_status_index, 100_000);
         assert_eq!(config.limits.max_statuses_per_request, 5_000);
         assert_eq!(config.limits.max_serialized_list_size, 1_048_576);
-        assert_eq!(config.server.cert.dns.provider, None);
+
         assert_eq!(config.database.pool.max_connections, 5);
         assert_eq!(config.database.pool.min_connections, 1);
         assert_eq!(config.database.pool.acquire_timeout_secs, 5);
         assert_eq!(config.database.pool.connect_timeout_secs, 10);
         assert_eq!(config.database.pool.idle_timeout_secs, 600);
         assert_eq!(config.database.pool.max_lifetime_secs, 1800);
+
         assert_eq!(
             config.telemetry.environment,
             TelemetryEnvironment::Development
         );
         assert_eq!(config.telemetry.sampler_ratio, 1.0);
-    }
 
-    #[test]
-    fn test_aggregation_uri_env_override() {
-        let config = Config::load_from_overrides(&[(
-            "server.aggregation_uri",
-            "https://example.com/aggregation",
-        )])
-        .expect("Failed to load config");
+        // DatabaseBackend helper unit tests
+        assert_eq!(DatabaseBackend::default(), DatabaseBackend::Memory);
+        assert_eq!(DatabaseBackend::Memory.as_str(), "memory");
+        assert_eq!(DatabaseBackend::Postgres.as_str(), "postgres");
+        assert_eq!(DatabaseBackend::MySql.as_str(), "mysql");
+        assert_eq!(DatabaseBackend::Sqlite.as_str(), "sqlite");
+        assert!(DatabaseBackend::Postgres.validate_url_scheme("postgres://user:pass@host:5432/db"));
+        assert!(DatabaseBackend::Postgres.validate_url_scheme("postgresql://user:pass@host:5432/db"));
+        assert!(DatabaseBackend::MySql.validate_url_scheme("mysql://user:pass@host:3306/db"));
+        assert!(DatabaseBackend::Sqlite.validate_url_scheme("sqlite::memory:"));
+        assert!(!DatabaseBackend::MySql.validate_url_scheme("postgres://user:pass@host:5432/db"));
 
+        // 2. Comprehensive environment variable override testing
+        let overridden = Config::load_from_overrides(&[
+            ("server.host", "0.0.0.0"),
+            ("server.port", "5002"),
+            ("server.aggregation_uri", "https://example.com/aggregation"),
+            (
+                "database.url",
+                "postgres://user:password@localhost:5432/status-list",
+            ),
+            ("redis.uri", "rediss://user:password@localhost:6379/redis"),
+            ("redis.require_client_auth", "true"),
+            ("server.cert.email", "test@gmail.com"),
+            (
+                "server.cert.acme_directory_url",
+                "https://acme-v02.api.letsencrypt.org/directory",
+            ),
+            ("server.cert.organization", "Test Org"),
+            ("server.cert.eku", "1,3,6,1,5,5,7,3,30"),
+            ("server.cert.provisioning_strategy", "store"),
+            ("server.cert.store.certificate_path", "/certs/tls.crt"),
+            ("server.cert.store.signing_key_path", "/certs/tls.key"),
+            ("server.cert.renewal_cron_schedule", "0 0 12 * * *"),
+            ("server.cert.dns_challenge_server_url", "http://pebble:8055"),
+            ("aws.region", "us-west-2"),
+            ("aws.secrets_cache_ttl", "600"),
+            ("aws.s3_bucket", "my-custom-bucket"),
+            ("aws.s3_key_prefix", "status-list/prod"),
+            ("cache.ttl", "600"),
+            ("cache.max_capacity", "2000"),
+            ("status_list.token_exp_secs", "1800"),
+            ("status_list.token_ttl_secs", "600"),
+            ("rate_limit.strict_burst_size", "3"),
+            ("rate_limit.strict_period_secs", "120"),
+            ("rate_limit.permissive_burst_size", "500"),
+            ("rate_limit.permissive_period_secs", "10"),
+            ("limits.max_body_size_bytes", "65536"),
+            ("limits.max_status_index", "4096"),
+            ("limits.max_statuses_per_request", "256"),
+            ("limits.max_serialized_list_size", "32768"),
+            ("APP_DATABASE__POOL__MAX_CONNECTIONS", "20"),
+            ("APP_DATABASE__POOL__MIN_CONNECTIONS", "2"),
+            ("APP_DATABASE__POOL__ACQUIRE_TIMEOUT_SECS", "3"),
+            ("APP_DATABASE__POOL__CONNECT_TIMEOUT_SECS", "15"),
+            ("APP_DATABASE__POOL__IDLE_TIMEOUT_SECS", "300"),
+            ("APP_DATABASE__POOL__MAX_LIFETIME_SECS", "900"),
+        ])
+        .expect("Failed to load config with overrides");
+
+        assert_eq!(overridden.server.host, "0.0.0.0");
+        assert_eq!(overridden.server.port, 5002);
         assert_eq!(
-            config.server.aggregation_uri.as_deref(),
+            overridden.server.aggregation_uri.as_deref(),
             Some("https://example.com/aggregation")
         );
+        assert_eq!(
+            overridden.database.url.expose_secret(),
+            "postgres://user:password@localhost:5432/status-list"
+        );
+        assert_eq!(
+            overridden.redis.uri.expose_secret(),
+            "rediss://user:password@localhost:6379/redis"
+        );
+        assert!(overridden.redis.require_client_auth);
+        assert_eq!(overridden.server.cert.email, "test@gmail.com");
+        assert_eq!(
+            overridden.server.cert.acme_directory_url,
+            "https://acme-v02.api.letsencrypt.org/directory"
+        );
+        assert_eq!(overridden.aws.region, "us-west-2");
+        assert_eq!(overridden.aws.secrets_cache_ttl, 600);
+        assert_eq!(overridden.aws.s3_bucket, "my-custom-bucket");
+        assert_eq!(overridden.aws.s3_key_prefix, "status-list/prod");
+        assert_eq!(overridden.cache.ttl, 600);
+        assert_eq!(overridden.cache.max_capacity, 2000);
+        assert_eq!(overridden.status_list.token_exp_secs, 1800);
+        assert_eq!(overridden.status_list.token_ttl_secs, 600);
+        assert_eq!(overridden.server.cert.renewal_cron_schedule, "0 0 12 * * *");
+        assert_eq!(
+            overridden.server.cert.dns_challenge_server_url.as_deref(),
+            Some("http://pebble:8055")
+        );
+        assert_eq!(overridden.server.cert.provisioning_strategy, "store");
+        assert_eq!(
+            overridden.server.cert.store.certificate_path.as_deref(),
+            Some("/certs/tls.crt")
+        );
+        assert_eq!(
+            overridden.server.cert.store.signing_key_path.as_deref(),
+            Some("/certs/tls.key")
+        );
+        assert_eq!(overridden.rate_limit.strict_burst_size, 3);
+        assert_eq!(overridden.rate_limit.strict_period_secs, 120);
+        assert_eq!(overridden.rate_limit.permissive_burst_size, 500);
+        assert_eq!(overridden.rate_limit.permissive_period_secs, 10);
+        assert_eq!(overridden.limits.max_body_size_bytes, 65_536);
+        assert_eq!(overridden.limits.max_status_index, 4_096);
+        assert_eq!(overridden.limits.max_statuses_per_request, 256);
+        assert_eq!(overridden.limits.max_serialized_list_size, 32_768);
+        assert_eq!(overridden.database.pool.max_connections, 20);
+        assert_eq!(overridden.database.pool.min_connections, 2);
+        assert_eq!(overridden.database.pool.acquire_timeout_secs, 3);
+        assert_eq!(overridden.database.pool.connect_timeout_secs, 15);
+        assert_eq!(overridden.database.pool.idle_timeout_secs, 300);
+        assert_eq!(overridden.database.pool.max_lifetime_secs, 900);
+
+        // 3. Database backend overrides (MySQL & SQLite)
+        let mysql_cfg = Config::load_from_overrides(&[
+            ("database.backend", "mysql"),
+            (
+                "database.url",
+                "mysql://user:password@localhost:3306/status-list",
+            ),
+        ])
+        .expect("Failed to load mysql config");
+        assert_eq!(mysql_cfg.database.backend, DatabaseBackend::MySql);
+        assert_eq!(
+            mysql_cfg.database.url.expose_secret(),
+            "mysql://user:password@localhost:3306/status-list"
+        );
+
+        let sqlite_cfg = Config::load_from_overrides(&[
+            ("database.backend", "sqlite"),
+            ("database.url", "sqlite::memory:"),
+        ])
+        .expect("Failed to load sqlite config");
+        assert_eq!(sqlite_cfg.database.backend, DatabaseBackend::Sqlite);
+        assert_eq!(sqlite_cfg.database.url.expose_secret(), "sqlite::memory:");
     }
 
     #[test]
@@ -1283,241 +1415,7 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_env_config() {
-        let config = Config::load_from_overrides(&[
-            ("server.host", "0.0.0.0"),
-            ("server.port", "5002"),
-            (
-                "database.url",
-                "postgres://user:password@localhost:5432/status-list",
-            ),
-            ("redis.uri", "rediss://user:password@localhost:6379/redis"),
-            ("redis.require_client_auth", "true"),
-            ("server.cert.email", "test@gmail.com"),
-            (
-                "server.cert.acme_directory_url",
-                "https://acme-v02.api.letsencrypt.org/directory",
-            ),
-        ])
-        .expect("Failed to load config");
 
-        assert_eq!(config.server.host, "0.0.0.0");
-        assert_eq!(config.server.port, 5002);
-        assert_eq!(
-            config.database.url.expose_secret(),
-            "postgres://user:password@localhost:5432/status-list"
-        );
-        assert_eq!(
-            config.redis.uri.expose_secret(),
-            "rediss://user:password@localhost:6379/redis"
-        );
-        assert!(config.redis.require_client_auth);
-        assert_eq!(config.server.cert.email, "test@gmail.com");
-        assert_eq!(
-            config.server.cert.acme_directory_url,
-            "https://acme-v02.api.letsencrypt.org/directory"
-        );
-    }
-
-    #[test]
-    fn test_env_config_with_tls() {
-        // Feature-conditional database configuration matching test_default_config pattern
-        #[cfg(feature = "postgres")]
-        let (expected_db_url, expected_db_backend) = (
-            "postgres://postgres:postgres@localhost:5432/status-list",
-            DatabaseBackend::Postgres,
-        );
-        #[cfg(all(not(feature = "postgres"), feature = "sqlite"))]
-        let (expected_db_url, expected_db_backend) = ("sqlite::memory:", DatabaseBackend::Sqlite);
-        #[cfg(all(not(feature = "postgres"), not(feature = "sqlite"), feature = "mysql"))]
-        let (expected_db_url, expected_db_backend) = (
-            "mysql://mysql:mysql@localhost:3306/status-list",
-            DatabaseBackend::MySql,
-        );
-        #[cfg(all(
-            not(feature = "postgres"),
-            not(feature = "sqlite"),
-            not(feature = "mysql")
-        ))]
-        let (expected_db_url, expected_db_backend) = ("memory:", DatabaseBackend::Memory);
-
-        let config = Config::load_from_overrides(&[
-            ("redis.uri", "rediss://user:password@localhost:6379/redis"),
-            ("redis.require_client_auth", "true"),
-            ("server.cert.email", "test@gmail.com"),
-            (
-                "server.cert.acme_directory_url",
-                "https://acme-v02.api.letsencrypt.org/directory",
-            ),
-            ("server.cert.organization", "Test Org"),
-            ("server.cert.eku", "1,3,6,1,5,5,7,3,30"),
-            ("aws.region", "us-west-2"),
-            ("aws.secrets_cache_ttl", "600"),
-            ("aws.s3_bucket", "my-custom-bucket"),
-            ("aws.s3_key_prefix", "status-list/prod"),
-            ("cache.ttl", "600"),
-            ("cache.max_capacity", "2000"),
-        ])
-        .expect("Failed to load config");
-
-        assert_eq!(config.server.host, "localhost");
-        assert_eq!(config.server.port, 8000);
-        assert_eq!(config.database.url.expose_secret(), expected_db_url);
-        assert_eq!(config.database.backend, expected_db_backend);
-        assert_eq!(
-            config.redis.uri.expose_secret(),
-            "rediss://user:password@localhost:6379/redis"
-        );
-        assert!(config.redis.require_client_auth);
-        assert_eq!(config.server.cert.email, "test@gmail.com");
-        assert_eq!(
-            config.server.cert.acme_directory_url,
-            "https://acme-v02.api.letsencrypt.org/directory"
-        );
-        assert_eq!(config.aws.region, "us-west-2");
-        assert_eq!(config.aws.secrets_cache_ttl, 600);
-        assert_eq!(config.aws.s3_bucket, "my-custom-bucket");
-        assert_eq!(config.aws.s3_key_prefix, "status-list/prod");
-        assert_eq!(config.cache.ttl, 600);
-        assert_eq!(config.cache.max_capacity, 2000);
-    }
-
-    #[test]
-    fn test_new_config_fields_env_override() {
-        let config = Config::load_from_overrides(&[
-            ("server.cert.provisioning_strategy", "store"),
-            ("aws.s3_bucket", "my-bucket"),
-            ("aws.s3_key_prefix", "prefix"),
-            ("status_list.token_exp_secs", "1800"),
-            ("status_list.token_ttl_secs", "600"),
-            ("server.cert.renewal_cron_schedule", "0 0 12 * * *"),
-            ("server.cert.dns_challenge_server_url", "http://pebble:8055"),
-            ("server.cert.store.certificate_path", "/certs/tls.crt"),
-            ("server.cert.store.signing_key_path", "/certs/tls.key"),
-        ])
-        .expect("Failed to load config");
-
-        assert_eq!(config.aws.s3_bucket, "my-bucket");
-        assert_eq!(config.aws.s3_key_prefix, "prefix");
-        assert_eq!(config.status_list.token_exp_secs, 1800);
-        assert_eq!(config.status_list.token_ttl_secs, 600);
-        assert_eq!(config.server.cert.renewal_cron_schedule, "0 0 12 * * *");
-        assert_eq!(
-            config.server.cert.dns_challenge_server_url.as_deref(),
-            Some("http://pebble:8055")
-        );
-        assert_eq!(config.server.cert.provisioning_strategy, "store");
-        assert_eq!(
-            config.server.cert.store.certificate_path.as_deref(),
-            Some("/certs/tls.crt")
-        );
-        assert_eq!(
-            config.server.cert.store.signing_key_path.as_deref(),
-            Some("/certs/tls.key")
-        );
-    }
-
-    #[test]
-    fn test_default_rate_limits_and_bounds() {
-        let config = Config::load_from_overrides(&[]).expect("Failed to load config");
-
-        assert_eq!(config.rate_limit.strict_burst_size, 10);
-        assert_eq!(config.rate_limit.strict_period_secs, 60);
-        assert_eq!(config.rate_limit.permissive_burst_size, 100);
-        assert_eq!(config.rate_limit.permissive_period_secs, 60);
-        assert_eq!(config.limits.max_body_size_bytes, 2_097_152);
-        assert_eq!(config.limits.max_status_index, 100_000);
-        assert_eq!(config.limits.max_statuses_per_request, 5_000);
-        assert_eq!(config.limits.max_serialized_list_size, 1_048_576);
-    }
-
-    #[test]
-    fn test_rate_limits_and_bounds_env_override() {
-        let config = Config::load_from_overrides(&[
-            ("rate_limit.strict_burst_size", "3"),
-            ("rate_limit.strict_period_secs", "120"),
-            ("rate_limit.permissive_burst_size", "500"),
-            ("rate_limit.permissive_period_secs", "10"),
-            ("limits.max_body_size_bytes", "65536"),
-            ("limits.max_status_index", "4096"),
-            ("limits.max_statuses_per_request", "256"),
-            ("limits.max_serialized_list_size", "32768"),
-        ])
-        .expect("Failed to load config");
-
-        assert_eq!(config.rate_limit.strict_burst_size, 3);
-        assert_eq!(config.rate_limit.strict_period_secs, 120);
-        assert_eq!(config.rate_limit.permissive_burst_size, 500);
-        assert_eq!(config.rate_limit.permissive_period_secs, 10);
-        assert_eq!(config.limits.max_body_size_bytes, 65_536);
-        assert_eq!(config.limits.max_status_index, 4_096);
-        assert_eq!(config.limits.max_statuses_per_request, 256);
-        assert_eq!(config.limits.max_serialized_list_size, 32_768);
-    }
-
-    #[test]
-    fn test_mysql_backend_config() {
-        let config = Config::load_from_overrides(&[
-            ("database.backend", "mysql"),
-            (
-                "database.url",
-                "mysql://user:password@localhost:3306/status-list",
-            ),
-        ])
-        .expect("Failed to load config");
-        assert_eq!(config.database.backend, DatabaseBackend::MySql);
-        assert_eq!(
-            config.database.url.expose_secret(),
-            "mysql://user:password@localhost:3306/status-list"
-        );
-    }
-
-    #[test]
-    fn test_sqlite_backend_config() {
-        let config = Config::load_from_overrides(&[
-            ("database.backend", "sqlite"),
-            ("database.url", "sqlite::memory:"),
-        ])
-        .expect("Failed to load config");
-        assert_eq!(config.database.backend, DatabaseBackend::Sqlite);
-        assert_eq!(config.database.url.expose_secret(), "sqlite::memory:");
-    }
-
-    #[test]
-    fn test_database_backend_validate_url_scheme() {
-        assert!(
-            DatabaseBackend::Postgres
-                .validate_url_scheme("postgres://postgres:postgres@localhost:5432/status-list")
-        );
-        assert!(
-            DatabaseBackend::Postgres
-                .validate_url_scheme("postgresql://postgres:postgres@localhost:5432/status-list")
-        );
-        assert!(
-            DatabaseBackend::MySql
-                .validate_url_scheme("mysql://user:password@localhost:3306/status-list")
-        );
-        assert!(DatabaseBackend::Sqlite.validate_url_scheme("sqlite::memory:"));
-        assert!(
-            !DatabaseBackend::MySql
-                .validate_url_scheme("postgres://postgres:postgres@localhost:5432/status-list")
-        );
-    }
-
-    #[test]
-    fn test_database_backend_default() {
-        let backend = DatabaseBackend::default();
-        assert_eq!(backend, DatabaseBackend::Memory);
-    }
-
-    #[test]
-    fn test_database_backend_as_str() {
-        assert_eq!(DatabaseBackend::Memory.as_str(), "memory");
-        assert_eq!(DatabaseBackend::Postgres.as_str(), "postgres");
-        assert_eq!(DatabaseBackend::MySql.as_str(), "mysql");
-        assert_eq!(DatabaseBackend::Sqlite.as_str(), "sqlite");
-    }
 
     #[test]
     fn test_default_config_ships_no_repo_key_material() {
@@ -1581,22 +1479,5 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_pool_config_env_override() {
-        let config = Config::load_from_overrides(&[
-            ("APP_DATABASE__POOL__MAX_CONNECTIONS", "20"),
-            ("APP_DATABASE__POOL__MIN_CONNECTIONS", "2"),
-            ("APP_DATABASE__POOL__ACQUIRE_TIMEOUT_SECS", "3"),
-            ("APP_DATABASE__POOL__CONNECT_TIMEOUT_SECS", "15"),
-            ("APP_DATABASE__POOL__IDLE_TIMEOUT_SECS", "300"),
-            ("APP_DATABASE__POOL__MAX_LIFETIME_SECS", "900"),
-        ])
-        .expect("Failed to load config");
-        assert_eq!(config.database.pool.max_connections, 20);
-        assert_eq!(config.database.pool.min_connections, 2);
-        assert_eq!(config.database.pool.acquire_timeout_secs, 3);
-        assert_eq!(config.database.pool.connect_timeout_secs, 15);
-        assert_eq!(config.database.pool.idle_timeout_secs, 300);
-        assert_eq!(config.database.pool.max_lifetime_secs, 900);
-    }
+
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1059,29 +1059,178 @@ mod tests {
     }
 
     #[test]
-    fn test_dns_provider_defaults_per_environment() {
-        let dns = DnsConfig::default();
-
+    fn test_dns_provider_resolution() {
+        // Environment defaults & explicit selection override
+        let default_dns = DnsConfig::default();
         assert_eq!(
-            dns.resolve("production").unwrap().kind(),
+            default_dns.resolve("production").unwrap().kind(),
             DnsProviderKind::Route53
         );
         assert_eq!(
-            dns.resolve("development").unwrap().kind(),
+            default_dns.resolve("development").unwrap().kind(),
             DnsProviderKind::Pebble
         );
-    }
 
-    #[test]
-    fn test_dns_provider_explicit_selection_overrides_environment() {
-        let dns = DnsConfig {
+        let explicit_dns = DnsConfig {
             provider: Some(DnsProviderKind::Pebble),
             ..Default::default()
         };
-
         assert_eq!(
-            dns.resolve("production").unwrap().kind(),
+            explicit_dns.resolve("production").unwrap().kind(),
             DnsProviderKind::Pebble
+        );
+
+        let env_override_cfg = Config::load_from_overrides(&[("server.cert.dns.provider", "route53")])
+            .expect("Failed to load config");
+        assert_eq!(
+            env_override_cfg.server.cert.dns.provider,
+            Some(DnsProviderKind::Route53)
+        );
+
+        // Valid provider settings resolve successfully
+        let cloudflare_dns = DnsConfig {
+            provider: Some(DnsProviderKind::Cloudflare),
+            cloudflare: Some(CloudflareDnsConfig {
+                api_token: "token".into(),
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            cloudflare_dns.resolve("production").unwrap().kind(),
+            DnsProviderKind::Cloudflare
+        );
+
+        let acmedns_helper = |cfg: AcmeDnsConfig| DnsConfig {
+            provider: Some(DnsProviderKind::Acmedns),
+            acmedns: Some(cfg),
+            ..Default::default()
+        };
+        let valid_acmedns = acmedns_helper(AcmeDnsConfig {
+            server_url: "https://auth.example.org".into(),
+            username: Some("user".into()),
+            password: Some("password".into()),
+            subdomain: Some("subdomain".into()),
+            accounts: Default::default(),
+        });
+        assert_eq!(
+            valid_acmedns.resolve("production").unwrap().kind(),
+            DnsProviderKind::Acmedns
+        );
+
+        let account = AcmeDnsAccount {
+            username: "user".into(),
+            password: "password".into(),
+            subdomain: "subdomain".into(),
+        };
+        let acmedns_map = acmedns_helper(AcmeDnsConfig {
+            server_url: "https://auth.example.org".into(),
+            username: None,
+            password: None,
+            subdomain: None,
+            accounts: [("status.example.com".to_string(), account)].into(),
+        });
+        assert_eq!(
+            acmedns_map.resolve("production").unwrap().kind(),
+            DnsProviderKind::Acmedns
+        );
+
+        let azure_dns = DnsConfig {
+            provider: Some(DnsProviderKind::Azure),
+            azure: Some(AzureDnsConfig {
+                tenant_id: "tenant".into(),
+                client_id: "client".into(),
+                client_secret: "secret".into(),
+                subscription_id: "sub".into(),
+                resource_group: "rg".into(),
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            azure_dns.resolve("production").unwrap().kind(),
+            DnsProviderKind::Azure
+        );
+
+        let gcloud_path_dns = DnsConfig {
+            provider: Some(DnsProviderKind::Gcloud),
+            gcloud: Some(GcloudDnsConfig {
+                service_account_key: None,
+                service_account_key_path: Some("/etc/gcloud/key.json".into()),
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            gcloud_path_dns.resolve("production").unwrap().kind(),
+            DnsProviderKind::Gcloud
+        );
+
+        // GCloud key source precedence (Inline key vs Path)
+        let gcloud_inline_and_path = DnsConfig {
+            provider: Some(DnsProviderKind::Gcloud),
+            gcloud: Some(GcloudDnsConfig {
+                service_account_key: Some("inline-key-json".into()),
+                service_account_key_path: Some("/etc/gcloud/key.json".into()),
+            }),
+            ..Default::default()
+        };
+        match gcloud_inline_and_path.resolve("production").unwrap() {
+            ResolvedDnsProvider::Gcloud(GcloudKeySource::Inline(key)) => {
+                assert_eq!(key.expose_secret(), "inline-key-json");
+            }
+            other => panic!("Expected an inline key source, got {other:?}"),
+        }
+
+        let gcloud_empty_inline_uses_path = DnsConfig {
+            provider: Some(DnsProviderKind::Gcloud),
+            gcloud: Some(GcloudDnsConfig {
+                service_account_key: Some("".into()),
+                service_account_key_path: Some("/etc/gcloud/key.json".into()),
+            }),
+            ..Default::default()
+        };
+        match gcloud_empty_inline_uses_path.resolve("production").unwrap() {
+            ResolvedDnsProvider::Gcloud(GcloudKeySource::Path(path)) => {
+                assert_eq!(path, "/etc/gcloud/key.json");
+            }
+            other => panic!("Expected a path key source, got {other:?}"),
+        }
+
+        // ACME-DNS accounts JSON parsing from environment overrides
+        let server_url = "https://auth.example.org";
+        let accounts_json = r#"{"a.example.com": {"username": "u1", "password": "p1", "subdomain": "s1"}, "b.example.com": {"username": "u2", "password": "p2", "subdomain": "s2"}}"#;
+        let acme_json_cfg = Config::load_from_overrides(&[
+            ("server.cert.dns.acmedns.server_url", server_url),
+            ("server.cert.dns.acmedns.accounts", accounts_json),
+        ])
+        .expect("Failed to load config with acmedns accounts JSON");
+
+        let acmedns = acme_json_cfg
+            .server
+            .cert
+            .dns
+            .acmedns
+            .expect("acmedns settings");
+        assert_eq!(acmedns.server_url, "https://auth.example.org");
+        assert!(acmedns.default_account().is_none());
+        assert_eq!(acmedns.accounts.len(), 2);
+        let b_acct = &acmedns.accounts["b.example.com"];
+        assert_eq!(b_acct.username, "u2");
+        assert_eq!(b_acct.password.expose_secret(), "p2");
+        assert_eq!(b_acct.subdomain, "s2");
+
+        let empty_acme_json_cfg = Config::load_from_overrides(&[
+            ("server.cert.dns.acmedns.server_url", server_url),
+            ("server.cert.dns.acmedns.accounts", ""),
+        ])
+        .expect("Failed to load config with empty acmedns accounts var");
+        assert!(
+            empty_acme_json_cfg
+                .server
+                .cert
+                .dns
+                .acmedns
+                .unwrap()
+                .accounts
+                .is_empty()
         );
     }
 
@@ -1317,103 +1466,7 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_gcloud_inline_key_wins_over_path() {
-        // Both sources configured: the inline key must be selected, not the path
-        let dns = DnsConfig {
-            provider: Some(DnsProviderKind::Gcloud),
-            gcloud: Some(GcloudDnsConfig {
-                service_account_key: Some("inline-key-json".into()),
-                service_account_key_path: Some("/etc/gcloud/key.json".into()),
-            }),
-            ..Default::default()
-        };
-        let resolved = dns.resolve("production").unwrap();
-        match resolved {
-            ResolvedDnsProvider::Gcloud(GcloudKeySource::Inline(key)) => {
-                assert_eq!(key.expose_secret(), "inline-key-json");
-            }
-            other => panic!("Expected an inline key source, got {other:?}"),
-        }
 
-        // An empty inline key counts as unset, so the path is used instead
-        let dns = DnsConfig {
-            provider: Some(DnsProviderKind::Gcloud),
-            gcloud: Some(GcloudDnsConfig {
-                service_account_key: Some("".into()),
-                service_account_key_path: Some("/etc/gcloud/key.json".into()),
-            }),
-            ..Default::default()
-        };
-        let resolved = dns.resolve("production").unwrap();
-        match resolved {
-            ResolvedDnsProvider::Gcloud(GcloudKeySource::Path(path)) => {
-                assert_eq!(path, "/etc/gcloud/key.json");
-            }
-            other => panic!("Expected a path key source, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn test_acme_dns_accounts_parse_from_env_json() {
-        let server_url = "https://auth.example.org";
-        let accounts_json = r#"{"a.example.com": {"username": "u1", "password": "p1", "subdomain": "s1"}, "b.example.com": {"username": "u2", "password": "p2", "subdomain": "s2"}}"#;
-        let config = Config::load_from_overrides(&[
-            ("server.cert.dns.acmedns.server_url", server_url),
-            ("server.cert.dns.acmedns.accounts", accounts_json),
-        ])
-        .expect("Failed to load config");
-
-        let acmedns = config.server.cert.dns.acmedns.expect("acmedns settings");
-        assert_eq!(acmedns.server_url, "https://auth.example.org");
-        assert!(acmedns.default_account().is_none());
-        assert_eq!(acmedns.accounts.len(), 2);
-        let account = &acmedns.accounts["b.example.com"];
-        assert_eq!(account.username, "u2");
-        assert_eq!(account.password.expose_secret(), "p2");
-        assert_eq!(account.subdomain, "s2");
-    }
-
-    #[test]
-    fn test_acme_dns_accounts_reject_malformed_json() {
-        Config::load_from_overrides(&[
-            (
-                "server.cert.dns.acmedns.server_url",
-                "https://auth.example.org",
-            ),
-            (
-                "server.cert.dns.acmedns.accounts",
-                "{\"a.example.com\": not valid json",
-            ),
-        ])
-        .expect_err("malformed accounts JSON must fail config loading");
-    }
-
-    #[test]
-    fn test_acme_dns_accounts_empty_env_var_means_no_accounts() {
-        let config = Config::load_from_overrides(&[
-            (
-                "server.cert.dns.acmedns.server_url",
-                "https://auth.example.org",
-            ),
-            ("server.cert.dns.acmedns.accounts", ""),
-        ])
-        .expect("Failed to load config");
-
-        let acmedns = config.server.cert.dns.acmedns.expect("acmedns settings");
-        assert!(acmedns.accounts.is_empty());
-    }
-
-    #[test]
-    fn test_dns_provider_env_override() {
-        let config = Config::load_from_overrides(&[("server.cert.dns.provider", "route53")])
-            .expect("Failed to load config");
-
-        assert_eq!(
-            config.server.cert.dns.provider,
-            Some(DnsProviderKind::Route53)
-        );
-    }
 
 
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -924,7 +924,9 @@ mod tests {
         assert_eq!(DatabaseBackend::MySql.as_str(), "mysql");
         assert_eq!(DatabaseBackend::Sqlite.as_str(), "sqlite");
         assert!(DatabaseBackend::Postgres.validate_url_scheme("postgres://user:pass@host:5432/db"));
-        assert!(DatabaseBackend::Postgres.validate_url_scheme("postgresql://user:pass@host:5432/db"));
+        assert!(
+            DatabaseBackend::Postgres.validate_url_scheme("postgresql://user:pass@host:5432/db")
+        );
         assert!(DatabaseBackend::MySql.validate_url_scheme("mysql://user:pass@host:3306/db"));
         assert!(DatabaseBackend::Sqlite.validate_url_scheme("sqlite::memory:"));
         assert!(!DatabaseBackend::MySql.validate_url_scheme("postgres://user:pass@host:5432/db"));
@@ -1080,8 +1082,9 @@ mod tests {
             DnsProviderKind::Pebble
         );
 
-        let env_override_cfg = Config::load_from_overrides(&[("server.cert.dns.provider", "route53")])
-            .expect("Failed to load config");
+        let env_override_cfg =
+            Config::load_from_overrides(&[("server.cert.dns.provider", "route53")])
+                .expect("Failed to load config");
         assert_eq!(
             env_override_cfg.server.cert.dns.provider,
             Some(DnsProviderKind::Route53)
@@ -1465,7 +1468,8 @@ mod tests {
         );
 
         // Security check: Default config contains no repository-specific test_data references
-        let default_config = Config::load_from_overrides(&[]).expect("Failed to load default config");
+        let default_config =
+            Config::load_from_overrides(&[]).expect("Failed to load default config");
         if let Some(path) = default_config.server.cert.store.certificate_path.as_deref() {
             assert!(
                 !path.contains("test_data"),

--- a/src/config.rs
+++ b/src/config.rs
@@ -1235,198 +1235,128 @@ mod tests {
     }
 
     #[test]
-    fn test_dns_provider_requires_its_settings() {
-        let dns = DnsConfig {
+    fn test_critical_validations() {
+        // Invalid database backend configuration
+        let invalid_db_res = Config::load_from_overrides(&[
+            ("database.backend", "redis"),
+            (
+                "database.url",
+                "postgres://user:password@localhost:5432/status-list",
+            ),
+        ]);
+        assert!(
+            invalid_db_res.is_err(),
+            "an unknown database backend value should fail config loading"
+        );
+
+        // DNS provider missing or empty required settings rejections
+        let missing_cloudflare = DnsConfig {
             provider: Some(DnsProviderKind::Cloudflare),
             ..Default::default()
         };
-        let err = dns.resolve("production").unwrap_err();
-        assert!(err.to_string().contains("dns.cloudflare"));
-
-        let dns = DnsConfig {
-            provider: Some(DnsProviderKind::Cloudflare),
-            cloudflare: Some(CloudflareDnsConfig {
-                api_token: "token".into(),
-            }),
-            ..Default::default()
-        };
-        assert_eq!(
-            dns.resolve("production").unwrap().kind(),
-            DnsProviderKind::Cloudflare
+        assert!(
+            missing_cloudflare
+                .resolve("production")
+                .unwrap_err()
+                .to_string()
+                .contains("dns.cloudflare")
         );
 
-        let dns = DnsConfig {
-            provider: Some(DnsProviderKind::Acmedns),
-            ..Default::default()
-        };
-        let err = dns.resolve("production").unwrap_err();
-        assert!(err.to_string().contains("dns.acmedns"));
-
-        // Legacy single-account config still resolves unchanged
-        let acmedns = |cfg: AcmeDnsConfig| DnsConfig {
-            provider: Some(DnsProviderKind::Acmedns),
-            acmedns: Some(cfg),
-            ..Default::default()
-        };
-        let dns = acmedns(AcmeDnsConfig {
-            server_url: "https://auth.example.org".into(),
-            username: Some("user".into()),
-            password: Some("password".into()),
-            subdomain: Some("subdomain".into()),
-            accounts: Default::default(),
-        });
-        assert_eq!(
-            dns.resolve("production").unwrap().kind(),
-            DnsProviderKind::Acmedns
-        );
-
-        // A per-domain accounts map alone is enough
-        let account = AcmeDnsAccount {
-            username: "user".into(),
-            password: "password".into(),
-            subdomain: "subdomain".into(),
-        };
-        let dns = acmedns(AcmeDnsConfig {
-            server_url: "https://auth.example.org".into(),
-            username: None,
-            password: None,
-            subdomain: None,
-            accounts: [("status.example.com".to_string(), account)].into(),
-        });
-        assert_eq!(
-            dns.resolve("production").unwrap().kind(),
-            DnsProviderKind::Acmedns
-        );
-
-        // A partial default account is rejected
-        let dns = acmedns(AcmeDnsConfig {
-            server_url: "https://auth.example.org".into(),
-            username: Some("user".into()),
-            password: None,
-            subdomain: None,
-            accounts: Default::default(),
-        });
-        let err = dns.resolve("production").unwrap_err();
-        assert!(err.to_string().contains("must be set together"));
-
-        // Neither a default account nor a map is rejected
-        let dns = acmedns(AcmeDnsConfig {
-            server_url: "https://auth.example.org".into(),
-            username: None,
-            password: None,
-            subdomain: None,
-            accounts: Default::default(),
-        });
-        let err = dns.resolve("production").unwrap_err();
-        assert!(err.to_string().contains("default account"));
-
-        // Gcloud needs the key inline or as a file path
-        let dns = DnsConfig {
-            provider: Some(DnsProviderKind::Gcloud),
-            gcloud: Some(GcloudDnsConfig {
-                service_account_key: None,
-                service_account_key_path: None,
-            }),
-            ..Default::default()
-        };
-        let err = dns.resolve("production").unwrap_err();
-        assert!(err.to_string().contains("dns.gcloud"));
-
-        let dns = DnsConfig {
-            provider: Some(DnsProviderKind::Gcloud),
-            gcloud: Some(GcloudDnsConfig {
-                service_account_key: None,
-                service_account_key_path: Some("/etc/gcloud/key.json".into()),
-            }),
-            ..Default::default()
-        };
-        assert_eq!(
-            dns.resolve("production").unwrap().kind(),
-            DnsProviderKind::Gcloud
-        );
-    }
-
-    #[test]
-    fn test_dns_provider_rejects_empty_required_fields() {
-        // Azure names exactly the empty fields
-        let azure = |tenant_id: &str, subscription_id: &str| DnsConfig {
-            provider: Some(DnsProviderKind::Azure),
-            azure: Some(AzureDnsConfig {
-                tenant_id: tenant_id.into(),
-                client_id: "client".into(),
-                client_secret: "secret".into(),
-                subscription_id: subscription_id.into(),
-                resource_group: "rg".into(),
-            }),
-            ..Default::default()
-        };
-        let err = azure("", " ")
-            .resolve("production")
-            .unwrap_err()
-            .to_string();
-        assert!(err.contains("tenant_id"));
-        assert!(err.contains("subscription_id"));
-        assert!(!err.contains("client_id"));
-        assert_eq!(
-            azure("tenant", "sub").resolve("production").unwrap().kind(),
-            DnsProviderKind::Azure
-        );
-
-        // Cloudflare rejects an empty api_token
-        let dns = DnsConfig {
+        let empty_cloudflare_token = DnsConfig {
             provider: Some(DnsProviderKind::Cloudflare),
             cloudflare: Some(CloudflareDnsConfig {
                 api_token: "".into(),
             }),
             ..Default::default()
         };
-        let err = dns.resolve("production").unwrap_err();
-        assert!(err.to_string().contains("api_token"));
+        assert!(
+            empty_cloudflare_token
+                .resolve("production")
+                .unwrap_err()
+                .to_string()
+                .contains("api_token")
+        );
 
-        // ACME-DNS rejects an empty server_url
-        let acmedns = |cfg: AcmeDnsConfig| DnsConfig {
+        let acmedns_helper = |cfg: AcmeDnsConfig| DnsConfig {
             provider: Some(DnsProviderKind::Acmedns),
             acmedns: Some(cfg),
             ..Default::default()
         };
-        let dns = acmedns(AcmeDnsConfig {
+
+        let missing_acmedns = DnsConfig {
+            provider: Some(DnsProviderKind::Acmedns),
+            ..Default::default()
+        };
+        assert!(
+            missing_acmedns
+                .resolve("production")
+                .unwrap_err()
+                .to_string()
+                .contains("dns.acmedns")
+        );
+
+        let partial_acmedns_default = acmedns_helper(AcmeDnsConfig {
+            server_url: "https://auth.example.org".into(),
+            username: Some("user".into()),
+            password: None,
+            subdomain: None,
+            accounts: Default::default(),
+        });
+        assert!(
+            partial_acmedns_default
+                .resolve("production")
+                .unwrap_err()
+                .to_string()
+                .contains("must be set together")
+        );
+
+        let empty_acmedns_account = acmedns_helper(AcmeDnsConfig {
+            server_url: "https://auth.example.org".into(),
+            username: None,
+            password: None,
+            subdomain: None,
+            accounts: Default::default(),
+        });
+        assert!(
+            empty_acmedns_account
+                .resolve("production")
+                .unwrap_err()
+                .to_string()
+                .contains("default account")
+        );
+
+        let empty_acmedns_url = acmedns_helper(AcmeDnsConfig {
             server_url: " ".into(),
             username: Some("user".into()),
             password: Some("password".into()),
             subdomain: Some("subdomain".into()),
             accounts: Default::default(),
         });
-        let err = dns.resolve("production").unwrap_err();
-        assert!(err.to_string().contains("server_url"));
+        assert!(
+            empty_acmedns_url
+                .resolve("production")
+                .unwrap_err()
+                .to_string()
+                .contains("server_url")
+        );
 
-        // An empty default-account field counts as unset, so the account
-        // is partial rather than silently unusable
-        let dns = acmedns(AcmeDnsConfig {
+        let empty_acmedns_subdomain = acmedns_helper(AcmeDnsConfig {
             server_url: "https://auth.example.org".into(),
             username: Some("user".into()),
             password: Some("password".into()),
             subdomain: Some("".into()),
             accounts: Default::default(),
         });
-        let err = dns.resolve("production").unwrap_err();
-        assert!(err.to_string().contains("must be set together"));
+        assert!(
+            empty_acmedns_subdomain
+                .resolve("production")
+                .unwrap_err()
+                .to_string()
+                .contains("must be set together")
+        );
 
-        // Gcloud with both key sources empty counts as missing
-        let dns = DnsConfig {
-            provider: Some(DnsProviderKind::Gcloud),
-            gcloud: Some(GcloudDnsConfig {
-                service_account_key: Some("".into()),
-                service_account_key_path: Some(" ".into()),
-            }),
-            ..Default::default()
-        };
-        let err = dns.resolve("production").unwrap_err();
-        assert!(err.to_string().contains("dns.gcloud"));
-    }
-
-    #[test]
-    fn test_acme_dns_rejects_unusable_account_entries() {
-        let acmedns = |accounts: HashMap<String, AcmeDnsAccount>| DnsConfig {
+        // ACME-DNS unusable account entries validation
+        let acmedns_accounts_helper = |accounts: HashMap<String, AcmeDnsAccount>| DnsConfig {
             provider: Some(DnsProviderKind::Acmedns),
             acmedns: Some(AcmeDnsConfig {
                 server_url: "https://auth.example.org".into(),
@@ -1437,100 +1367,133 @@ mod tests {
             }),
             ..Default::default()
         };
-        let account = |username: &str, subdomain: &str| AcmeDnsAccount {
+        let make_acct = |username: &str, subdomain: &str| AcmeDnsAccount {
             username: username.into(),
             password: "password".into(),
             subdomain: subdomain.into(),
         };
 
-        // An entry with empty fields is rejected, naming the domain and fields
-        let dns = acmedns([("status.example.com".to_string(), account("", " "))].into());
-        let err = dns.resolve("production").unwrap_err().to_string();
-        assert!(err.contains("status.example.com"));
-        assert!(err.contains("username"));
-        assert!(err.contains("subdomain"));
-        assert!(!err.contains("password"));
+        let empty_fields_err = acmedns_accounts_helper(
+            [("status.example.com".to_string(), make_acct("", " "))].into(),
+        )
+        .resolve("production")
+        .unwrap_err()
+        .to_string();
+        assert!(empty_fields_err.contains("status.example.com"));
+        assert!(empty_fields_err.contains("username"));
+        assert!(empty_fields_err.contains("subdomain"));
+        assert!(!empty_fields_err.contains("password"));
 
-        // A key that does not name a domain is rejected
-        for key in ["", "  ", "*.", "."] {
-            let dns = acmedns([(key.to_string(), account("user", "sub"))].into());
-            let err = dns.resolve("production").unwrap_err().to_string();
-            assert!(err.contains("does not name a domain"), "key {key:?}: {err}");
+        for invalid_key in ["", "  ", "*.", "."] {
+            let invalid_key_err = acmedns_accounts_helper(
+                [(invalid_key.to_string(), make_acct("user", "sub"))].into(),
+            )
+            .resolve("production")
+            .unwrap_err()
+            .to_string();
+            assert!(
+                invalid_key_err.contains("does not name a domain"),
+                "key {invalid_key:?}: {invalid_key_err}"
+            );
         }
 
-        // A usable entry passes
-        let dns = acmedns([("status.example.com".to_string(), account("user", "sub"))].into());
-        assert_eq!(
-            dns.resolve("production").unwrap().kind(),
-            DnsProviderKind::Acmedns
+        let missing_gcloud_key = DnsConfig {
+            provider: Some(DnsProviderKind::Gcloud),
+            gcloud: Some(GcloudDnsConfig {
+                service_account_key: None,
+                service_account_key_path: None,
+            }),
+            ..Default::default()
+        };
+        assert!(
+            missing_gcloud_key
+                .resolve("production")
+                .unwrap_err()
+                .to_string()
+                .contains("dns.gcloud")
         );
-    }
 
+        let empty_gcloud_keys = DnsConfig {
+            provider: Some(DnsProviderKind::Gcloud),
+            gcloud: Some(GcloudDnsConfig {
+                service_account_key: Some("".into()),
+                service_account_key_path: Some(" ".into()),
+            }),
+            ..Default::default()
+        };
+        assert!(
+            empty_gcloud_keys
+                .resolve("production")
+                .unwrap_err()
+                .to_string()
+                .contains("dns.gcloud")
+        );
 
+        let azure_helper = |tenant_id: &str, subscription_id: &str| DnsConfig {
+            provider: Some(DnsProviderKind::Azure),
+            azure: Some(AzureDnsConfig {
+                tenant_id: tenant_id.into(),
+                client_id: "client".into(),
+                client_secret: "secret".into(),
+                subscription_id: subscription_id.into(),
+                resource_group: "rg".into(),
+            }),
+            ..Default::default()
+        };
+        let azure_err = azure_helper("", " ")
+            .resolve("production")
+            .unwrap_err()
+            .to_string();
+        assert!(azure_err.contains("tenant_id"));
+        assert!(azure_err.contains("subscription_id"));
+        assert!(!azure_err.contains("client_id"));
 
+        // Malformed ACME-DNS accounts JSON rejection
+        assert!(
+            Config::load_from_overrides(&[
+                (
+                    "server.cert.dns.acmedns.server_url",
+                    "https://auth.example.org",
+                ),
+                (
+                    "server.cert.dns.acmedns.accounts",
+                    "{\"a.example.com\": not valid json",
+                ),
+            ])
+            .is_err(),
+            "malformed accounts JSON must fail config loading"
+        );
 
-
-    #[test]
-    fn test_default_config_ships_no_repo_key_material() {
-        // The default config must not reference any test_data/ paths or
-        // other repository-local key material, ensuring it can be used
-        // in production without requiring those test files
-        let config = Config::load_from_overrides(&[]).expect("Failed to load config");
-
-        // Cert store paths should be None when using ACME strategy (default on feature=acme)
-        // or None/empty when using store strategy (default without feature=acme)
-        let cert_path = config.server.cert.store.certificate_path;
-        let key_path = config.server.cert.store.signing_key_path;
-
-        if let Some(path) = cert_path.as_deref() {
+        // Security check: Default config contains no repository-specific test_data references
+        let default_config = Config::load_from_overrides(&[]).expect("Failed to load default config");
+        if let Some(path) = default_config.server.cert.store.certificate_path.as_deref() {
             assert!(
                 !path.contains("test_data"),
                 "Default config certificate_path references test_data: {path}"
             );
         }
-        if let Some(path) = key_path.as_deref() {
+        if let Some(path) = default_config.server.cert.store.signing_key_path.as_deref() {
             assert!(
                 !path.contains("test_data"),
                 "Default config signing_key_path references test_data: {path}"
             );
         }
-
-        // Database URL should not reference test_data either
-        let db_url = config.database.url.expose_secret();
+        let db_url = default_config.database.url.expose_secret();
         assert!(
             !db_url.contains("test_data"),
             "Default config database URL references test_data: {db_url}"
         );
-
-        // AWS secret keys should be None or not reference test_data
-        if let Some(key) = config.server.cert.store.certificate_key.as_deref() {
+        if let Some(key) = default_config.server.cert.store.certificate_key.as_deref() {
             assert!(
                 !key.contains("test_data"),
                 "Default config certificate_key references test_data: {key}"
             );
         }
-        if let Some(key) = config.server.cert.store.signing_key_key.as_deref() {
+        if let Some(key) = default_config.server.cert.store.signing_key_key.as_deref() {
             assert!(
                 !key.contains("test_data"),
                 "Default config signing_key_key references test_data: {key}"
             );
         }
     }
-
-    #[test]
-    fn test_invalid_database_backend_config() {
-        let result = Config::load_from_overrides(&[
-            ("database.backend", "redis"),
-            (
-                "database.url",
-                "postgres://user:password@localhost:5432/status-list",
-            ),
-        ]);
-        assert!(
-            result.is_err(),
-            "an unknown backend value should fail to load config"
-        );
-    }
-
-
 }


### PR DESCRIPTION
The configuration tests in src/config.rs have grown too large and contain many overlapping test cases. The current test suite (lines 833-1602, ~770 lines) tests many individual fields separately, creating maintenance overhead and slowing down test execution.