### PR TITLE
feat: Consolidate certificate and signing-key material backend

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -26,9 +26,7 @@ APP_SERVER__CERT__EKU=1,3,6,1,5,5,7,3,30
 # The cryptographic material backend is selected by enabled Cargo features:
 # vault => Vault/OpenBao; aws-secrets without vault => AWS Secrets Manager;
 # neither feature => in-memory storage for local development and tests.
-# TTL in seconds for certificate material reads from the selected backend.
-# Set to 0 to disable this material cache.
-APP_SERVER__CERT__MATERIAL_CACHE_TTL=300
+# Certificate material stays cached until provisioning or renewal invalidates it.
 # TTL in seconds for private signing-key reads from the selected backend.
 # Set to 0 to force every private-key read to the backend.
 APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL=0

--- a/.env.template
+++ b/.env.template
@@ -23,6 +23,14 @@ APP_SERVER__CERT__ORGANIZATION=example.com
 APP_SERVER__CERT__ACME_DIRECTORY_URL=https://pebble:14000/dir
 # The last number is not explicitly defined in the spec
 APP_SERVER__CERT__EKU=1,3,6,1,5,5,7,3,30
+# Primary backend for server cryptographic material: memory | aws_secrets_manager | vault
+APP_SERVER__CERT__MATERIAL_BACKEND=memory
+# TTL in seconds for certificate material reads from the selected backend.
+# Set to 0 to disable this material cache.
+APP_SERVER__CERT__MATERIAL_CACHE_TTL=300
+# TTL in seconds for private signing-key reads from the selected backend.
+# Set to 0 to force every private-key read to the backend.
+APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL=0
 # Cron schedule for certificate renewal checks (6-field cron: sec min hour day month day-of-week)
 APP_SERVER__CERT__RENEWAL_CRON_SCHEDULE=0 0 0 * * *
 # TTL in seconds for the in-memory parsed certificate chain cache.
@@ -34,8 +42,8 @@ APP_SERVER__CERT__CHAIN_CACHE_TTL=3600
 
 # Store provisioning settings. Required only when APP_SERVER__CERT__PROVISIONING_STRATEGY=store.
 # source=filesystem: load from local files. Files may contain PEM text or raw DER.
-# source=storage: load cert from configured certificate storage and key from configured secrets storage.
-# source=aws_secrets_manager: load both cert and key from configured AWS Secrets Manager backend.
+# source=storage: load cert and key from the configured cryptographic material backend.
+# source=aws_secrets_manager: compatibility alias for storage.
 # Storage-backed values may contain PEM text or base64/base64url-encoded DER.
 # Private keys must be PKCS#8 PEM or DER.
 APP_SERVER__CERT__STORE__SOURCE=filesystem
@@ -103,14 +111,15 @@ APP_DATABASE__POOL__IDLE_TIMEOUT_SECS=600
 APP_DATABASE__POOL__MAX_LIFETIME_SECS=1800
 
 # Redis configuration (optional)
-# Redis is NOT required for status-list persistence or reads. It is only used
-# as a distributed certificate-material cache for multi-replica deployments
-# that use AWS S3 certificate storage with the 'redis' feature compiled.
+# Redis is optional. The server does not use Redis for status-list persistence
+# or status-list reads; those use the configured repository backend and the
+# in-process status-list cache. Certificate and signing-key material are managed
+# together by the selected cryptographic material backend; prefer the built-in
+# material read-cache TTLs before adding Redis.
 # Leave APP_REDIS__URI empty to disable Redis entirely.
 APP_REDIS__URI=
 APP_REDIS__REQUIRE_CLIENT_AUTH=false
-# TTL for the certificate cache in Redis.
-# Set to 0 to disable and always fetch from S3.
+# TTL for Redis-backed certificate cache integrations that explicitly opt in.
 APP_REDIS__CERT_CACHE_TTL=3600
 
 # AWS SDK
@@ -121,14 +130,10 @@ AWS_SECRET_ACCESS_KEY=test
 # TTL for the Secrets Manager cache.
 # Set to 0 to disable and always fetch from AWS API directly.
 APP_AWS__SECRETS_CACHE_TTL=300
-# S3 bucket name for storing certificate data
-APP_AWS__S3_BUCKET=status-list-adorsys
-# Optional prefix prepended to all S3 object keys (empty = no prefix)
-APP_AWS__S3_KEY_PREFIX=
 
 # Vault / OpenBao KV v2 configuration (feature = "vault")
-# When compiled with `vault` feature, Vault/OpenBao is used
-# as the secrets backend for signing-key material.
+# When compiled with the `vault` feature, Vault/OpenBao can be selected as the
+# cryptographic material backend for certificate and signing-key material.
 #
 # APP_VAULT__ADDR=http://vault:8200
 # APP_VAULT__TOKEN=hvs.XXXXXXXXXXXXXXXXXXXXXXXX

--- a/.env.template
+++ b/.env.template
@@ -23,8 +23,9 @@ APP_SERVER__CERT__ORGANIZATION=example.com
 APP_SERVER__CERT__ACME_DIRECTORY_URL=https://pebble:14000/dir
 # The last number is not explicitly defined in the spec
 APP_SERVER__CERT__EKU=1,3,6,1,5,5,7,3,30
-# Primary backend for server cryptographic material: memory | aws_secrets_manager | vault
-APP_SERVER__CERT__MATERIAL_BACKEND=memory
+# The cryptographic material backend is selected by enabled Cargo features:
+# vault => Vault/OpenBao; aws-secrets without vault => AWS Secrets Manager;
+# neither feature => in-memory storage for local development and tests.
 # TTL in seconds for certificate material reads from the selected backend.
 # Set to 0 to disable this material cache.
 APP_SERVER__CERT__MATERIAL_CACHE_TTL=300

--- a/.env.template
+++ b/.env.template
@@ -34,9 +34,7 @@ APP_SERVER__CERT__MATERIAL_CACHE_TTL=300
 APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL=0
 # Cron schedule for certificate renewal checks (6-field cron: sec min hour day month day-of-week)
 APP_SERVER__CERT__RENEWAL_CRON_SCHEDULE=0 0 0 * * *
-# TTL in seconds for the in-memory parsed certificate chain cache.
-# Set to 0 to keep entries forever; in multi-replica deployments, non-provisioning replicas rely on this TTL to pick up renewed chains.
-APP_SERVER__CERT__CHAIN_CACHE_TTL=3600
+# Parsed certificate chains stay cached until certificate provisioning or renewal replaces them.
 # DNS challenge server URL. Optional; only used in development mode (APP_ENV=development).
 # Falls back to http://challtestsrv:8055 when unset.
 # APP_SERVER__CERT__DNS_CHALLENGE_SERVER_URL=http://challtestsrv:8055

--- a/.env.template
+++ b/.env.template
@@ -41,16 +41,14 @@ APP_SERVER__CERT__CHAIN_CACHE_TTL=3600
 # APP_SERVER__CERT__DNS_CHALLENGE_SERVER_URL=http://challtestsrv:8055
 
 # Store provisioning settings. Required only when APP_SERVER__CERT__PROVISIONING_STRATEGY=store.
-# source=filesystem: load from local files. Files may contain PEM text or raw DER.
-# source=storage: load cert and key from the configured cryptographic material backend.
-# source=aws_secrets_manager: compatibility alias for storage.
+# Configure either filesystem paths or storage keys, not both.
+# Filesystem values may contain PEM text or raw DER.
 # Storage-backed values may contain PEM text or base64/base64url-encoded DER.
 # Private keys must be PKCS#8 PEM or DER.
-APP_SERVER__CERT__STORE__SOURCE=filesystem
-# Required for source=filesystem.
+# Filesystem provisioning:
 # APP_SERVER__CERT__STORE__CERTIFICATE_PATH=/etc/status-list/tls.crt
 # APP_SERVER__CERT__STORE__SIGNING_KEY_PATH=/etc/status-list/tls.key
-# Required for source=storage or source=aws_secrets_manager.
+# Storage-backed provisioning from the selected cryptographic material backend:
 # APP_SERVER__CERT__STORE__CERTIFICATE_KEY=status-list/server-certificate
 # APP_SERVER__CERT__STORE__SIGNING_KEY_KEY=status-list/server-signing-key
 
@@ -127,9 +125,6 @@ APP_AWS__REGION=us-east-1
 AWS_ENDPOINT_URL=http://localstack:4566 # remove this in production
 AWS_ACCESS_KEY_ID=test
 AWS_SECRET_ACCESS_KEY=test
-# TTL for the Secrets Manager cache.
-# Set to 0 to disable and always fetch from AWS API directly.
-APP_AWS__SECRETS_CACHE_TTL=300
 
 # Vault / OpenBao KV v2 configuration (feature = "vault")
 # When compiled with the `vault` feature, Vault/OpenBao can be selected as the
@@ -144,8 +139,6 @@ APP_AWS__SECRETS_CACHE_TTL=300
 # APP_VAULT__PATH_PREFIX=
 # Vault Enterprise / OpenBao namespace (default: empty / unset)
 # APP_VAULT__NAMESPACE=
-# TTL for in-memory secrets cache in seconds. Set to 0 to disable caching
-# APP_VAULT__SECRETS_CACHE_TTL=300
 # HTTP request timeout in seconds
 # APP_VAULT__TIMEOUT_SECS=30
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-route53"
-version = "1.118.0"
+version = "1.119.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d2d58dd226c731886e9565cb829a5a628a92bf43d13b20b3348d9039218c7f"
+checksum = "9980bada33fcae23b9d5617e9f8a1b25753469e96e3b7118a0b72beea443f53f"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -339,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.141.0"
+version = "1.142.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f9420d3a2467eed22ed3635ca653653162c386a0b0f65c78189f9bd3c1379e"
+checksum = "f9e15a5c55e05f4b0b7e483160b3c85cccdf77cff02c95504f3e71d460855cd2"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -376,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-secretsmanager"
-version = "1.111.0"
+version = "1.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f840fd8a79900661ca05e9af1f4e2b3c74386e9fc1b4a9dd58745faf689f0"
+checksum = "5230ecd791109507f2bec2f907ed605a5c9fbd37033736943f06c9a09ad3914d"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -402,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.110.0"
+version = "1.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b14781dfbff48984017d57167b6ea0b6471c6920ec52b44a2677c7feb3c13"
+checksum = "120e7eb63457a9e547f9986fe3b273f77c43679da4d04f46359fa881c5e19b6e"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -488,9 +488,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.61.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9381123ab62d20c13082b151f30f962a3b112b727345394536dfa39a482944"
+checksum = "6de526c7b567420a31bc283657a7921b45c4cafe0827fdf2490713dcc770c28f"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -521,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "635d23afda0a6ab48d666c4d447c4873e8d1e83518a2be2093122397e50b838e"
+checksum = "3c1c8a04cb31ba74d0115af5a890bb8c0d48fba64b52812fa13929a6ef0cc83c"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -578,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.12.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07505b34e8f4b3591a4fa69e9792b52289b95488dbbc68c3c0075b7bedb245e1"
+checksum = "483b858ff67522011c4786310c5cd8fd88d0be7ea3d5f1a48328446300c4269e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -644,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6dc683efb34b9e755675b37fedbe0103141e5b6df7bdc9eb6967756a8c167d8"
+checksum = "fce83ce9abbb198d25bc7131e468d0f9fe1257125e58c39f3f9fc9f5098c9647"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -846,7 +846,7 @@ checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
 dependencies = [
  "autocfg",
  "libm",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
  "serde",
@@ -1083,9 +1083,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1676,7 +1676,7 @@ dependencies = [
  "asn1-rs",
  "displaydoc",
  "nom",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "rusticata-macros",
 ]
@@ -2022,9 +2022,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "flate2"
@@ -2312,9 +2312,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2505,9 +2505,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2672,9 +2672,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -2686,9 +2686,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2699,9 +2699,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2713,16 +2713,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -2733,15 +2734,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -3071,14 +3072,14 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
  "bitflags 2.13.1",
  "libc",
  "plain",
- "redox_syscall 0.9.1",
+ "redox_syscall 0.9.2",
 ]
 
 [[package]]
@@ -3100,9 +3101,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
@@ -3319,7 +3320,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -3332,6 +3333,16 @@ name = "num-bigint"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -3404,7 +3415,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
 ]
@@ -3746,9 +3757,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
+checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -3756,9 +3767,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
+checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3766,9 +3777,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
+checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
 dependencies = [
  "pest",
  "pest_meta",
@@ -3779,9 +3790,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
+checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
 dependencies = [
  "pest",
 ]
@@ -3878,9 +3889,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plain"
@@ -3905,9 +3916,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -4145,9 +4156,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -4318,9 +4329,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3257df217f7eab0044627a268c9cc6cdb60c0c421c88f83ac41c4e31520b6b84"
+checksum = "e37a4ca5c6ca42aa3e6df2fd32b987a65d32a4c2159a6f3fe0fd1df306a2658f"
 dependencies = [
  "arc-swap",
  "arcstr",
@@ -4332,7 +4343,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "itoa",
- "num-bigint",
+ "num-bigint 0.5.1",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
@@ -4358,9 +4369,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07507be7b4a5f9f26eeb41eeaebb1f5a7ff29dfb29739facc21d35bf8b11c21e"
+checksum = "f1c93da5bb2c5d4e6c0ef7abeead62c89169a0a4882bfb83ac892f2423aea2fe"
 dependencies = [
  "bitflags 2.13.1",
 ]
@@ -5310,7 +5321,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "thiserror 2.0.20",
  "time",
@@ -5556,7 +5567,7 @@ dependencies = [
  "log",
  "md-5 0.10.6",
  "memchr",
- "num-bigint",
+ "num-bigint 0.4.8",
  "once_cell",
  "rand 0.8.7",
  "rust_decimal",
@@ -5988,9 +5999,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -6505,9 +6516,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -7043,9 +7054,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "wyz"
@@ -7099,9 +7110,9 @@ checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
 
 [[package]]
 name = "yaml-rust2"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631a50d867fafb7093e709d75aaee9e0e0d5deb934021fcea25ac2fe09edc51e"
+checksum = "b36710ce3a279cfce8465dbab826f161675a262950b922cb2c3663852dfe9eb0"
 dependencies = [
  "arraydeque",
  "encoding_rs",
@@ -7210,9 +7221,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -7221,9 +7232,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -7232,13 +7243,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ mysql = ["history", "sea-orm?/sqlx-mysql"]
 redis = ["dep:redis"]
 vault = ["acme"]
 aws-secrets = [
+  "acme",
   "dep:aws-config",
   "dep:aws-sdk-route53",
   "dep:aws-sdk-s3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ sqlite = ["history", "sea-orm?/sqlx-sqlite"]
 mysql = ["history", "sea-orm?/sqlx-mysql"]
 redis = ["dep:redis"]
 vault = ["acme"]
-aws = [
+aws-secrets = [
   "dep:aws-config",
   "dep:aws-sdk-route53",
   "dep:aws-sdk-s3",

--- a/README.md
+++ b/README.md
@@ -93,15 +93,15 @@ By default, the server will listen on `http://localhost:8000` using in-memory re
 
 The crate uses modular Cargo feature flags to gate optional production backend drivers:
 
-| Feature       | Description                                                                                                                                        | Default    |
-| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
-| `memory`      | In-memory repositories (`MemoryStatusLists`, `MemoryCredentials`, `MemoryStatusListHistory`), Moka TTL cache, and store-based certificate storage. | ✅ Default |
-| `postgres`    | SeaORM PostgreSQL database driver.                                                                                                                 | ❌ Opt-in  |
-| `sqlite`      | SeaORM SQLite database driver.                                                                                                                     | ❌ Opt-in  |
-| `mysql`       | SeaORM MySQL database driver.                                                                                                                      | ❌ Opt-in  |
-| `redis`       | Redis storage driver for explicit cache/storage integrations.                                                                                      | ❌ Opt-in  |
-| `aws-secrets` | AWS S3 object storage, Route53 DNS-01, and AWS Secrets Manager drivers.                                                                            | ❌ Opt-in  |
-| `acme`        | ACME DNS-01 certificate manager driver.                                                                                                            | ❌ Opt-in  |
+| Feature       | Description                                                             | Default    |
+| ------------- | ----------------------------------------------------------------------- | ---------- |
+| `memory`      | In-memory repositories, TTL cache, and store-based certificate storage. | ✅ Default |
+| `postgres`    | SeaORM PostgreSQL database driver.                                      | ❌ Opt-in  |
+| `sqlite`      | SeaORM SQLite database driver.                                          | ❌ Opt-in  |
+| `mysql`       | SeaORM MySQL database driver.                                           | ❌ Opt-in  |
+| `redis`       | Redis storage driver for explicit cache/storage integrations.           | ❌ Opt-in  |
+| `aws-secrets` | Route53 DNS-01, and AWS Secrets Manager drivers.                        | ❌ Opt-in  |
+| `acme`        | ACME DNS-01 certificate manager driver.                                 | ❌ Opt-in  |
 
 To build with specific backend drivers, pass the matching feature flag(s):
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ The Status List Server is provisioned with a cryptographic certificate that is e
 - Certificate issuance and renewal are managed according to the configured renewal strategy.
 - Every day, a cron job checks whether the certificate should be renewed based on this strategy.
 - If the certificate is still considered valid according to the configured strategy, no renewal occurs; renewal is only triggered when necessary.
-- The server signing key and certificate chain are stored in one selected cryptographic-material backend, configured with `server.cert.material_backend`.
+- The server signing key and certificate chain are stored in one cryptographic-material backend selected by enabled Cargo features (`vault`, `aws-secrets`, or in-memory fallback).
 - Certificate and signing-key reads can be cached with `APP_SERVER__CERT__MATERIAL_CACHE_TTL` and `APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL`. Set the signing-key TTL to `0` to force private-key reads to bypass the material cache.
 - Parsed certificate chains are cached in memory for `APP_SERVER__CERT__CHAIN_CACHE_TTL` seconds (default: `3600`). A value of `0` keeps entries indefinitely. In multi-replica deployments, replicas that did not perform renewal rely on this TTL to refresh their in-memory chain.
 
@@ -211,7 +211,7 @@ The Status List Server is provisioned with a cryptographic certificate that is e
 - `server.cert.provisioning_strategy = "acme"` requests and renews certificates through ACME.
 - `server.cert.provisioning_strategy = "store"` loads externally managed certificate material and persists it into the configured cryptographic-material backend.
 - Store provisioning infers filesystem loading when `server.cert.store.certificate_path` and `signing_key_path` are configured.
-- Store provisioning infers storage-backed loading when `server.cert.store.certificate_key` and `signing_key_key` are configured; those keys are read from the selected cryptographic-material backend.
+- Store provisioning infers storage-backed loading when `server.cert.store.certificate_key` and `signing_key_key` are configured; those keys are read from the feature-selected cryptographic-material backend.
 - Filesystem store inputs may be PEM text or raw DER. Storage-backed store inputs may be PEM text or base64/base64url-encoded DER. Private keys must be PKCS#8 in PEM or DER form.
 - The renewal cron schedule is configured with `server.cert.renewal_cron_schedule`. For store provisioning, each scheduled run reloads the configured source and refreshes persisted material only when it changed.
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ The Status List Server is provisioned with a cryptographic certificate that is e
 - If the certificate is still considered valid according to the configured strategy, no renewal occurs; renewal is only triggered when necessary.
 - The server signing key and certificate chain are stored in one cryptographic-material backend selected by enabled Cargo features (`vault`, `aws-secrets`, or in-memory fallback).
 - Certificate and signing-key reads can be cached with `APP_SERVER__CERT__MATERIAL_CACHE_TTL` and `APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL`. Set the signing-key TTL to `0` to force private-key reads to bypass the material cache.
-- Parsed certificate chains are cached in memory for `APP_SERVER__CERT__CHAIN_CACHE_TTL` seconds (default: `3600`). A value of `0` keeps entries indefinitely. In multi-replica deployments, replicas that did not perform renewal rely on this TTL to refresh their in-memory chain.
+- Parsed certificate chains stay cached in memory until certificate provisioning or renewal replaces them.
 
 **Provisioning Modes:**
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The crate uses modular Cargo feature flags to gate optional production backend d
 | `postgres` | SeaORM PostgreSQL database driver.                                                                                                                 | ❌ Opt-in  |
 | `sqlite`   | SeaORM SQLite database driver.                                                                                                                     | ❌ Opt-in  |
 | `mysql`    | SeaORM MySQL database driver.                                                                                                                      | ❌ Opt-in  |
-| `redis`    | Redis storage driver for legacy or explicit cache/storage integrations.                                                                            | ❌ Opt-in  |
+| `redis`    | Redis storage driver for explicit cache/storage integrations.                                                                                      | ❌ Opt-in  |
 | `aws`      | AWS S3 object storage and AWS Secrets Manager drivers.                                                                                             | ❌ Opt-in  |
 | `acme`     | ACME DNS-01 certificate manager driver.                                                                                                            | ❌ Opt-in  |
 
@@ -115,9 +115,7 @@ cargo run --features postgres,aws,acme
 
 ## Redis Role
 
-Redis is not required for core status-list persistence or status-list reads. Status-list records are stored by the configured repository backend (`memory`, PostgreSQL, MySQL, or SQLite), and hot status-list reads are cached in-process by `MokaStatusListCache`.
-
-The ACME certificate manager uses the selected cryptographic-material backend for both the certificate chain and signing key. Prefer the built-in material read caches (`APP_SERVER__CERT__MATERIAL_CACHE_TTL` and `APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL`) before adding Redis. Redis remains available only for explicit adapter-level integrations that still opt into it.
+Redis is optional. The server does not use Redis for status-list persistence or status-list reads; those use the configured repository backend and the in-process status-list cache. Certificate and signing-key material are managed together by the selected cryptographic material backend; prefer the built-in material read-cache TTLs before adding Redis.
 
 For single-replica deployments, local development, tests, or deployments where certificate material reads are inexpensive, leave `APP_REDIS__URI` unset and omit the `redis` Cargo feature.
 
@@ -224,7 +222,7 @@ The Status List Server is provisioned with a cryptographic certificate that is e
 - ACME uses `DefaultHttpClient` unless `.acme_http_client(...)` is supplied.
 - Store provisioning does not create ACME HTTP client state unless explicitly configured.
 - `email` defaults to an empty string, `organization` defaults to none, and `eku` defaults to none.
-- `domains` and `crypto_material_storage` must always be provided.
+- `domains` and `crypto_storage` must always be provided.
 - ACME additionally requires `challenge_handler` and `acme_directory_url`.
 
 ```rust
@@ -233,7 +231,7 @@ let manager = CertManager::builder()
     .email("support@example.com")
     .organization(Some("example.com"))
     .acme_directory_url("https://acme-v02.api.letsencrypt.org/directory")
-    .crypto_material_storage(material_storage)
+    .crypto_storage(material_storage)
     .challenge_handler(challenge_handler)
     .eku(&[1, 3, 6, 1, 5, 5, 7, 3, 30])
     .acme_strategy()
@@ -243,7 +241,7 @@ let manager = CertManager::builder()
 ```rust
 let manager = CertManager::builder()
     .domains(["statuslist.example.com"])
-    .crypto_material_storage(material_storage)
+    .crypto_storage(material_storage)
     .store_strategy(StoreProvisioningStrategy::filesystem(
         "/etc/status-list/tls.crt",
         "/etc/status-list/tls.key",

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The crate uses modular Cargo feature flags to gate optional production backend d
 | `postgres` | SeaORM PostgreSQL database driver.                                                                                                                 | ❌ Opt-in  |
 | `sqlite`   | SeaORM SQLite database driver.                                                                                                                     | ❌ Opt-in  |
 | `mysql`    | SeaORM MySQL database driver.                                                                                                                      | ❌ Opt-in  |
-| `redis`    | Redis storage and certificate cache driver.                                                                                                        | ❌ Opt-in  |
+| `redis`    | Redis storage driver for legacy or explicit cache/storage integrations.                                                                            | ❌ Opt-in  |
 | `aws`      | AWS S3 object storage and AWS Secrets Manager drivers.                                                                                             | ❌ Opt-in  |
 | `acme`     | ACME DNS-01 certificate manager driver.                                                                                                            | ❌ Opt-in  |
 
@@ -109,15 +109,15 @@ To build with specific backend drivers, pass the matching feature flag(s):
 # Run with PostgreSQL and Redis support available
 cargo run --features postgres,redis
 
-# Run with all AWS and ACME production integrations, including the optional Redis cache driver
-cargo run --features postgres,redis,aws,acme
+# Run with AWS and ACME production integrations
+cargo run --features postgres,aws,acme
 ```
 
 ## Redis Role
 
 Redis is not required for core status-list persistence or status-list reads. Status-list records are stored by the configured repository backend (`memory`, PostgreSQL, MySQL, or SQLite), and hot status-list reads are cached in-process by `MokaStatusListCache`.
 
-When compiled with the `redis` feature and configured with a non-empty `APP_REDIS__URI`, Redis is used only as an optional distributed cache for certificate material loaded from S3 by the ACME/AWS certificate manager path. This can help multi-replica deployments share certificate cache entries and reduce repeated object-storage reads. The tradeoff is an extra operational dependency: Redis credentials, TLS settings if used, availability monitoring, backups or persistence choices, and HA/upgrade complexity.
+The ACME certificate manager uses the selected cryptographic-material backend for both the certificate chain and signing key. Prefer the built-in material read caches (`APP_SERVER__CERT__MATERIAL_CACHE_TTL` and `APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL`) before adding Redis. Redis remains available only for explicit adapter-level integrations that still opt into it.
 
 For single-replica deployments, local development, tests, or deployments where certificate material reads are inexpensive, leave `APP_REDIS__URI` unset and omit the `redis` Cargo feature.
 
@@ -204,14 +204,16 @@ The Status List Server is provisioned with a cryptographic certificate that is e
 - Certificate issuance and renewal are managed according to the configured renewal strategy.
 - Every day, a cron job checks whether the certificate should be renewed based on this strategy.
 - If the certificate is still considered valid according to the configured strategy, no renewal occurs; renewal is only triggered when necessary.
+- The server signing key and certificate chain are stored in one selected cryptographic-material backend, configured with `server.cert.material_backend`.
+- Certificate and signing-key reads can be cached with `APP_SERVER__CERT__MATERIAL_CACHE_TTL` and `APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL`. Set the signing-key TTL to `0` to force private-key reads to bypass the material cache.
 - Parsed certificate chains are cached in memory for `APP_SERVER__CERT__CHAIN_CACHE_TTL` seconds (default: `3600`). A value of `0` keeps entries indefinitely. In multi-replica deployments, replicas that did not perform renewal rely on this TTL to refresh their in-memory chain.
 
 **Provisioning Modes:**
 
 - `server.cert.provisioning_strategy = "acme"` requests and renews certificates through ACME.
-- `server.cert.provisioning_strategy = "store"` loads externally managed certificate material and persists it into the configured certificate/secrets storage.
+- `server.cert.provisioning_strategy = "store"` loads externally managed certificate material and persists it into the configured cryptographic-material backend.
 - Store provisioning supports `server.cert.store.source = "filesystem"` with `certificate_path` and `signing_key_path`.
-- Store provisioning also supports `server.cert.store.source = "storage"` for the configured certificate/secrets storage backends, or `"aws_secrets_manager"` when both PEM values are stored in the configured secrets backend, using `certificate_key` and `signing_key_key`.
+- Store provisioning also supports `server.cert.store.source = "storage"` or `"aws_secrets_manager"` when both PEM values are already present in the configured material backend, using `certificate_key` and `signing_key_key`.
 - Filesystem store inputs may be PEM text or raw DER. Storage-backed store inputs may be PEM text or base64/base64url-encoded DER. Private keys must be PKCS#8 in PEM or DER form.
 - The renewal cron schedule is configured with `server.cert.renewal_cron_schedule`. For store provisioning, each scheduled run reloads the configured source and refreshes persisted material only when it changed.
 
@@ -222,7 +224,7 @@ The Status List Server is provisioned with a cryptographic certificate that is e
 - ACME uses `DefaultHttpClient` unless `.acme_http_client(...)` is supplied.
 - Store provisioning does not create ACME HTTP client state unless explicitly configured.
 - `email` defaults to an empty string, `organization` defaults to none, and `eku` defaults to none.
-- `domains`, `cert_storage`, and `secrets_storage` must always be provided.
+- `domains` and `crypto_material_storage` must always be provided.
 - ACME additionally requires `challenge_handler` and `acme_directory_url`.
 
 ```rust
@@ -231,8 +233,7 @@ let manager = CertManager::builder()
     .email("support@example.com")
     .organization(Some("example.com"))
     .acme_directory_url("https://acme-v02.api.letsencrypt.org/directory")
-    .cert_storage(cert_storage)
-    .secrets_storage(secrets_storage)
+    .crypto_material_storage(material_storage)
     .challenge_handler(challenge_handler)
     .eku(&[1, 3, 6, 1, 5, 5, 7, 3, 30])
     .acme_strategy()
@@ -242,8 +243,7 @@ let manager = CertManager::builder()
 ```rust
 let manager = CertManager::builder()
     .domains(["statuslist.example.com"])
-    .cert_storage(cert_storage)
-    .secrets_storage(secrets_storage)
+    .crypto_material_storage(material_storage)
     .store_strategy(StoreProvisioningStrategy::filesystem(
         "/etc/status-list/tls.crt",
         "/etc/status-list/tls.key",

--- a/README.md
+++ b/README.md
@@ -93,15 +93,15 @@ By default, the server will listen on `http://localhost:8000` using in-memory re
 
 The crate uses modular Cargo feature flags to gate optional production backend drivers:
 
-| Feature    | Description                                                                                                                                        | Default    |
-| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
-| `memory`   | In-memory repositories (`MemoryStatusLists`, `MemoryCredentials`, `MemoryStatusListHistory`), Moka TTL cache, and store-based certificate storage. | ✅ Default |
-| `postgres` | SeaORM PostgreSQL database driver.                                                                                                                 | ❌ Opt-in  |
-| `sqlite`   | SeaORM SQLite database driver.                                                                                                                     | ❌ Opt-in  |
-| `mysql`    | SeaORM MySQL database driver.                                                                                                                      | ❌ Opt-in  |
-| `redis`    | Redis storage driver for explicit cache/storage integrations.                                                                                      | ❌ Opt-in  |
-| `aws-secrets` | AWS S3 object storage, Route53 DNS-01, and AWS Secrets Manager drivers.                                                                        | ❌ Opt-in  |
-| `acme`     | ACME DNS-01 certificate manager driver.                                                                                                            | ❌ Opt-in  |
+| Feature       | Description                                                                                                                                        | Default    |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| `memory`      | In-memory repositories (`MemoryStatusLists`, `MemoryCredentials`, `MemoryStatusListHistory`), Moka TTL cache, and store-based certificate storage. | ✅ Default |
+| `postgres`    | SeaORM PostgreSQL database driver.                                                                                                                 | ❌ Opt-in  |
+| `sqlite`      | SeaORM SQLite database driver.                                                                                                                     | ❌ Opt-in  |
+| `mysql`       | SeaORM MySQL database driver.                                                                                                                      | ❌ Opt-in  |
+| `redis`       | Redis storage driver for explicit cache/storage integrations.                                                                                      | ❌ Opt-in  |
+| `aws-secrets` | AWS S3 object storage, Route53 DNS-01, and AWS Secrets Manager drivers.                                                                            | ❌ Opt-in  |
+| `acme`        | ACME DNS-01 certificate manager driver.                                                                                                            | ❌ Opt-in  |
 
 To build with specific backend drivers, pass the matching feature flag(s):
 

--- a/README.md
+++ b/README.md
@@ -65,18 +65,18 @@ The simplest way to run the project is with [docker compose](https://docs.docker
 docker compose up --build
 ```
 
-This command will pull all required images and start the server compiled with default compose features (`postgres,aws,acme`). Redis is not part of the default path.
+This command will pull all required images and start the server compiled with default compose features (`postgres,aws-secrets,acme`). Redis is not part of the default path.
 
 To pass custom Cargo feature flags during build, specify the `FEATURES` environment variable:
 
 ```sh
-FEATURES="mysql,aws,acme" docker compose --profile mysql up --build
+FEATURES="mysql,aws-secrets,acme" docker compose --profile mysql up --build
 ```
 
 To test the optional Redis certificate-material cache locally, enable the Redis profile, compile the Redis feature, and provide a Redis URI:
 
 ```sh
-FEATURES="postgres,redis,aws,acme" APP_REDIS__URI="redis://redis:6379" docker compose --profile redis up --build
+FEATURES="postgres,redis,aws-secrets,acme" APP_REDIS__URI="redis://redis:6379" docker compose --profile redis up --build
 ```
 
 #### Running Manually
@@ -100,7 +100,7 @@ The crate uses modular Cargo feature flags to gate optional production backend d
 | `sqlite`   | SeaORM SQLite database driver.                                                                                                                     | ❌ Opt-in  |
 | `mysql`    | SeaORM MySQL database driver.                                                                                                                      | ❌ Opt-in  |
 | `redis`    | Redis storage driver for explicit cache/storage integrations.                                                                                      | ❌ Opt-in  |
-| `aws`      | AWS S3 object storage and AWS Secrets Manager drivers.                                                                                             | ❌ Opt-in  |
+| `aws-secrets` | AWS S3 object storage, Route53 DNS-01, and AWS Secrets Manager drivers.                                                                        | ❌ Opt-in  |
 | `acme`     | ACME DNS-01 certificate manager driver.                                                                                                            | ❌ Opt-in  |
 
 To build with specific backend drivers, pass the matching feature flag(s):
@@ -110,7 +110,7 @@ To build with specific backend drivers, pass the matching feature flag(s):
 cargo run --features postgres,redis
 
 # Run with AWS and ACME production integrations
-cargo run --features postgres,aws,acme
+cargo run --features postgres,aws-secrets,acme
 ```
 
 ## Redis Role
@@ -210,8 +210,8 @@ The Status List Server is provisioned with a cryptographic certificate that is e
 
 - `server.cert.provisioning_strategy = "acme"` requests and renews certificates through ACME.
 - `server.cert.provisioning_strategy = "store"` loads externally managed certificate material and persists it into the configured cryptographic-material backend.
-- Store provisioning supports `server.cert.store.source = "filesystem"` with `certificate_path` and `signing_key_path`.
-- Store provisioning also supports `server.cert.store.source = "storage"` or `"aws_secrets_manager"` when both PEM values are already present in the configured material backend, using `certificate_key` and `signing_key_key`.
+- Store provisioning infers filesystem loading when `server.cert.store.certificate_path` and `signing_key_path` are configured.
+- Store provisioning infers storage-backed loading when `server.cert.store.certificate_key` and `signing_key_key` are configured; those keys are read from the selected cryptographic-material backend.
 - Filesystem store inputs may be PEM text or raw DER. Storage-backed store inputs may be PEM text or base64/base64url-encoded DER. Private keys must be PKCS#8 in PEM or DER form.
 - The renewal cron schedule is configured with `server.cert.renewal_cron_schedule`. For store provisioning, each scheduled run reloads the configured source and refreshes persisted material only when it changed.
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ The Status List Server is provisioned with a cryptographic certificate that is e
 - Every day, a cron job checks whether the certificate should be renewed based on this strategy.
 - If the certificate is still considered valid according to the configured strategy, no renewal occurs; renewal is only triggered when necessary.
 - The server signing key and certificate chain are stored in one cryptographic-material backend selected by enabled Cargo features (`vault`, `aws-secrets`, or in-memory fallback).
-- Certificate and signing-key reads can be cached with `APP_SERVER__CERT__MATERIAL_CACHE_TTL` and `APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL`. Set the signing-key TTL to `0` to force private-key reads to bypass the material cache.
+- Certificate material stays cached until provisioning or renewal invalidates it. Signing-key reads can be cached with `APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL`; set it to `0` to force private-key reads to bypass the material cache.
 - Parsed certificate chains stay cached in memory until certificate provisioning or renewal replaces them.
 
 **Provisioning Modes:**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        FEATURES: ${FEATURES:-postgres,aws,acme}
+        FEATURES: ${FEATURES:-postgres,aws-secrets,acme}
     container_name: status-list-server
     env_file:
       - path: .env.template

--- a/docs/database-backends.md
+++ b/docs/database-backends.md
@@ -86,6 +86,6 @@ There is no separate MariaDB service because MariaDB uses the same MySQL-driver 
 
 ## Redis Is Not A Database Backend
 
-Redis is not used for status-list persistence or for the status-list read path. Reads use the configured database/repository plus the in-process Moka cache. The optional `redis` feature provides a distributed certificate-material cache for the AWS S3 certificate storage path when `APP_REDIS__URI` is set.
+Redis is not used for status-list persistence or for the status-list read path. Reads use the configured database/repository plus the in-process Moka cache. Certificate and signing-key material are managed together by the selected cryptographic-material backend; prefer the built-in material read-cache TTLs before adding another service.
 
-Use Redis when multiple application replicas should share cached certificate material and reducing backend object-storage reads is worth the added Redis credentials, TLS, HA, and monitoring work. Leave it disabled for local, single-replica, and simple deployments.
+Keep Redis disabled for local, single-replica, and simple deployments. Enable it only for explicit adapter-level integrations that still require Redis and where the added credentials, TLS, HA, and monitoring work is justified.

--- a/docs/database-backends.md
+++ b/docs/database-backends.md
@@ -33,7 +33,7 @@ SQLite is not a distributed database, so it is not a good match for horizontally
 
 Every client-facing write — publishing a list, updating one, the snapshot each writes alongside it, and credential registration — runs in a transaction pinned to **READ COMMITTED** on PostgreSQL and MySQL. The level is set by the application, not inherited from the server, so both backends behave identically instead of running at their differing defaults (PostgreSQL READ COMMITTED, InnoDB REPEATABLE READ).
 
-The one write that is **not** pinned is the retention sweep (`delete_older_than`); see *Other notes* below.
+The one write that is **not** pinned is the retention sweep (`delete_older_than`); see _Other notes_ below.
 
 The guard itself does not depend on this. The guarded update is `UPDATE ... WHERE list_id = ? AND updated_at = ?`, a compare-and-set whose match count decides the outcome. That is a current read on both engines, so it sees the latest committed row at either level, and no write transaction issues a `SELECT` whose view could go stale.
 
@@ -50,7 +50,7 @@ SET GLOBAL transaction_isolation = 'SERIALIZABLE';
 
 then without the pin these transactions would inherit it, and a routine race between two writers — normally a clean `409 update_conflict` telling the client to re-read — would instead surface as a serialization failure. Note that this is deliberately **not overridable**: the compare-and-set is the concurrency mechanism here and it wants READ COMMITTED, regardless of what else shares the database.
 
-**Materially fewer deadlocks on MySQL.** This is the larger effect in practice, and it applies to every stock MySQL deployment, not just misconfigured ones — REPEATABLE READ *is* the InnoDB default. At REPEATABLE READ InnoDB takes next-key (gap) locks; at READ COMMITTED it locks index records only. Concretely: every snapshot insert writes `exp = now + token_exp_secs`, so concurrent inserts for unrelated lists land in the same gap of `idx_status_list_history_exp`, while the retention sweep deletes a range of that same index. Those are the ingredients of an insert-intention deadlock. Pinning removes the gap locks and with them that entire class of `1213`.
+**Materially fewer deadlocks on MySQL.** This is the larger effect in practice, and it applies to every stock MySQL deployment, not just misconfigured ones — REPEATABLE READ _is_ the InnoDB default. At REPEATABLE READ InnoDB takes next-key (gap) locks; at READ COMMITTED it locks index records only. Concretely: every snapshot insert writes `exp = now + token_exp_secs`, so concurrent inserts for unrelated lists land in the same gap of `idx_status_list_history_exp`, while the retention sweep deletes a range of that same index. Those are the ingredients of an insert-intention deadlock. Pinning removes the gap locks and with them that entire class of `1213`.
 
 ### MySQL: binary logging must be ROW or MIXED
 

--- a/docs/database-backends.md
+++ b/docs/database-backends.md
@@ -70,10 +70,10 @@ SET GLOBAL binlog_format = 'ROW';  -- then restart the server
 
 ## Compose Profiles
 
-`docker compose up` starts PostgreSQL by default and builds the container with `postgres,aws,acme` features enabled. To run the MySQL service instead:
+`docker compose up` starts PostgreSQL by default and builds the container with `postgres,aws-secrets,acme` features enabled. To run the MySQL service instead:
 
 ```bash
-FEATURES="mysql,aws,acme" docker compose --profile mysql up --build
+FEATURES="mysql,aws-secrets,acme" docker compose --profile mysql up --build
 ```
 
 There is no separate MariaDB service because MariaDB uses the same MySQL-driver path (`mysql://` URL). Connect to a MariaDB host by pointing `APP_DATABASE__URL` at your MariaDB instance on port 3306 (the default) and setting `APP_DATABASE__BACKEND=mysql`.

--- a/docs/database-backends.md
+++ b/docs/database-backends.md
@@ -86,6 +86,6 @@ There is no separate MariaDB service because MariaDB uses the same MySQL-driver 
 
 ## Redis Is Not A Database Backend
 
-Redis is not used for status-list persistence or for the status-list read path. Reads use the configured database/repository plus the in-process Moka cache. Certificate and signing-key material are managed together by the selected cryptographic-material backend; prefer the built-in material read-cache TTLs before adding another service.
+Redis is not used for status-list persistence or for the status-list read path. Reads use the configured database/repository plus the in-process Moka cache. Certificate and signing-key material are managed together by the feature-selected cryptographic-material backend; prefer the built-in material read-cache TTLs before adding another service.
 
 Keep Redis disabled for local, single-replica, and simple deployments. Enable it only for explicit adapter-level integrations that still require Redis and where the added credentials, TLS, HA, and monitoring work is justified.

--- a/docs/secrets-backends.md
+++ b/docs/secrets-backends.md
@@ -1,8 +1,8 @@
-# Secrets Storage Backend Guidance
+# Cryptographic-Material Backend Guidance
 
-The server supports storing sensitive cryptographic materials (such as ACME account keys and server signing keys) in secure secrets management backends.
+The server stores lifecycle-coupled cryptographic material in one selected backend by default: ACME account keys, the server signing key, and the certificate chain associated with that key.
 
-The supported secrets backends include:
+The supported material backends include:
 
 - **HashiCorp Vault / OpenBao** (KV v2 engine)
 - **AWS Secrets Manager**

--- a/docs/secrets-backends.md
+++ b/docs/secrets-backends.md
@@ -17,8 +17,8 @@ Both HashiCorp Vault and OpenBao share the KV v2 REST API interface and are supp
 | Variable                                    | Type              | Default    | Description                                                                                                  |
 | ------------------------------------------- | ----------------- | ---------- | ------------------------------------------------------------------------------------------------------------ |
 | `APP_SERVER__CERT__MATERIAL_BACKEND`        | String            | `memory`   | Primary backend for server cryptographic material: `memory`, `aws_secrets_manager`, or `vault`.              |
-| `APP_SERVER__CERT__MATERIAL_CACHE_TTL`      | Integer (seconds) | `300`      | In-memory read-cache TTL for certificate material. Set to `0` to disable this material cache.                 |
-| `APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL`   | Integer (seconds) | `0`        | In-memory read-cache TTL for private signing-key material. Set to `0` to force every read to the backend.     |
+| `APP_SERVER__CERT__MATERIAL_CACHE_TTL`      | Integer (seconds) | `300`      | In-memory read-cache TTL for certificate material. Set to `0` to disable this material cache.                |
+| `APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL`   | Integer (seconds) | `0`        | In-memory read-cache TTL for private signing-key material. Set to `0` to force every read to the backend.    |
 
 Backend-specific settings:
 

--- a/docs/secrets-backends.md
+++ b/docs/secrets-backends.md
@@ -1,6 +1,6 @@
 # Cryptographic Material Backend Guidance
 
-The server stores lifecycle-coupled cryptographic material in one selected backend by default: ACME account keys, the server signing key, and the certificate chain associated with that key.
+The server stores lifecycle-coupled cryptographic material in one backend by default: ACME account keys, the server signing key, and the certificate chain associated with that key.
 
 The supported backends include:
 
@@ -8,17 +8,7 @@ The supported backends include:
 - **AWS Secrets Manager**
 - **In-Memory** (for development and testing)
 
-## Storage Semantics
-
-All supported cryptographic-material backends use the same logical model for certificate chains and private signing keys:
-
-| Backend               | Certificate chain                                     | Private signing key                                   | Behavior                                                                                |
-| --------------------- | ----------------------------------------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| In-memory             | Stored as a string under the certificate material key | Stored as a string under the signing-key material key | Volatile process-local storage for development and tests                                |
-| AWS Secrets Manager   | Stored as one secret string                           | Stored as one secret string                           | Same create, update, load, delete, cache, and invalidation path as certificate material |
-| Vault / OpenBao KV v2 | Stored as one KV v2 secret value                      | Stored as one KV v2 secret value                      | Same create, update, load, delete, cache, and invalidation path as certificate material |
-
-ACME provisioning writes the issued certificate chain and the signing key through this single abstraction. Store provisioning can seed material either from local files or from existing keys in the selected material backend, but the refreshed server material is persisted back through the same backend and invalidated together.
+Backend selection is controlled by enabled Cargo features. Builds with `vault` use Vault/OpenBao. Builds with `aws-secrets` and without `vault` use AWS Secrets Manager. Builds without either backend feature use in-memory storage for local development and tests.
 
 ## HashiCorp Vault & OpenBao (KV v2)
 
@@ -28,7 +18,6 @@ Both HashiCorp Vault and OpenBao share the KV v2 REST API interface and are supp
 
 | Variable                                    | Type              | Default    | Description                                                                                                  |
 | ------------------------------------------- | ----------------- | ---------- | ------------------------------------------------------------------------------------------------------------ |
-| `APP_SERVER__CERT__MATERIAL_BACKEND`        | String            | `memory`   | Primary backend for server cryptographic material: `memory`, `aws_secrets_manager`, or `vault`.              |
 | `APP_SERVER__CERT__MATERIAL_CACHE_TTL`      | Integer (seconds) | `300`      | In-memory read-cache TTL for certificate material. Set to `0` to disable this material cache.                |
 | `APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL`   | Integer (seconds) | `0`        | In-memory read-cache TTL for private signing-key material. Set to `0` to force every read to the backend.    |
 
@@ -91,7 +80,6 @@ When compiled with the `aws-secrets` feature flag:
 AWS_ACCESS_KEY_ID=test
 AWS_SECRET_ACCESS_KEY=test
 APP_AWS__REGION=us-east-1
-APP_SERVER__CERT__MATERIAL_BACKEND=aws_secrets_manager
 APP_SERVER__CERT__MATERIAL_CACHE_TTL=300
 APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL=0
 ```

--- a/docs/secrets-backends.md
+++ b/docs/secrets-backends.md
@@ -18,7 +18,6 @@ Both HashiCorp Vault and OpenBao share the KV v2 REST API interface and are supp
 
 | Variable                                    | Type              | Default    | Description                                                                                                  |
 | ------------------------------------------- | ----------------- | ---------- | ------------------------------------------------------------------------------------------------------------ |
-| `APP_SERVER__CERT__MATERIAL_CACHE_TTL`      | Integer (seconds) | `300`      | In-memory read-cache TTL for certificate material. Set to `0` to disable this material cache.                |
 | `APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL`   | Integer (seconds) | `0`        | In-memory read-cache TTL for private signing-key material. Set to `0` to force every read to the backend.    |
 
 Backend-specific settings:
@@ -69,7 +68,8 @@ APP_VAULT__NAMESPACE=my-org-namespace
 
 ### Cache Behavior
 
-- Certificate and signing-key material reads are controlled consistently across backends by `APP_SERVER__CERT__MATERIAL_CACHE_TTL` and `APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL`.
+- Certificate material stays cached until provisioning or renewal invalidates it.
+- Signing-key material reads are controlled consistently across backends by `APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL`.
 - To require every private-key read to query the selected material backend, keep `APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL=0`.
 
 ## AWS Secrets Manager
@@ -80,6 +80,5 @@ When compiled with the `aws-secrets` feature flag:
 AWS_ACCESS_KEY_ID=test
 AWS_SECRET_ACCESS_KEY=test
 APP_AWS__REGION=us-east-1
-APP_SERVER__CERT__MATERIAL_CACHE_TTL=300
 APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL=0
 ```

--- a/docs/secrets-backends.md
+++ b/docs/secrets-backends.md
@@ -8,6 +8,18 @@ The supported backends include:
 - **AWS Secrets Manager**
 - **In-Memory** (for development and testing)
 
+## Storage Semantics
+
+All supported cryptographic-material backends use the same logical model for certificate chains and private signing keys:
+
+| Backend | Certificate chain | Private signing key | Behavior |
+| ------- | ----------------- | ------------------- | -------- |
+| In-memory | Stored as a string under the certificate material key | Stored as a string under the signing-key material key | Volatile process-local storage for development and tests |
+| AWS Secrets Manager | Stored as one secret string | Stored as one secret string | Same create, update, load, delete, cache, and invalidation path as certificate material |
+| Vault / OpenBao KV v2 | Stored as one KV v2 secret value | Stored as one KV v2 secret value | Same create, update, load, delete, cache, and invalidation path as certificate material |
+
+ACME provisioning writes the issued certificate chain and the signing key through this single abstraction. Store provisioning can seed material either from local files or from existing keys in the selected material backend, but the refreshed server material is persisted back through the same backend and invalidated together.
+
 ## HashiCorp Vault & OpenBao (KV v2)
 
 Both HashiCorp Vault and OpenBao share the KV v2 REST API interface and are supported natively when the `vault` feature flag is enabled.
@@ -29,7 +41,6 @@ Backend-specific settings:
 | `APP_VAULT__MOUNT`             | String            | `"secret"`                          | KV v2 secrets engine mount point                                         |
 | `APP_VAULT__PATH_PREFIX`       | String            | `""`                                | Optional prefix prepended to all secret keys (e.g. `status-list-server`) |
 | `APP_VAULT__NAMESPACE`         | String            | `None`                              | Optional Enterprise/OpenBao namespace header (`X-Vault-Namespace`)       |
-| `APP_VAULT__SECRETS_CACHE_TTL` | Integer (seconds) | `300` (5 minutes)                   | In-memory cache TTL in seconds. Set to `0` to disable caching.           |
 | `APP_VAULT__TIMEOUT_SECS`      | Integer (seconds) | `30`                                | HTTP request timeout duration in seconds                                 |
 
 ### Example 1: Local Development with HashiCorp Vault
@@ -47,7 +58,6 @@ APP_VAULT__ADDR=http://127.0.0.1:8200
 APP_VAULT__TOKEN=root
 APP_VAULT__MOUNT=secret
 APP_VAULT__PATH_PREFIX=dev/status-list
-APP_VAULT__SECRETS_CACHE_TTL=300
 ```
 
 ### Example 2: Deployment with OpenBao
@@ -66,24 +76,21 @@ APP_VAULT__TOKEN=s.xxxxxxxxx
 APP_VAULT__MOUNT=secret
 APP_VAULT__PATH_PREFIX=production/status-list
 APP_VAULT__NAMESPACE=my-org-namespace
-APP_VAULT__SECRETS_CACHE_TTL=600
 ```
 
 ### Cache Behavior
 
-- Vault adapter reads may use its own backend cache via `APP_VAULT__SECRETS_CACHE_TTL`.
-- Certificate and signing-key material reads are additionally controlled by `APP_SERVER__CERT__MATERIAL_CACHE_TTL` and `APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL`.
+- Certificate and signing-key material reads are controlled consistently across backends by `APP_SERVER__CERT__MATERIAL_CACHE_TTL` and `APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL`.
 - To require every private-key read to query the selected material backend, keep `APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL=0`.
 
 ## AWS Secrets Manager
 
-When compiled with the `aws` feature flag:
+When compiled with the `aws-secrets` feature flag:
 
 ```env
 AWS_ACCESS_KEY_ID=test
 AWS_SECRET_ACCESS_KEY=test
 APP_AWS__REGION=us-east-1
-APP_AWS__SECRETS_CACHE_TTL=300
 APP_SERVER__CERT__MATERIAL_BACKEND=aws_secrets_manager
 APP_SERVER__CERT__MATERIAL_CACHE_TTL=300
 APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL=0

--- a/docs/secrets-backends.md
+++ b/docs/secrets-backends.md
@@ -1,8 +1,8 @@
-# Cryptographic-Material Backend Guidance
+# Cryptographic Material Backend Guidance
 
 The server stores lifecycle-coupled cryptographic material in one selected backend by default: ACME account keys, the server signing key, and the certificate chain associated with that key.
 
-The supported material backends include:
+The supported backends include:
 
 - **HashiCorp Vault / OpenBao** (KV v2 engine)
 - **AWS Secrets Manager**
@@ -13,6 +13,14 @@ The supported material backends include:
 Both HashiCorp Vault and OpenBao share the KV v2 REST API interface and are supported natively when the `vault` feature flag is enabled.
 
 ### Configuration Variables
+
+| Variable                                    | Type              | Default    | Description                                                                                                  |
+| ------------------------------------------- | ----------------- | ---------- | ------------------------------------------------------------------------------------------------------------ |
+| `APP_SERVER__CERT__MATERIAL_BACKEND`        | String            | `memory`   | Primary backend for server cryptographic material: `memory`, `aws_secrets_manager`, or `vault`.              |
+| `APP_SERVER__CERT__MATERIAL_CACHE_TTL`      | Integer (seconds) | `300`      | In-memory read-cache TTL for certificate material. Set to `0` to disable this material cache.                 |
+| `APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL`   | Integer (seconds) | `0`        | In-memory read-cache TTL for private signing-key material. Set to `0` to force every read to the backend.     |
+
+Backend-specific settings:
 
 | Variable                       | Type              | Default                             | Description                                                              |
 | ------------------------------ | ----------------- | ----------------------------------- | ------------------------------------------------------------------------ |
@@ -63,8 +71,9 @@ APP_VAULT__SECRETS_CACHE_TTL=600
 
 ### Cache Behavior
 
-- Secrets are cached in-memory using TTL semantics to minimize latency and Vault API request volume.
-- To disable caching entirely (forcing every read to query Vault directly), set `APP_VAULT__SECRETS_CACHE_TTL=0`.
+- Vault adapter reads may use its own backend cache via `APP_VAULT__SECRETS_CACHE_TTL`.
+- Certificate and signing-key material reads are additionally controlled by `APP_SERVER__CERT__MATERIAL_CACHE_TTL` and `APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL`.
+- To require every private-key read to query the selected material backend, keep `APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL=0`.
 
 ## AWS Secrets Manager
 
@@ -75,4 +84,7 @@ AWS_ACCESS_KEY_ID=test
 AWS_SECRET_ACCESS_KEY=test
 APP_AWS__REGION=us-east-1
 APP_AWS__SECRETS_CACHE_TTL=300
+APP_SERVER__CERT__MATERIAL_BACKEND=aws_secrets_manager
+APP_SERVER__CERT__MATERIAL_CACHE_TTL=300
+APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL=0
 ```

--- a/docs/secrets-backends.md
+++ b/docs/secrets-backends.md
@@ -16,20 +16,20 @@ Both HashiCorp Vault and OpenBao share the KV v2 REST API interface and are supp
 
 ### Configuration Variables
 
-| Variable                                    | Type              | Default    | Description                                                                                                  |
-| ------------------------------------------- | ----------------- | ---------- | ------------------------------------------------------------------------------------------------------------ |
-| `APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL`   | Integer (seconds) | `0`        | In-memory read-cache TTL for private signing-key material. Set to `0` to force every read to the backend.    |
+| Variable                                  | Type              | Default | Description                                                                                               |
+| ----------------------------------------- | ----------------- | ------- | --------------------------------------------------------------------------------------------------------- |
+| `APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL` | Integer (seconds) | `0`     | In-memory read-cache TTL for private signing-key material. Set to `0` to force every read to the backend. |
 
 Backend-specific settings:
 
-| Variable                       | Type              | Default                             | Description                                                              |
-| ------------------------------ | ----------------- | ----------------------------------- | ------------------------------------------------------------------------ |
-| `APP_VAULT__ADDR`              | String            | `http://127.0.0.1:8200`             | Base URL of the Vault / OpenBao cluster                                  |
-| `APP_VAULT__TOKEN`             | String            | _(Mandatory when Vault is enabled)_ | Authentication token (`X-Vault-Token`)                                   |
-| `APP_VAULT__MOUNT`             | String            | `"secret"`                          | KV v2 secrets engine mount point                                         |
-| `APP_VAULT__PATH_PREFIX`       | String            | `""`                                | Optional prefix prepended to all secret keys (e.g. `status-list-server`) |
-| `APP_VAULT__NAMESPACE`         | String            | `None`                              | Optional Enterprise/OpenBao namespace header (`X-Vault-Namespace`)       |
-| `APP_VAULT__TIMEOUT_SECS`      | Integer (seconds) | `30`                                | HTTP request timeout duration in seconds                                 |
+| Variable                  | Type              | Default                             | Description                                                              |
+| ------------------------- | ----------------- | ----------------------------------- | ------------------------------------------------------------------------ |
+| `APP_VAULT__ADDR`         | String            | `http://127.0.0.1:8200`             | Base URL of the Vault / OpenBao cluster                                  |
+| `APP_VAULT__TOKEN`        | String            | _(Mandatory when Vault is enabled)_ | Authentication token (`X-Vault-Token`)                                   |
+| `APP_VAULT__MOUNT`        | String            | `"secret"`                          | KV v2 secrets engine mount point                                         |
+| `APP_VAULT__PATH_PREFIX`  | String            | `""`                                | Optional prefix prepended to all secret keys (e.g. `status-list-server`) |
+| `APP_VAULT__NAMESPACE`    | String            | `None`                              | Optional Enterprise/OpenBao namespace header (`X-Vault-Namespace`)       |
+| `APP_VAULT__TIMEOUT_SECS` | Integer (seconds) | `30`                                | HTTP request timeout duration in seconds                                 |
 
 ### Example 1: Local Development with HashiCorp Vault
 

--- a/docs/secrets-backends.md
+++ b/docs/secrets-backends.md
@@ -12,11 +12,11 @@ The supported backends include:
 
 All supported cryptographic-material backends use the same logical model for certificate chains and private signing keys:
 
-| Backend | Certificate chain | Private signing key | Behavior |
-| ------- | ----------------- | ------------------- | -------- |
-| In-memory | Stored as a string under the certificate material key | Stored as a string under the signing-key material key | Volatile process-local storage for development and tests |
-| AWS Secrets Manager | Stored as one secret string | Stored as one secret string | Same create, update, load, delete, cache, and invalidation path as certificate material |
-| Vault / OpenBao KV v2 | Stored as one KV v2 secret value | Stored as one KV v2 secret value | Same create, update, load, delete, cache, and invalidation path as certificate material |
+| Backend               | Certificate chain                                     | Private signing key                                   | Behavior                                                                                |
+| --------------------- | ----------------------------------------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| In-memory             | Stored as a string under the certificate material key | Stored as a string under the signing-key material key | Volatile process-local storage for development and tests                                |
+| AWS Secrets Manager   | Stored as one secret string                           | Stored as one secret string                           | Same create, update, load, delete, cache, and invalidation path as certificate material |
+| Vault / OpenBao KV v2 | Stored as one KV v2 secret value                      | Stored as one KV v2 secret value                      | Same create, update, load, delete, cache, and invalidation path as certificate material |
 
 ACME provisioning writes the issued certificate chain and the signing key through this single abstraction. Store provisioning can seed material either from local files or from existing keys in the selected material backend, but the refreshed server material is persisted back through the same backend and invalidated together.
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -35,7 +35,7 @@ The following files are used to configure the deployment:
 
 ## Redis Role
 
-Redis is optional. The server does not use Redis for status-list persistence or status-list reads; those use the configured repository backend and the in-process Moka status-list cache. Certificate and signing-key material are managed together by the selected cryptographic-material backend; prefer the built-in material read-cache TTLs before adding Redis.
+Redis is optional. The server does not use Redis for status-list persistence or status-list reads; those use the configured repository backend and the in-process Moka status-list cache. Certificate and signing-key material are managed together by the feature-selected cryptographic-material backend; prefer the built-in material read-cache TTLs before adding Redis.
 
 Keep Redis disabled for a simpler deployment. Enable it only for explicit adapter-level integrations that still require Redis and where the extra dependency, credentials, TLS configuration, monitoring, and HA operations are worth it.
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -50,7 +50,7 @@ helm template statuslist ./chart --namespace statuslist
 
 ### Redis-Enabled Certificate Cache
 
-To enable Redis, use an application image built with `redis,aws,acme` features, set `redis-ha.enabled=true`, provide a `redis-password` in the configured secret or ExternalSecret, and keep `APP_REDIS__URI` unset in `statuslist.env` so the chart can generate it from the Redis HA service. Set `APP_REDIS__REQUIRE_CLIENT_AUTH` and Redis HAProxy TLS values only when your Redis endpoint requires them.
+To enable Redis, use an application image built with `redis,aws-secrets,acme` features, set `redis-ha.enabled=true`, provide a `redis-password` in the configured secret or ExternalSecret, and keep `APP_REDIS__URI` unset in `statuslist.env` so the chart can generate it from the Redis HA service. Set `APP_REDIS__REQUIRE_CLIENT_AUTH` and Redis HAProxy TLS values only when your Redis endpoint requires them.
 
 ## Production Deployment Instructions
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -35,9 +35,9 @@ The following files are used to configure the deployment:
 
 ## Redis Role
 
-Redis is optional. The server does not use Redis for status-list persistence or status-list reads; those use the configured repository backend and the in-process Moka status-list cache. In this chart, Redis is intended only as a distributed certificate-material cache for multi-replica deployments that use the AWS S3 certificate storage path and compile the application with the `redis` feature.
+Redis is optional. The server does not use Redis for status-list persistence or status-list reads; those use the configured repository backend and the in-process Moka status-list cache. Certificate and signing-key material are managed together by the selected cryptographic-material backend; prefer the built-in material read-cache TTLs before adding Redis.
 
-Keep Redis disabled for a simpler deployment. Enable it when sharing certificate cache entries across replicas and reducing object-storage reads is worth the extra Redis dependency, credentials, TLS configuration, monitoring, and HA operations.
+Keep Redis disabled for a simpler deployment. Enable it only for explicit adapter-level integrations that still require Redis and where the extra dependency, credentials, TLS configuration, monitoring, and HA operations are worth it.
 
 ### No-Redis Deployment
 

--- a/helm/chart/values-local.yaml
+++ b/helm/chart/values-local.yaml
@@ -28,7 +28,6 @@ statuslist:
     APP_ENV: "local"
     APP_SERVER__CERT__ACME_DIRECTORY_URL: "https://acme-staging-v02.api.letsencrypt.org/directory"
     # Parsed certificate chain cache TTL in seconds. "0" means no expiry; non-provisioning replicas rely on this TTL for renewed chains.
-    APP_SERVER__CERT__CHAIN_CACHE_TTL: "3600"
     # Status-list record cache TTL in seconds. "0" disables this cache.
     APP_CACHE__TTL: "120"
     APP_CACHE__MAX_CAPACITY: "500"

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -54,7 +54,6 @@ statuslist:
     APP_SERVER__CERT__EKU: "1,3,6,1,5,5,7,3,30"
     APP_SERVER__CERT__RENEWAL_CRON_SCHEDULE: "0 0 0 * * *"
     # Parsed certificate chain cache TTL in seconds. "0" means no expiry; non-provisioning replicas rely on this TTL for renewed chains.
-    APP_SERVER__CERT__CHAIN_CACHE_TTL: "3600"
     # DNS provider for ACME DNS-01 challenges: route53 | cloudflare | gcloud | azure | acmedns
     # (pebble also exists but is a development-only fake, not for deployments)
     # See docs/dns-providers.md for the settings each provider needs.

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -62,7 +62,6 @@ statuslist:
     # APP_SERVER__CERT__DNS__ACMEDNS__ACCOUNTS JSON, which holds every account password)
     # must come from a secret (see externalSecret below), not from plain env values.
     APP_SERVER__CERT__DNS__PROVIDER: "route53"
-    APP_AWS__SECRETS_CACHE_TTL: "300"
     APP_AWS__S3_BUCKET: "status-list-adorsys"
     APP_AWS__S3_KEY_PREFIX: ""
     # Status-list record cache TTL in seconds. "0" disables this cache.

--- a/src/config.rs
+++ b/src/config.rs
@@ -193,9 +193,6 @@ pub struct CertConfig {
     pub material_cache_ttl: u64,
     /// Cache TTL for private signing-key reads in seconds. `0` disables this cache.
     pub signing_key_cache_ttl: u64,
-    /// Cache TTL for parsed certificate chains in seconds.
-    /// A value of 0 keeps entries in memory indefinitely without expiration.
-    pub chain_cache_ttl: u64,
     pub renewal_cron_schedule: String,
     #[serde(default)]
     pub dns_challenge_server_url: Option<String>,
@@ -776,11 +773,6 @@ fn base_builder() -> Result<ConfigBuilder<DefaultState>, ConfigError> {
     let (default_provisioning_strategy, default_cert_path, default_key_path) =
         ("store", Option::<String>::None, Option::<String>::None);
 
-    #[cfg(feature = "acme")]
-    let default_chain_cache_ttl = crate::utils::cert_manager::DEFAULT_CHAIN_CACHE_TTL.as_secs();
-    #[cfg(not(feature = "acme"))]
-    let default_chain_cache_ttl = 86400;
-
     let telemetry_environment = match std::env::var("APP_ENV")
         .unwrap_or_default()
         .trim()
@@ -823,7 +815,6 @@ fn base_builder() -> Result<ConfigBuilder<DefaultState>, ConfigError> {
         )?
         .set_default("server.cert.material_cache_ttl", 300)?
         .set_default("server.cert.signing_key_cache_ttl", 0)?
-        .set_default("server.cert.chain_cache_ttl", default_chain_cache_ttl)?
         .set_default("server.cert.renewal_cron_schedule", "0 0 0 * * *")?
         .set_default("server.cert.store.certificate_path", default_cert_path)?
         .set_default("server.cert.store.signing_key_path", default_key_path)?

--- a/src/config.rs
+++ b/src/config.rs
@@ -1578,7 +1578,6 @@ mod tests {
             ("vault.mount", "kv-secrets"),
             ("vault.path_prefix", "services/status-list"),
             ("vault.namespace", "tenant-1"),
-            ("vault.secrets_cache_ttl", "60"),
             ("vault.timeout_secs", "15"),
         ])
         .expect("Failed to load overridden config");
@@ -1608,7 +1607,7 @@ mod tests {
         // Vault AppRole overrides with secret_id_path
         let secret_file = std::env::temp_dir().join(format!(
             "vault_secret_id_test_{}.txt",
-            time::UtcDateTime::now().nanosecond()
+            time::OffsetDateTime::now_utc().nanosecond()
         ));
         std::fs::write(&secret_file, "  file-secret-id-value \n").expect("write secret file");
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -209,7 +209,6 @@ pub struct CertConfig {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct CertStoreConfig {
-    pub source: String,
     #[serde(default)]
     pub certificate_path: Option<String>,
     #[serde(default)]
@@ -600,9 +599,6 @@ pub struct DatabaseConfig {
 #[derive(Debug, Clone, Deserialize)]
 pub struct AwsConfig {
     pub region: String,
-    /// Cache TTL for AWS Secrets Manager entries in seconds.
-    /// Setting this to 0 disables caching entirely.
-    pub secrets_cache_ttl: u64,
     pub s3_bucket: String,
     pub s3_key_prefix: String,
 }
@@ -620,9 +616,6 @@ pub struct VaultConfig {
     /// Optional Vault Enterprise / OpenBao namespace.
     #[serde(default)]
     pub namespace: Option<String>,
-    /// Cache TTL for Vault secrets in seconds.
-    /// Setting this to 0 disables caching entirely.
-    pub secrets_cache_ttl: u64,
     /// HTTP request timeout in seconds.
     pub timeout_secs: u64,
 }
@@ -818,7 +811,6 @@ fn base_builder() -> Result<ConfigBuilder<DefaultState>, ConfigError> {
         .set_default("redis.uri", "")?
         .set_default("redis.require_client_auth", false)?
         .set_default("redis.cert_cache_ttl", 3600)?
-        .set_default("aws.secrets_cache_ttl", 300)?
         .set_default("aws.s3_bucket", "status-list-adorsys")?
         .set_default("aws.s3_key_prefix", "")?
         .set_default(
@@ -837,7 +829,6 @@ fn base_builder() -> Result<ConfigBuilder<DefaultState>, ConfigError> {
         .set_default("server.cert.signing_key_cache_ttl", 0)?
         .set_default("server.cert.chain_cache_ttl", default_chain_cache_ttl)?
         .set_default("server.cert.renewal_cron_schedule", "0 0 0 * * *")?
-        .set_default("server.cert.store.source", "filesystem")?
         .set_default("server.cert.store.certificate_path", default_cert_path)?
         .set_default("server.cert.store.signing_key_path", default_key_path)?
         .set_default("server.cert.store.certificate_key", Option::<String>::None)?
@@ -848,7 +839,6 @@ fn base_builder() -> Result<ConfigBuilder<DefaultState>, ConfigError> {
         .set_default("vault.mount", "secret")?
         .set_default("vault.path_prefix", "")?
         .set_default("vault.namespace", Option::<String>::None)?
-        .set_default("vault.secrets_cache_ttl", 300)?
         .set_default("vault.timeout_secs", 30)?
         .set_default("cache.ttl", 5 * 60)?
         .set_default("cache.max_capacity", 100)?
@@ -930,7 +920,6 @@ mod tests {
         assert_eq!(config.server.cert.material_backend, "memory");
         assert_eq!(config.server.cert.material_cache_ttl, 300);
         assert_eq!(config.server.cert.signing_key_cache_ttl, 0);
-        assert_eq!(config.server.cert.store.source, "filesystem");
         assert_eq!(
             config.server.cert.store.certificate_path,
             expected_cert_path
@@ -1000,7 +989,6 @@ mod tests {
             ("server.cert.renewal_cron_schedule", "0 0 12 * * *"),
             ("server.cert.dns_challenge_server_url", "http://pebble:8055"),
             ("aws.region", "us-west-2"),
-            ("aws.secrets_cache_ttl", "600"),
             ("aws.s3_bucket", "my-custom-bucket"),
             ("aws.s3_key_prefix", "status-list/prod"),
             ("cache.ttl", "600"),
@@ -1045,7 +1033,6 @@ mod tests {
             "https://acme-v02.api.letsencrypt.org/directory"
         );
         assert_eq!(overridden.aws.region, "us-west-2");
-        assert_eq!(overridden.aws.secrets_cache_ttl, 600);
         assert_eq!(overridden.aws.s3_bucket, "my-custom-bucket");
         assert_eq!(overridden.aws.s3_key_prefix, "status-list/prod");
         assert_eq!(overridden.cache.ttl, 600);

--- a/src/config.rs
+++ b/src/config.rs
@@ -189,8 +189,6 @@ pub struct CertConfig {
     #[serde(default)]
     pub eku: Vec<u64>,
     pub acme_directory_url: String,
-    /// Cache TTL for certificate material reads in seconds. `0` disables this cache.
-    pub material_cache_ttl: u64,
     /// Cache TTL for private signing-key reads in seconds. `0` disables this cache.
     pub signing_key_cache_ttl: u64,
     pub renewal_cron_schedule: String,
@@ -813,7 +811,6 @@ fn base_builder() -> Result<ConfigBuilder<DefaultState>, ConfigError> {
             "server.cert.acme_directory_url",
             "https://acme-v02.api.letsencrypt.org/directory",
         )?
-        .set_default("server.cert.material_cache_ttl", 300)?
         .set_default("server.cert.signing_key_cache_ttl", 0)?
         .set_default("server.cert.renewal_cron_schedule", "0 0 0 * * *")?
         .set_default("server.cert.store.certificate_path", default_cert_path)?
@@ -904,7 +901,6 @@ mod tests {
         let (expected_strategy, expected_cert_path, expected_key_path) =
             ("store", Option::<String>::None, Option::<String>::None);
         assert_eq!(config.server.cert.provisioning_strategy, expected_strategy);
-        assert_eq!(config.server.cert.material_cache_ttl, 300);
         assert_eq!(config.server.cert.signing_key_cache_ttl, 0);
         assert_eq!(
             config.server.cert.store.certificate_path,
@@ -967,7 +963,6 @@ mod tests {
             ("server.cert.organization", "Test Org"),
             ("server.cert.eku", "1,3,6,1,5,5,7,3,30"),
             ("server.cert.provisioning_strategy", "store"),
-            ("server.cert.material_cache_ttl", "120"),
             ("server.cert.signing_key_cache_ttl", "0"),
             ("server.cert.store.certificate_path", "/certs/tls.crt"),
             ("server.cert.store.signing_key_path", "/certs/tls.key"),
@@ -1030,7 +1025,6 @@ mod tests {
             Some("http://pebble:8055")
         );
         assert_eq!(overridden.server.cert.provisioning_strategy, "store");
-        assert_eq!(overridden.server.cert.material_cache_ttl, 120);
         assert_eq!(overridden.server.cert.signing_key_cache_ttl, 0);
         assert_eq!(
             overridden.server.cert.store.certificate_path.as_deref(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -189,9 +189,6 @@ pub struct CertConfig {
     #[serde(default)]
     pub eku: Vec<u64>,
     pub acme_directory_url: String,
-    /// Primary backend for server cryptographic material (`memory`,
-    /// `aws_secrets_manager`, or `vault` when compiled in).
-    pub material_backend: String,
     /// Cache TTL for certificate material reads in seconds. `0` disables this cache.
     pub material_cache_ttl: u64,
     /// Cache TTL for private signing-key reads in seconds. `0` disables this cache.
@@ -824,7 +821,6 @@ fn base_builder() -> Result<ConfigBuilder<DefaultState>, ConfigError> {
             "server.cert.acme_directory_url",
             "https://acme-v02.api.letsencrypt.org/directory",
         )?
-        .set_default("server.cert.material_backend", "memory")?
         .set_default("server.cert.material_cache_ttl", 300)?
         .set_default("server.cert.signing_key_cache_ttl", 0)?
         .set_default("server.cert.chain_cache_ttl", default_chain_cache_ttl)?
@@ -917,7 +913,6 @@ mod tests {
         let (expected_strategy, expected_cert_path, expected_key_path) =
             ("store", Option::<String>::None, Option::<String>::None);
         assert_eq!(config.server.cert.provisioning_strategy, expected_strategy);
-        assert_eq!(config.server.cert.material_backend, "memory");
         assert_eq!(config.server.cert.material_cache_ttl, 300);
         assert_eq!(config.server.cert.signing_key_cache_ttl, 0);
         assert_eq!(
@@ -981,7 +976,6 @@ mod tests {
             ("server.cert.organization", "Test Org"),
             ("server.cert.eku", "1,3,6,1,5,5,7,3,30"),
             ("server.cert.provisioning_strategy", "store"),
-            ("server.cert.material_backend", "aws_secrets_manager"),
             ("server.cert.material_cache_ttl", "120"),
             ("server.cert.signing_key_cache_ttl", "0"),
             ("server.cert.store.certificate_path", "/certs/tls.crt"),
@@ -1045,10 +1039,6 @@ mod tests {
             Some("http://pebble:8055")
         );
         assert_eq!(overridden.server.cert.provisioning_strategy, "store");
-        assert_eq!(
-            overridden.server.cert.material_backend,
-            "aws_secrets_manager"
-        );
         assert_eq!(overridden.server.cert.material_cache_ttl, 120);
         assert_eq!(overridden.server.cert.signing_key_cache_ttl, 0);
         assert_eq!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -189,6 +189,13 @@ pub struct CertConfig {
     #[serde(default)]
     pub eku: Vec<u64>,
     pub acme_directory_url: String,
+    /// Primary backend for server cryptographic material (`memory`,
+    /// `aws_secrets_manager`, or `vault` when compiled in).
+    pub material_backend: String,
+    /// Cache TTL for certificate material reads in seconds. `0` disables this cache.
+    pub material_cache_ttl: u64,
+    /// Cache TTL for private signing-key reads in seconds. `0` disables this cache.
+    pub signing_key_cache_ttl: u64,
     /// Cache TTL for parsed certificate chains in seconds.
     /// A value of 0 keeps entries in memory indefinitely without expiration.
     pub chain_cache_ttl: u64,
@@ -825,6 +832,9 @@ fn base_builder() -> Result<ConfigBuilder<DefaultState>, ConfigError> {
             "server.cert.acme_directory_url",
             "https://acme-v02.api.letsencrypt.org/directory",
         )?
+        .set_default("server.cert.material_backend", "memory")?
+        .set_default("server.cert.material_cache_ttl", 300)?
+        .set_default("server.cert.signing_key_cache_ttl", 0)?
         .set_default("server.cert.chain_cache_ttl", default_chain_cache_ttl)?
         .set_default("server.cert.renewal_cron_schedule", "0 0 0 * * *")?
         .set_default("server.cert.store.source", "filesystem")?
@@ -917,6 +927,9 @@ mod tests {
         let (expected_strategy, expected_cert_path, expected_key_path) =
             ("store", Option::<String>::None, Option::<String>::None);
         assert_eq!(config.server.cert.provisioning_strategy, expected_strategy);
+        assert_eq!(config.server.cert.material_backend, "memory");
+        assert_eq!(config.server.cert.material_cache_ttl, 300);
+        assert_eq!(config.server.cert.signing_key_cache_ttl, 0);
         assert_eq!(config.server.cert.store.source, "filesystem");
         assert_eq!(
             config.server.cert.store.certificate_path,
@@ -979,6 +992,9 @@ mod tests {
             ("server.cert.organization", "Test Org"),
             ("server.cert.eku", "1,3,6,1,5,5,7,3,30"),
             ("server.cert.provisioning_strategy", "store"),
+            ("server.cert.material_backend", "aws_secrets_manager"),
+            ("server.cert.material_cache_ttl", "120"),
+            ("server.cert.signing_key_cache_ttl", "0"),
             ("server.cert.store.certificate_path", "/certs/tls.crt"),
             ("server.cert.store.signing_key_path", "/certs/tls.key"),
             ("server.cert.renewal_cron_schedule", "0 0 12 * * *"),
@@ -1042,6 +1058,12 @@ mod tests {
             Some("http://pebble:8055")
         );
         assert_eq!(overridden.server.cert.provisioning_strategy, "store");
+        assert_eq!(
+            overridden.server.cert.material_backend,
+            "aws_secrets_manager"
+        );
+        assert_eq!(overridden.server.cert.material_cache_ttl, 120);
+        assert_eq!(overridden.server.cert.signing_key_cache_ttl, 0);
         assert_eq!(
             overridden.server.cert.store.certificate_path.as_deref(),
             Some("/certs/tls.crt")

--- a/src/outbound/mod.rs
+++ b/src/outbound/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "aws")]
+#[cfg(feature = "aws-secrets")]
 pub mod aws;
 pub mod cache;
 pub mod cert;

--- a/src/server/health.rs
+++ b/src/server/health.rs
@@ -229,21 +229,14 @@ impl ReadinessCheck for CertStoreCheck {
     }
 
     async fn check(&self) -> Result<(), String> {
-        let cert_store = self
+        let material_store = self
             .manager
-            .cert_storage()
-            .map_err(|e| format!("cert storage not configured: {e}"))?;
-        crate::cert_manager::storage::Storage::reachable(cert_store)
+            .crypto_material_storage()
+            .map_err(|e| format!("cryptographic-material backend not configured: {e}"))?;
+        material_store
+            .reachable()
             .await
-            .map_err(|e| format!("cert store unreachable: {e}"))?;
-
-        let secrets_store = self
-            .manager
-            .secrets_storage()
-            .map_err(|e| format!("secrets storage not configured: {e}"))?;
-        crate::cert_manager::storage::Storage::reachable(secrets_store)
-            .await
-            .map_err(|e| format!("secrets store unreachable: {e}"))
+            .map_err(|e| format!("cryptographic-material backend unreachable: {e}"))
     }
 }
 
@@ -500,10 +493,6 @@ mod tests {
 
     #[cfg(feature = "acme")]
     impl ReachabilityStorage {
-        fn reachable() -> Self {
-            Self { reachable: true }
-        }
-
         fn unreachable() -> Self {
             Self { reachable: false }
         }
@@ -535,7 +524,7 @@ mod tests {
 
     #[cfg(feature = "acme")]
     #[tokio::test]
-    async fn ready_fails_when_cert_storage_is_reachable_but_secrets_storage_is_not() {
+    async fn ready_fails_when_crypto_material_backend_is_unreachable() {
         init_crypto();
 
         let manager = CertManager::new(
@@ -545,8 +534,7 @@ mod tests {
             "https://acme.example.com/directory",
         )
         .expect("build cert manager")
-        .with_cert_storage(ReachabilityStorage::reachable())
-        .with_secrets_storage(ReachabilityStorage::unreachable());
+        .with_crypto_material_storage(ReachabilityStorage::unreachable());
 
         let state =
             app_state_with_checks(vec![Arc::new(CertStoreCheck::new(Arc::new(manager)))]).await;

--- a/src/server/health.rs
+++ b/src/server/health.rs
@@ -229,11 +229,11 @@ impl ReadinessCheck for CertStoreCheck {
     }
 
     async fn check(&self) -> Result<(), String> {
-        let material_store = self
+        let crypto_store = self
             .manager
-            .crypto_material_storage()
+            .crypto_storage()
             .map_err(|e| format!("cryptographic-material backend not configured: {e}"))?;
-        material_store
+        crypto_store
             .reachable()
             .await
             .map_err(|e| format!("cryptographic-material backend unreachable: {e}"))
@@ -534,7 +534,7 @@ mod tests {
             "https://acme.example.com/directory",
         )
         .expect("build cert manager")
-        .with_crypto_material_storage(ReachabilityStorage::unreachable());
+        .with_crypto_storage(ReachabilityStorage::unreachable());
 
         let state =
             app_state_with_checks(vec![Arc::new(CertStoreCheck::new(Arc::new(manager)))]).await;

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -231,10 +231,9 @@ async fn build_state_impl(config: &AppConfig) -> EyeResult<BuildStateResult> {
             .email(&config.server.cert.email)
             .organization(config.server.cert.organization.as_deref())
             .acme_directory_url(&config.server.cert.acme_directory_url)
-            .crypto_cache_policy(CryptoCachePolicy::new(
-                Duration::from_secs(config.server.cert.material_cache_ttl),
-                Duration::from_secs(config.server.cert.signing_key_cache_ttl),
-            ))
+            .crypto_cache_policy(CryptoCachePolicy::new(Duration::from_secs(
+                config.server.cert.signing_key_cache_ttl,
+            )))
             .crypto_storage(material_storage)
             .eku(&config.server.cert.eku);
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -47,7 +47,8 @@ use crate::cert_manager::challenge::{
 use crate::cert_manager::http_client::DefaultHttpClient;
 #[cfg(feature = "acme")]
 use crate::cert_manager::{
-    CertManager, StoreProvisioningStrategy, storage::MemoryStorage, storage::Storage,
+    CertManager, StoreProvisioningStrategy,
+    storage::{CryptoMaterialCachePolicy, MemoryStorage, Storage},
 };
 use crate::config::{Config as AppConfig, DatabaseBackend};
 #[cfg(feature = "acme")]
@@ -59,16 +60,12 @@ use crate::domain::{
     service::Service,
 };
 #[cfg(feature = "aws")]
-use crate::outbound::aws::AwsS3;
-#[cfg(all(feature = "aws", not(feature = "vault")))]
 use crate::outbound::aws::AwsSecretsManager;
 use crate::outbound::cache::MokaStatusListCache;
 #[cfg(feature = "acme")]
 use crate::outbound::cert::AcmeCertificateProvider;
 #[cfg(feature = "memory")]
 use crate::outbound::memory::{MemoryCredentials, MemoryStatusListSnapshotRepo, MemoryStatusLists};
-#[cfg(feature = "redis")]
-use crate::outbound::redis::Redis;
 #[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
 use crate::outbound::sql::{
     Migrator, SeaOrmStore, SqlCredentialRepo, SqlStatusListRepo, SqlStatusListSnapshotRepo,
@@ -218,98 +215,7 @@ async fn build_state_impl(config: &AppConfig) -> EyeResult<BuildStateResult> {
     ) = {
         let app_env = std::env::var("APP_ENV").unwrap_or(ENV_DEVELOPMENT.to_string());
         let cert_domains = [config.server.domain.as_str()];
-        let secrets_storage: Box<dyn Storage> = {
-            #[cfg(feature = "vault")]
-            {
-                tracing::info!("Using Vault KV v2 as secrets backend");
-                Box::new(
-                    VaultClient::builder(&config.vault.addr, config.vault.token.clone())
-                        .mount(&config.vault.mount)
-                        .path_prefix(&config.vault.path_prefix)
-                        .namespace(config.vault.namespace.as_deref())
-                        .secrets_cache_ttl(Duration::from_secs(config.vault.secrets_cache_ttl))
-                        .timeout(Duration::from_secs(config.vault.timeout_secs))
-                        .build()?,
-                )
-            }
-            #[cfg(not(feature = "vault"))]
-            {
-                #[cfg(feature = "aws")]
-                {
-                    if config
-                        .server
-                        .cert
-                        .store
-                        .source
-                        .eq_ignore_ascii_case("aws_secrets_manager")
-                    {
-                        let aws_config = aws_config::defaults(BehaviorVersion::latest())
-                            .region(Region::new(config.aws.region.clone()))
-                            .load()
-                            .await;
-                        Box::new(
-                            AwsSecretsManager::new(
-                                &aws_config,
-                                Duration::from_secs(config.aws.secrets_cache_ttl),
-                            )
-                            .await?,
-                        )
-                    } else {
-                        Box::new(MemoryStorage::default())
-                    }
-                }
-                #[cfg(not(feature = "aws"))]
-                Box::new(MemoryStorage::default())
-            }
-        };
-
-        // Uses S3 when available and configured, otherwise memory.
-        let cert_storage: Box<dyn Storage> = {
-            #[cfg(feature = "aws")]
-            {
-                if !config.aws.s3_bucket.is_empty() {
-                    let aws_config = aws_config::defaults(BehaviorVersion::latest())
-                        .region(Region::new(config.aws.region.clone()))
-                        .load()
-                        .await;
-
-                    #[cfg(feature = "redis")]
-                    let cache_opt = if !config.redis.uri.expose_secret().is_empty() {
-                        match config.redis.start(None, None, None).await {
-                            Ok(redis_conn) => {
-                                Some(Redis::new(redis_conn).with_ttl(config.redis.cert_cache_ttl))
-                            }
-                            Err(e) => {
-                                tracing::warn!(
-                                    "Redis connection failed ({}); certificate cache disabled, falling back to direct S3",
-                                    e
-                                );
-                                None
-                            }
-                        }
-                    } else {
-                        None
-                    };
-                    #[cfg(not(feature = "redis"))]
-                    let cache_opt = None;
-
-                    let s3 = AwsS3::new(
-                        &aws_config,
-                        &config.aws.s3_bucket,
-                        &config.aws.region,
-                        &config.aws.s3_key_prefix,
-                    );
-                    match cache_opt {
-                        Some(c) => Box::new(s3.with_cache(c)),
-                        None => Box::new(s3),
-                    }
-                } else {
-                    Box::new(MemoryStorage::default())
-                }
-            }
-            #[cfg(not(feature = "aws"))]
-            Box::new(MemoryStorage::default())
-        };
+        let material_storage = build_crypto_material_storage(config).await?;
 
         let cert_strategy = store_certificate_strategy(config)?;
         let uses_acme_strategy = config
@@ -323,8 +229,11 @@ async fn build_state_impl(config: &AppConfig) -> EyeResult<BuildStateResult> {
             .email(&config.server.cert.email)
             .organization(config.server.cert.organization.as_deref())
             .acme_directory_url(&config.server.cert.acme_directory_url)
-            .cert_storage(cert_storage)
-            .secrets_storage(secrets_storage)
+            .crypto_material_cache_policy(CryptoMaterialCachePolicy::new(
+                Duration::from_secs(config.server.cert.material_cache_ttl),
+                Duration::from_secs(config.server.cert.signing_key_cache_ttl),
+            ))
+            .crypto_material_storage(material_storage)
             .chain_cache_ttl(Duration::from_secs(config.server.cert.chain_cache_ttl))
             .eku(&config.server.cert.eku);
 
@@ -518,6 +427,61 @@ fn acme_dns_credentials(account: &crate::config::AcmeDnsAccount) -> AcmeDnsCrede
         password: account.password.clone(),
         subdomain: account.subdomain.clone(),
     }
+}
+
+#[cfg(feature = "acme")]
+async fn build_crypto_material_storage(config: &AppConfig) -> EyeResult<Box<dyn Storage>> {
+    let backend = config.server.cert.material_backend.as_str();
+    if backend.eq_ignore_ascii_case("memory") {
+        tracing::info!("Using in-memory cryptographic-material backend");
+        return Ok(Box::new(MemoryStorage::default()));
+    }
+
+    if backend.eq_ignore_ascii_case("vault") {
+        #[cfg(feature = "vault")]
+        {
+            tracing::info!("Using Vault KV v2 as cryptographic-material backend");
+            return Ok(Box::new(
+                VaultClient::builder(&config.vault.addr, config.vault.token.clone())
+                    .mount(&config.vault.mount)
+                    .path_prefix(&config.vault.path_prefix)
+                    .namespace(config.vault.namespace.as_deref())
+                    .secrets_cache_ttl(Duration::ZERO)
+                    .timeout(Duration::from_secs(config.vault.timeout_secs))
+                    .build()?,
+            ));
+        }
+        #[cfg(not(feature = "vault"))]
+        {
+            return Err(eyre!(
+                "cryptographic-material backend 'vault' configured, but 'vault' feature is disabled"
+            ));
+        }
+    }
+
+    if backend.eq_ignore_ascii_case("aws_secrets_manager") {
+        #[cfg(feature = "aws")]
+        {
+            tracing::info!("Using AWS Secrets Manager as cryptographic-material backend");
+            let aws_config = aws_config::defaults(BehaviorVersion::latest())
+                .region(Region::new(config.aws.region.clone()))
+                .load()
+                .await;
+            return Ok(Box::new(
+                AwsSecretsManager::new(&aws_config, Duration::ZERO).await?,
+            ));
+        }
+        #[cfg(not(feature = "aws"))]
+        {
+            return Err(eyre!(
+                "cryptographic-material backend 'aws_secrets_manager' configured, but 'aws' feature is disabled"
+            ));
+        }
+    }
+
+    Err(eyre!(
+        "unsupported cryptographic-material backend '{backend}'; expected 'memory', 'aws_secrets_manager', or 'vault'"
+    ))
 }
 
 #[cfg(feature = "acme")]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -45,10 +45,12 @@ use crate::cert_manager::challenge::{
 };
 #[cfg(feature = "acme")]
 use crate::cert_manager::http_client::DefaultHttpClient;
+#[cfg(all(feature = "acme", not(feature = "vault"), not(feature = "aws-secrets")))]
+use crate::cert_manager::storage::MemoryStorage;
 #[cfg(feature = "acme")]
 use crate::cert_manager::{
     CertManager, StoreProvisioningStrategy,
-    storage::{CryptoCachePolicy, MemoryStorage, Storage},
+    storage::{CryptoCachePolicy, Storage},
 };
 use crate::config::{Config as AppConfig, DatabaseBackend};
 #[cfg(feature = "acme")]
@@ -59,7 +61,7 @@ use crate::domain::{
     ports::{CertificateProvider, CredentialRepo, StatusListRepo, StatusListSnapshotRepo},
     service::Service,
 };
-#[cfg(feature = "aws-secrets")]
+#[cfg(all(feature = "aws-secrets", not(feature = "vault")))]
 use crate::outbound::aws::AwsSecretsManager;
 use crate::outbound::cache::MokaStatusListCache;
 #[cfg(feature = "acme")]
@@ -318,7 +320,7 @@ async fn build_state_impl(config: &AppConfig) -> EyeResult<BuildStateResult> {
     }
 
     // Redis is optional in this setup. Certificate and signing-key material use
-    // the selected cryptographic-material backend, so Redis is intentionally
+    // the feature-selected cryptographic-material backend, so Redis is intentionally
     // omitted from readiness gating.
 
     #[cfg(feature = "acme")]
@@ -430,58 +432,38 @@ fn acme_dns_credentials(account: &crate::config::AcmeDnsAccount) -> AcmeDnsCrede
 }
 
 #[cfg(feature = "acme")]
-async fn build_crypto_storage(config: &AppConfig) -> EyeResult<Box<dyn Storage>> {
-    let backend = config.server.cert.material_backend.as_str();
-    if backend.eq_ignore_ascii_case("memory") {
+async fn build_crypto_storage(_config: &AppConfig) -> EyeResult<Box<dyn Storage>> {
+    #[cfg(feature = "vault")]
+    {
+        tracing::info!("Using Vault KV v2 as cryptographic-material backend");
+        Ok(Box::new(
+            VaultClient::builder(&_config.vault.addr, _config.vault.token.clone())
+                .mount(&_config.vault.mount)
+                .path_prefix(&_config.vault.path_prefix)
+                .namespace(_config.vault.namespace.as_deref())
+                .secrets_cache_ttl(Duration::ZERO)
+                .timeout(Duration::from_secs(_config.vault.timeout_secs))
+                .build()?,
+        ))
+    }
+
+    #[cfg(all(not(feature = "vault"), feature = "aws-secrets"))]
+    {
+        tracing::info!("Using AWS Secrets Manager as cryptographic-material backend");
+        let aws_config = aws_config::defaults(BehaviorVersion::latest())
+            .region(Region::new(_config.aws.region.clone()))
+            .load()
+            .await;
+        Ok(Box::new(
+            AwsSecretsManager::new(&aws_config, Duration::ZERO).await?,
+        ))
+    }
+
+    #[cfg(all(not(feature = "vault"), not(feature = "aws-secrets")))]
+    {
         tracing::info!("Using in-memory cryptographic-material backend");
-        return Ok(Box::new(MemoryStorage::default()));
+        Ok(Box::new(MemoryStorage::default()))
     }
-
-    if backend.eq_ignore_ascii_case("vault") {
-        #[cfg(feature = "vault")]
-        {
-            tracing::info!("Using Vault KV v2 as cryptographic-material backend");
-            return Ok(Box::new(
-                VaultClient::builder(&config.vault.addr, config.vault.token.clone())
-                    .mount(&config.vault.mount)
-                    .path_prefix(&config.vault.path_prefix)
-                    .namespace(config.vault.namespace.as_deref())
-                    .secrets_cache_ttl(Duration::ZERO)
-                    .timeout(Duration::from_secs(config.vault.timeout_secs))
-                    .build()?,
-            ));
-        }
-        #[cfg(not(feature = "vault"))]
-        {
-            return Err(eyre!(
-                "cryptographic-material backend 'vault' configured, but 'vault' feature is disabled"
-            ));
-        }
-    }
-
-    if backend.eq_ignore_ascii_case("aws_secrets_manager") {
-        #[cfg(feature = "aws-secrets")]
-        {
-            tracing::info!("Using AWS Secrets Manager as cryptographic-material backend");
-            let aws_config = aws_config::defaults(BehaviorVersion::latest())
-                .region(Region::new(config.aws.region.clone()))
-                .load()
-                .await;
-            return Ok(Box::new(
-                AwsSecretsManager::new(&aws_config, Duration::ZERO).await?,
-            ));
-        }
-        #[cfg(not(feature = "aws-secrets"))]
-        {
-            return Err(eyre!(
-                "cryptographic-material backend 'aws_secrets_manager' configured, but 'aws-secrets' feature is disabled"
-            ));
-        }
-    }
-
-    Err(eyre!(
-        "unsupported cryptographic-material backend '{backend}'; expected 'memory', 'aws_secrets_manager', or 'vault'"
-    ))
 }
 
 #[cfg(feature = "acme")]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -48,7 +48,7 @@ use crate::cert_manager::http_client::DefaultHttpClient;
 #[cfg(feature = "acme")]
 use crate::cert_manager::{
     CertManager, StoreProvisioningStrategy,
-    storage::{CryptoMaterialCachePolicy, MemoryStorage, Storage},
+    storage::{CryptoCachePolicy, MemoryStorage, Storage},
 };
 use crate::config::{Config as AppConfig, DatabaseBackend};
 #[cfg(feature = "acme")]
@@ -215,7 +215,7 @@ async fn build_state_impl(config: &AppConfig) -> EyeResult<BuildStateResult> {
     ) = {
         let app_env = std::env::var("APP_ENV").unwrap_or(ENV_DEVELOPMENT.to_string());
         let cert_domains = [config.server.domain.as_str()];
-        let material_storage = build_crypto_material_storage(config).await?;
+        let material_storage = build_crypto_storage(config).await?;
 
         let cert_strategy = store_certificate_strategy(config)?;
         let uses_acme_strategy = config
@@ -229,11 +229,11 @@ async fn build_state_impl(config: &AppConfig) -> EyeResult<BuildStateResult> {
             .email(&config.server.cert.email)
             .organization(config.server.cert.organization.as_deref())
             .acme_directory_url(&config.server.cert.acme_directory_url)
-            .crypto_material_cache_policy(CryptoMaterialCachePolicy::new(
+            .crypto_cache_policy(CryptoCachePolicy::new(
                 Duration::from_secs(config.server.cert.material_cache_ttl),
                 Duration::from_secs(config.server.cert.signing_key_cache_ttl),
             ))
-            .crypto_material_storage(material_storage)
+            .crypto_storage(material_storage)
             .chain_cache_ttl(Duration::from_secs(config.server.cert.chain_cache_ttl))
             .eku(&config.server.cert.eku);
 
@@ -317,9 +317,9 @@ async fn build_state_impl(config: &AppConfig) -> EyeResult<BuildStateResult> {
         readiness = readiness.with_check(AlwaysReady::new("database"));
     }
 
-    // Redis is an optional certificate-cache accelerator in this setup. Startup
-    // falls back to direct certificate storage when Redis cannot connect, so it
-    // is intentionally omitted from readiness gating.
+    // Redis is optional in this setup. Certificate and signing-key material use
+    // the selected cryptographic-material backend, so Redis is intentionally
+    // omitted from readiness gating.
 
     #[cfg(feature = "acme")]
     {
@@ -430,7 +430,7 @@ fn acme_dns_credentials(account: &crate::config::AcmeDnsAccount) -> AcmeDnsCrede
 }
 
 #[cfg(feature = "acme")]
-async fn build_crypto_material_storage(config: &AppConfig) -> EyeResult<Box<dyn Storage>> {
+async fn build_crypto_storage(config: &AppConfig) -> EyeResult<Box<dyn Storage>> {
     let backend = config.server.cert.material_backend.as_str();
     if backend.eq_ignore_ascii_case("memory") {
         tracing::info!("Using in-memory cryptographic-material backend");
@@ -529,14 +529,17 @@ fn store_certificate_strategy(config: &AppConfig) -> EyeResult<Option<StoreProvi
                 signing_key_path,
             )))
         }
-        source if source.eq_ignore_ascii_case("aws_secrets_manager") => {
+        source
+            if source.eq_ignore_ascii_case("aws_secrets_manager")
+                || source.eq_ignore_ascii_case("storage") =>
+        {
             let certificate_key = cert_config
                 .store
                 .certificate_key
                 .as_deref()
                 .ok_or_else(|| {
                     eyre!(
-                        "server.cert.store.certificate_key is required for aws_secrets_manager store provisioning"
+                        "server.cert.store.certificate_key is required for storage-backed store provisioning"
                     )
                 })?;
             let signing_key_key = cert_config
@@ -545,16 +548,16 @@ fn store_certificate_strategy(config: &AppConfig) -> EyeResult<Option<StoreProvi
                 .as_deref()
                 .ok_or_else(|| {
                     eyre!(
-                        "server.cert.store.signing_key_key is required for aws_secrets_manager store provisioning"
+                        "server.cert.store.signing_key_key is required for storage-backed store provisioning"
                     )
                 })?;
-            Ok(Some(StoreProvisioningStrategy::secrets_storage(
+            Ok(Some(StoreProvisioningStrategy::storage(
                 certificate_key,
                 signing_key_key,
             )))
         }
         unsupported => Err(eyre!(
-            "unsupported certificate store source '{unsupported}'; expected 'filesystem' or 'aws_secrets_manager'"
+            "unsupported certificate store source '{unsupported}'; expected 'filesystem', 'storage', or 'aws_secrets_manager'"
         )),
     }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -236,7 +236,6 @@ async fn build_state_impl(config: &AppConfig) -> EyeResult<BuildStateResult> {
                 Duration::from_secs(config.server.cert.signing_key_cache_ttl),
             ))
             .crypto_storage(material_storage)
-            .chain_cache_ttl(Duration::from_secs(config.server.cert.chain_cache_ttl))
             .eku(&config.server.cert.eku);
 
         cert_manager_builder = if uses_acme_strategy {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -434,18 +434,20 @@ async fn build_crypto_storage(_config: &AppConfig) -> EyeResult<Box<dyn Storage>
     #[cfg(feature = "vault")]
     {
         tracing::info!("Using Vault KV v2 as secrets backend");
-        let secret_id = config.vault.resolve_secret_id()?;
-        Box::new(
-            VaultClient::builder(&config.vault.addr, &config.vault.role_id, secret_id)
-                .auth_mount(&config.vault.auth_mount)
-                .mount(&config.vault.mount)
-                .path_prefix(&config.vault.path_prefix)
-                .namespace(config.vault.namespace.as_deref())
-                .secrets_cache_ttl(Duration::from_secs(config.vault.secrets_cache_ttl))
-                .timeout(Duration::from_secs(config.vault.timeout_secs))
+        let secret_id = _config.vault.resolve_secret_id()?;
+        Ok(Box::new(
+            VaultClient::builder(&_config.vault.addr, &_config.vault.role_id, secret_id)
+                .auth_mount(&_config.vault.auth_mount)
+                .mount(&_config.vault.mount)
+                .path_prefix(&_config.vault.path_prefix)
+                .namespace(_config.vault.namespace.as_deref())
+                .secrets_cache_ttl(Duration::from_secs(
+                    _config.server.cert.signing_key_cache_ttl,
+                ))
+                .timeout(Duration::from_secs(_config.vault.timeout_secs))
                 .build()
                 .await?,
-        )
+        ))
     }
 
     #[cfg(all(not(feature = "vault"), feature = "aws-secrets"))]
@@ -456,7 +458,11 @@ async fn build_crypto_storage(_config: &AppConfig) -> EyeResult<Box<dyn Storage>
             .load()
             .await;
         Ok(Box::new(
-            AwsSecretsManager::new(&aws_config, Duration::ZERO).await?,
+            AwsSecretsManager::new(
+                &aws_config,
+                Duration::from_secs(_config.server.cert.signing_key_cache_ttl),
+            )
+            .await?,
         ))
     }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,6 +1,6 @@
 //! Composition root assembling outbound infrastructure adapters and creating the AppState container.
 
-#[cfg(feature = "aws")]
+#[cfg(feature = "aws-secrets")]
 use aws_config::{BehaviorVersion, Region};
 #[cfg(any(
     feature = "acme",
@@ -36,7 +36,7 @@ use std::time::Duration;
 #[cfg(feature = "acme")]
 use tracing::warn;
 
-#[cfg(feature = "aws")]
+#[cfg(feature = "aws-secrets")]
 use crate::cert_manager::challenge::AwsRoute53DnsProvider;
 #[cfg(feature = "acme")]
 use crate::cert_manager::challenge::{
@@ -59,7 +59,7 @@ use crate::domain::{
     ports::{CertificateProvider, CredentialRepo, StatusListRepo, StatusListSnapshotRepo},
     service::Service,
 };
-#[cfg(feature = "aws")]
+#[cfg(feature = "aws-secrets")]
 use crate::outbound::aws::AwsSecretsManager;
 use crate::outbound::cache::MokaStatusListCache;
 #[cfg(feature = "acme")]
@@ -460,7 +460,7 @@ async fn build_crypto_storage(config: &AppConfig) -> EyeResult<Box<dyn Storage>>
     }
 
     if backend.eq_ignore_ascii_case("aws_secrets_manager") {
-        #[cfg(feature = "aws")]
+        #[cfg(feature = "aws-secrets")]
         {
             tracing::info!("Using AWS Secrets Manager as cryptographic-material backend");
             let aws_config = aws_config::defaults(BehaviorVersion::latest())
@@ -471,10 +471,10 @@ async fn build_crypto_storage(config: &AppConfig) -> EyeResult<Box<dyn Storage>>
                 AwsSecretsManager::new(&aws_config, Duration::ZERO).await?,
             ));
         }
-        #[cfg(not(feature = "aws"))]
+        #[cfg(not(feature = "aws-secrets"))]
         {
             return Err(eyre!(
-                "cryptographic-material backend 'aws_secrets_manager' configured, but 'aws' feature is disabled"
+                "cryptographic-material backend 'aws_secrets_manager' configured, but 'aws-secrets' feature is disabled"
             ));
         }
     }
@@ -504,60 +504,33 @@ fn store_certificate_strategy(config: &AppConfig) -> EyeResult<Option<StoreProvi
         ));
     }
 
-    match cert_config.store.source.as_str() {
-        source if source.eq_ignore_ascii_case("filesystem") => {
-            let certificate_path = cert_config
-                .store
-                .certificate_path
-                .as_deref()
-                .ok_or_else(|| {
-                    eyre!(
-                        "server.cert.store.certificate_path is required for filesystem store provisioning"
-                    )
-                })?;
-            let signing_key_path = cert_config
-                .store
-                .signing_key_path
-                .as_deref()
-                .ok_or_else(|| {
-                    eyre!(
-                        "server.cert.store.signing_key_path is required for filesystem store provisioning"
-                    )
-                })?;
-            Ok(Some(StoreProvisioningStrategy::filesystem(
-                certificate_path,
-                signing_key_path,
-            )))
-        }
-        source
-            if source.eq_ignore_ascii_case("aws_secrets_manager")
-                || source.eq_ignore_ascii_case("storage") =>
-        {
-            let certificate_key = cert_config
-                .store
-                .certificate_key
-                .as_deref()
-                .ok_or_else(|| {
-                    eyre!(
-                        "server.cert.store.certificate_key is required for storage-backed store provisioning"
-                    )
-                })?;
-            let signing_key_key = cert_config
-                .store
-                .signing_key_key
-                .as_deref()
-                .ok_or_else(|| {
-                    eyre!(
-                        "server.cert.store.signing_key_key is required for storage-backed store provisioning"
-                    )
-                })?;
-            Ok(Some(StoreProvisioningStrategy::storage(
-                certificate_key,
-                signing_key_key,
-            )))
-        }
-        unsupported => Err(eyre!(
-            "unsupported certificate store source '{unsupported}'; expected 'filesystem', 'storage', or 'aws_secrets_manager'"
+    let filesystem = (
+        cert_config.store.certificate_path.as_deref(),
+        cert_config.store.signing_key_path.as_deref(),
+    );
+    let storage = (
+        cert_config.store.certificate_key.as_deref(),
+        cert_config.store.signing_key_key.as_deref(),
+    );
+
+    match (filesystem, storage) {
+        ((Some(certificate_path), Some(signing_key_path)), (None, None)) => Ok(Some(
+            StoreProvisioningStrategy::filesystem(certificate_path, signing_key_path),
+        )),
+        ((None, None), (Some(certificate_key), Some(signing_key_key))) => Ok(Some(
+            StoreProvisioningStrategy::storage(certificate_key, signing_key_key),
+        )),
+        ((Some(_), Some(_)), (Some(_), Some(_))) => Err(eyre!(
+            "store provisioning must configure either filesystem paths or material backend keys, not both"
+        )),
+        ((Some(_), None) | (None, Some(_)), _) => Err(eyre!(
+            "filesystem store provisioning requires both server.cert.store.certificate_path and server.cert.store.signing_key_path"
+        )),
+        (_, (Some(_), None) | (None, Some(_))) => Err(eyre!(
+            "storage-backed store provisioning requires both server.cert.store.certificate_key and server.cert.store.signing_key_key"
+        )),
+        ((None, None), (None, None)) => Err(eyre!(
+            "store provisioning requires either filesystem paths or material backend keys"
         )),
     }
 }
@@ -569,7 +542,7 @@ async fn build_dns_challenge_handler(
     cert_domains: &[&str],
 ) -> EyeResult<Dns01Handler> {
     let handler = match provider {
-        #[cfg(feature = "aws")]
+        #[cfg(feature = "aws-secrets")]
         ResolvedDnsProvider::Route53 => {
             let aws_config = aws_config::defaults(BehaviorVersion::latest())
                 .region(Region::new(config.aws.region.clone()))
@@ -577,10 +550,10 @@ async fn build_dns_challenge_handler(
                 .await;
             Dns01Handler::new(AwsRoute53DnsProvider::new(&aws_config))
         }
-        #[cfg(not(feature = "aws"))]
+        #[cfg(not(feature = "aws-secrets"))]
         ResolvedDnsProvider::Route53 => {
             return Err(eyre!(
-                "Route53 DNS provider requested, but 'aws' feature is disabled at compile time."
+                "Route53 DNS provider requested, but 'aws-secrets' feature is disabled at compile time."
             ));
         }
         ResolvedDnsProvider::Cloudflare(cfg) => {
@@ -662,7 +635,7 @@ mod tests {
         let domain = config.server.domain.clone();
         let domains = [domain.as_str()];
 
-        #[cfg(feature = "aws")]
+        #[cfg(feature = "aws-secrets")]
         assert!(
             build_dns_challenge_handler(DnsProviderKind::Route53, &mut config, &domains).is_ok()
         );

--- a/src/utils/cache/cert_chain.rs
+++ b/src/utils/cache/cert_chain.rs
@@ -135,13 +135,14 @@ mod tests {
     use super::*;
     use crate::{
         config::{TelemetryConfig, TelemetryEnvironment},
-        utils::metrics::setup_metrics,
+        utils::metrics::{metrics_test_lock, setup_metrics},
     };
     use opentelemetry_sdk::Resource;
     use prometheus::{Encoder, Registry, TextEncoder};
 
     #[tokio::test]
     async fn test_counters_are_exported_to_prometheus() {
+        let _metrics_guard = metrics_test_lock();
         let registry = Registry::new();
         let config = TelemetryConfig {
             environment: TelemetryEnvironment::Development,

--- a/src/utils/cache/cert_chain.rs
+++ b/src/utils/cache/cert_chain.rs
@@ -100,11 +100,6 @@ impl CertChainCache {
         self.inner.insert(key, value).await;
     }
 
-    #[cfg(test)]
-    pub(crate) async fn invalidate(&self, key: &str) {
-        self.inner.invalidate(key).await;
-    }
-
     fn attributes(&self) -> Vec<KeyValue> {
         if self.domain_label.is_empty() {
             vec![]

--- a/src/utils/cache/cert_chain.rs
+++ b/src/utils/cache/cert_chain.rs
@@ -140,8 +140,8 @@ mod tests {
     use opentelemetry_sdk::Resource;
     use prometheus::{Encoder, Registry, TextEncoder};
 
-    #[tokio::test]
-    async fn test_counters_are_exported_to_prometheus() {
+    #[test]
+    fn test_counters_are_exported_to_prometheus() {
         let _metrics_guard = metrics_test_lock();
         let registry = Registry::new();
         let config = TelemetryConfig {
@@ -162,16 +162,23 @@ mod tests {
         let cache = CertChainCache::new(Duration::ZERO, "example.com");
         cache.init_counters();
 
-        let chain: CertificateChain = Arc::from(vec!["a".to_string()]);
-        cache.insert("k".to_string(), chain.clone()).await;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime");
 
-        // hit
-        assert!(cache.get("k").await.is_some());
-        // miss
-        assert!(cache.get("missing").await.is_none());
-        // replacement
-        let new_chain: CertificateChain = Arc::from(vec!["b".to_string()]);
-        cache.replace("k".to_string(), new_chain).await;
+        rt.block_on(async {
+            let chain: CertificateChain = Arc::from(vec!["a".to_string()]);
+            cache.insert("k".to_string(), chain.clone()).await;
+
+            // hit
+            assert!(cache.get("k").await.is_some());
+            // miss
+            assert!(cache.get("missing").await.is_none());
+            // replacement
+            let new_chain: CertificateChain = Arc::from(vec!["b".to_string()]);
+            cache.replace("k".to_string(), new_chain).await;
+        });
 
         assert_counter_value(&registry, HIT_METRIC, 1.0);
         assert_counter_value(&registry, MISS_METRIC, 1.0);

--- a/src/utils/cache/cert_chain.rs
+++ b/src/utils/cache/cert_chain.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use moka::future::Cache;
 use opentelemetry::{
@@ -19,15 +19,8 @@ const REPLACEMENT_METRIC: &str = "certificate_chain_cache_replacements";
 /// instance owns exactly one `CertChainCache`, so the cache holds at most one
 /// entry per running process.
 ///
-/// # TTL semantics
-///
-/// A **zero** TTL (`Duration::ZERO`) keeps the cache active with **no expiry**;
-/// entries persist until explicitly replaced by the provisioning hook.
-///
-/// This intentionally differs from [`StatusListCache`](crate::domain::ports::StatusListCache),
-/// where `ttl = 0` **disables** the cache entirely (inserts expire immediately).
-/// The rationale is that certificate chains only change when explicitly provisioned,
-/// making the "never expire" behavior safe for single-replica deployments.
+/// Entries do not expire by time. They stay cached until provisioning or
+/// renewal replaces the entry through the certificate manager.
 #[derive(Clone)]
 pub(crate) struct CertChainCache {
     inner: Cache<String, CertificateChain>,
@@ -50,7 +43,7 @@ impl CertChainCache {
     /// provider. Telemetry initialization must install the provider before
     /// application state constructs this cache; otherwise these handles would
     /// remain no-op for the lifetime of the process.
-    pub(crate) fn new(ttl: Duration, domain: impl AsRef<str>) -> Self {
+    pub(crate) fn new(domain: impl AsRef<str>) -> Self {
         let meter = global::meter("status-list-server");
 
         let hit_counter = meter
@@ -66,16 +59,7 @@ impl CertChainCache {
             .with_description("Certificate chain cache replacements (post-provisioning)")
             .build();
 
-        let builder = Cache::builder().max_capacity(CACHE_CAPACITY);
-        let inner = if ttl.is_zero() {
-            tracing::warn!(
-                "chain_cache_ttl=0: chain cached for process lifetime; \
-                renewals on other replicas will not be observed"
-            );
-            builder.build()
-        } else {
-            builder.time_to_live(ttl).build()
-        };
+        let inner = Cache::builder().max_capacity(CACHE_CAPACITY).build();
         Self {
             inner,
             domain_label: domain.as_ref().to_string(),
@@ -159,7 +143,7 @@ mod tests {
         )
         .expect("metrics setup");
 
-        let cache = CertChainCache::new(Duration::ZERO, "example.com");
+        let cache = CertChainCache::new("example.com");
         cache.init_counters();
 
         let rt = tokio::runtime::Builder::new_current_thread()

--- a/src/utils/cache/mod.rs
+++ b/src/utils/cache/mod.rs
@@ -4,27 +4,23 @@ mod cert_chain;
 #[cfg(feature = "acme")]
 pub(crate) use cert_chain::{CertChainCache, CertificateChain};
 
-/// Pins the deliberately-opposite `ttl = 0` semantics of the two caches.
-///
-/// `CertChainCache` treats zero as "never expire"; the status-list cache treats
-/// zero as "disabled".
+/// Pins that certificate chain cache entries stay cached until replacement.
 #[cfg(all(test, feature = "acme"))]
-mod ttl_zero_semantics_matrix {
+mod cert_chain_cache_semantics {
     use std::sync::Arc;
-    use std::time::Duration;
 
     use super::*;
 
     #[tokio::test]
-    async fn cert_chain_cache_zero_ttl_caches_indefinitely() {
-        let cache = CertChainCache::new(Duration::ZERO, "");
+    async fn cert_chain_cache_entries_do_not_expire_by_time() {
+        let cache = CertChainCache::new("");
         let chain: CertificateChain = Arc::from(vec!["cert".to_string()]);
         cache.insert("key".to_string(), chain.clone()).await;
 
         let cached: Option<CertificateChain> = cache.get("key").await;
         assert!(
             cached.is_some(),
-            "CertChainCache with ttl=0: entries must cache indefinitely (never expire)"
+            "CertChainCache entries must stay cached until explicit replacement"
         );
     }
 }

--- a/src/utils/cert_manager.rs
+++ b/src/utils/cert_manager.rs
@@ -343,7 +343,7 @@ impl CertManager {
 
         // Store the certificate
         self.persist_certificate_data(&cert_data).await?;
-        self.refresh_material_cache(&cert_data.certificate).await?;
+        self.cache_provisioned_chain(&cert_data.certificate).await?;
 
         info!(
             "Certificate obtained successfully. Valid from {} to {}",
@@ -740,7 +740,7 @@ impl CertManager {
     ) -> Result<(), CertError> {
         self.persist_certificate_data(cert_data).await?;
         self.persist_signing_key(signing_key).await?;
-        self.refresh_material_cache(&cert_data.certificate).await
+        self.cache_provisioned_chain(&cert_data.certificate).await
     }
 
     fn parse_cert_chain_parts(&self, cert_pem: &str) -> Result<CertificateChain, CertError> {
@@ -766,14 +766,6 @@ impl CertManager {
         // Replace eagerly so the next request never hits storage for this key.
         self.cert_chain_cache.replace(cert_key, parts).await;
         Ok(())
-    }
-
-    /// Refresh process-local caches after lifecycle-coupled certificate and key material changes.
-    async fn refresh_material_cache(&self, cert_pem: &str) -> Result<(), CertError> {
-        self.crypto_storage()?
-            .invalidate_signing_key(&self.signing_secret_id())
-            .await?;
-        self.cache_provisioned_chain(cert_pem).await
     }
 
     #[inline]

--- a/src/utils/cert_manager.rs
+++ b/src/utils/cert_manager.rs
@@ -87,12 +87,6 @@ impl Default for CertManagerMetrics {
     }
 }
 
-/// Default cache TTL when no override is supplied.
-///
-/// Exported as a single source of truth: `Config::load` references this
-/// constant so the runtime default and the code fallback always agree.
-pub const DEFAULT_CHAIN_CACHE_TTL: Duration = Duration::from_secs(3600);
-
 /// Struct that hold the certificate and its metadata
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CertificateData {
@@ -167,7 +161,7 @@ impl CertManager {
 
         let domains: Vec<String> = domains.into_iter().map(|d| d.into()).collect();
         let domain_label = domains.first().map(String::as_str).unwrap_or_default();
-        let cert_chain_cache = CertChainCache::new(DEFAULT_CHAIN_CACHE_TTL, domain_label);
+        let cert_chain_cache = CertChainCache::new(domain_label);
 
         Ok(Self {
             crypto_storage: None,
@@ -222,31 +216,6 @@ impl CertManager {
         strategy: impl CertProvisioningStrategy + 'static,
     ) -> Self {
         self.provisioning_strategy = Box::new(strategy);
-        self
-    }
-
-    /// Override the in-memory parsed certificate chain cache TTL.
-    ///
-    /// A zero duration keeps the cache active with no TTL safety expiry; cache
-    /// replacement still happens whenever this manager provisions a new certificate.
-    ///
-    /// **Multi-replica deployments:** Only the replica that performs the
-    /// provisioning call (`request_certificate`) replaces its in-memory cache.
-    /// Non-provisioning replicas therefore rely on the TTL as the only refresh
-    /// mechanism for picking up a newly provisioned chain. Set `ttl = 0` only
-    /// when the process is guaranteed to re-provision or restart on every
-    /// rotation — otherwise long-lived replicas with a disabled TTL will serve
-    /// the stale chain until they happen to re-provision.
-    ///
-    /// **Staleness safety:** This caching strategy is safe because the signing
-    /// key is stable across certificate renewals — the provisioning flow reuses
-    /// the stored secret key (`signing_key_pem`). If renewal ever rotates the
-    /// signing key, the staleness window becomes a token-validation outage:
-    /// verifiers would receive the old certificate chain while tokens are
-    /// signed with the new key.
-    pub fn with_cert_chain_cache_ttl(mut self, ttl: Duration) -> Self {
-        let domain_label = self.domains.first().map(String::as_str).unwrap_or_default();
-        self.cert_chain_cache = CertChainCache::new(ttl, domain_label);
         self
     }
 

--- a/src/utils/cert_manager.rs
+++ b/src/utils/cert_manager.rs
@@ -9,6 +9,7 @@ pub mod http_client;
 pub mod storage;
 
 use crate::utils::cache::{CertChainCache, CertificateChain};
+use crate::utils::cert_manager::storage::{CryptoMaterialStorage, Storage};
 use crate::utils::keygen::Keypair;
 pub use builder::CertificateManagerBuilder;
 use challenge::CleanupFuture;
@@ -35,9 +36,7 @@ use tokio_cron_scheduler::{Job, JobScheduler};
 use tracing::{error, info, instrument, warn};
 use x509_parser::pem::Pem as X509Pem;
 
-use crate::cert_manager::{
-    challenge::ChallengeHandler, http_client::DefaultHttpClient, storage::Storage,
-};
+use crate::cert_manager::{challenge::ChallengeHandler, http_client::DefaultHttpClient};
 
 use opentelemetry::{
     global,
@@ -121,10 +120,8 @@ type ACMEHttpClientFactory = Box<dyn Fn() -> Box<dyn HttpClient> + Send + Sync>;
 
 /// Struct representing the certificate manager
 pub struct CertManager {
-    // Certificate storage backend
-    cert_storage: Option<Box<dyn Storage>>,
-    // Secrets storage backend
-    secrets_storage: Option<Box<dyn Storage>>,
+    // Consolidated backend for certificate chain, signing key, and ACME account material.
+    crypto_material_storage: Option<CryptoMaterialStorage>,
     // ACME challenge handler
     challenge_handler: Option<Box<dyn ChallengeHandler>>,
     // ACME client
@@ -173,8 +170,7 @@ impl CertManager {
         let cert_chain_cache = CertChainCache::new(DEFAULT_CHAIN_CACHE_TTL, domain_label);
 
         Ok(Self {
-            cert_storage: None,
-            secrets_storage: None,
+            crypto_material_storage: None,
             challenge_handler: None,
             acme_client: Arc::new(Mutex::new(None)),
             acme_http_client_factory: Some(acme_http_client_factory),
@@ -192,17 +188,24 @@ impl CertManager {
 
     /// Set the storage backend for the certificate.
     ///
-    /// **Note:** This method is required.
-    pub fn with_cert_storage(mut self, storage: impl Storage + 'static) -> Self {
-        self.cert_storage = Some(Box::new(storage));
-        self
+    /// New code should use [`Self::with_crypto_material_storage`].
+    pub fn with_cert_storage(self, storage: impl Storage + 'static) -> Self {
+        self.with_crypto_material_storage(storage)
     }
 
     /// Set the storage backend for the sensitive data.
     ///
-    /// **Note:** This method is required.
-    pub fn with_secrets_storage(mut self, storage: impl Storage + 'static) -> Self {
-        self.secrets_storage = Some(Box::new(storage));
+    /// Compatibility alias for the consolidated cryptographic-material backend.
+    ///
+    /// When used after [`Self::with_cert_storage`], this backend wins so legacy
+    /// call chains converge on the selected secrets/material backend.
+    pub fn with_secrets_storage(self, storage: impl Storage + 'static) -> Self {
+        self.with_crypto_material_storage(storage)
+    }
+
+    /// Set the consolidated backend for server certificate and signing-key material.
+    pub fn with_crypto_material_storage(mut self, storage: impl Storage + 'static) -> Self {
+        self.crypto_material_storage = Some(CryptoMaterialStorage::new(storage));
         self
     }
 
@@ -326,10 +329,7 @@ impl CertManager {
     pub(crate) async fn request_acme_certificate(&self) -> Result<CertificateData, CertError> {
         use instant_acme::RetryPolicy;
 
-        let cert_storage = self
-            .cert_storage
-            .as_ref()
-            .ok_or_else(|| CertError::Other(eyre!("Certificate storage not set")))?;
+        self.crypto_material_storage()?;
 
         let challenge_handler = self
             .challenge_handler
@@ -390,9 +390,8 @@ impl CertManager {
         let cert_data = CertificateData::new(cert_chain_pem, not_before, not_after);
 
         // Store the certificate
-        self.persist_certificate_data_with_storage(cert_storage.as_ref(), &cert_data)
-            .await?;
-        self.cache_provisioned_chain(&cert_data.certificate).await?;
+        self.persist_certificate_data(&cert_data).await?;
+        self.refresh_material_cache(&cert_data.certificate).await?;
 
         info!(
             "Certificate obtained successfully. Valid from {} to {}",
@@ -439,11 +438,11 @@ impl CertManager {
         const MAX_RETRIES: u32 = 3;
         const RETRY_DELAY: Duration = Duration::from_millis(500);
 
-        let secrets_storage = self.secrets_storage()?;
+        let material_storage = self.crypto_material_storage()?;
 
         // Try to load the existing signing key
         let secret_id = self.signing_secret_id();
-        if let Some(secret) = secrets_storage.load(&secret_id).await? {
+        if let Some(secret) = material_storage.load_signing_key(&secret_id).await? {
             info!("Found existing server secret. Skipping...");
             return Ok(secret);
         }
@@ -455,7 +454,10 @@ impl CertManager {
         let mut retries = 0;
         loop {
             info!("Trying to store the newly generated server secret...");
-            match secrets_storage.store(&secret_id, &key_pem).await {
+            match material_storage
+                .store_signing_key(&secret_id, &key_pem)
+                .await
+            {
                 Ok(_) => {
                     info!("Successfully stored the secret");
                     return Ok(key_pem);
@@ -477,9 +479,9 @@ impl CertManager {
     /// # Errors
     /// Returns an error if the certificate data cannot be parsed or if there was an issue when trying to retrieve the certificate data.
     pub async fn certificate(&self) -> Result<Option<CertificateData>, CertError> {
-        let cert_storage = self.cert_storage()?;
+        let material_storage = self.crypto_material_storage()?;
         let cert_key = self.cert_key();
-        if let Some(cert_data) = cert_storage.load(&cert_key).await? {
+        if let Some(cert_data) = material_storage.load_certificate_data(&cert_key).await? {
             return Ok(Some(serde_json::from_str(&cert_data)?));
         }
         Ok(None)
@@ -575,7 +577,7 @@ impl CertManager {
         fields(domains = ?self.domains, email = %self.email)
     )]
     async fn acme_account(&self) -> Result<Account, CertError> {
-        let secrets_storage = self.secrets_storage()?;
+        let material_storage = self.crypto_material_storage()?;
 
         let mut client_guard = self.acme_client.lock().await;
         if let Some(account) = client_guard.as_ref() {
@@ -584,7 +586,7 @@ impl CertManager {
         }
 
         let account_id = self.acme_account_id();
-        if let Some(credentials) = secrets_storage.load(&account_id).await? {
+        if let Some(credentials) = material_storage.load_secret(&account_id).await? {
             info!("Found existing credentials. Trying to load account...");
             let credentials: AccountCredentials = serde_json::from_str(&credentials)?;
             let http_client = self.create_http_client()?;
@@ -599,7 +601,7 @@ impl CertManager {
                 }
                 Err(e) => {
                     warn!("Invalid credentials: {e}\nrecreating new account...");
-                    secrets_storage.delete(&account_id).await?;
+                    material_storage.delete_secret(&account_id).await?;
                 }
             }
         }
@@ -616,8 +618,8 @@ impl CertManager {
             )
             .await?;
         // Store new credentials
-        secrets_storage
-            .store(&account_id, &serde_json::to_string(&credentials)?)
+        material_storage
+            .store_secret(&account_id, &serde_json::to_string(&credentials)?)
             .await?;
         *client_guard = Some(account.clone());
         info!("Account successfully created");
@@ -724,21 +726,15 @@ impl CertManager {
         ))
     }
 
-    pub(crate) fn cert_storage(&self) -> Result<&dyn Storage, CertError> {
-        self.cert_storage
-            .as_deref()
-            .ok_or_else(|| CertError::Other(eyre!("Certificate storage not set")))
-    }
-
-    pub(crate) fn secrets_storage(&self) -> Result<&dyn Storage, CertError> {
-        self.secrets_storage
-            .as_deref()
-            .ok_or_else(|| CertError::Other(eyre!("Secrets storage not set")))
+    pub(crate) fn crypto_material_storage(&self) -> Result<&CryptoMaterialStorage, CertError> {
+        self.crypto_material_storage
+            .as_ref()
+            .ok_or_else(|| CertError::Other(eyre!("Cryptographic-material backend not set")))
     }
 
     pub(crate) async fn signing_key_from_storage(&self) -> Result<Option<String>, CertError> {
-        self.secrets_storage()?
-            .load(&self.signing_secret_id())
+        self.crypto_material_storage()?
+            .load_signing_key(&self.signing_secret_id())
             .await
             .map_err(Into::into)
     }
@@ -747,31 +743,40 @@ impl CertManager {
         &self,
         cert_data: &CertificateData,
     ) -> Result<(), CertError> {
-        self.persist_certificate_data_with_storage(self.cert_storage()?, cert_data)
-            .await
-    }
-
-    async fn persist_certificate_data_with_storage(
-        &self,
-        cert_storage: &dyn Storage,
-        cert_data: &CertificateData,
-    ) -> Result<(), CertError> {
         let serialized_cert_data = serde_json::to_string(cert_data)?;
-        cert_storage
-            .store(&self.cert_key(), &serialized_cert_data)
+        self.crypto_material_storage()?
+            .store_certificate_data(&self.cert_key(), &serialized_cert_data)
             .await?;
         Ok(())
     }
 
     pub(crate) async fn persist_signing_key(&self, signing_key: &str) -> Result<(), CertError> {
-        let secrets_storage = self.secrets_storage()?;
+        let material_storage = self.crypto_material_storage()?;
         let secret_id = self.signing_secret_id();
-        if secrets_storage.load(&secret_id).await?.is_some() {
-            secrets_storage.update(&secret_id, signing_key).await?;
+        if material_storage
+            .load_signing_key(&secret_id)
+            .await?
+            .is_some()
+        {
+            material_storage
+                .update_signing_key(&secret_id, signing_key)
+                .await?;
         } else {
-            secrets_storage.store(&secret_id, signing_key).await?;
+            material_storage
+                .store_signing_key(&secret_id, signing_key)
+                .await?;
         }
         Ok(())
+    }
+
+    pub(crate) async fn persist_crypto_material(
+        &self,
+        cert_data: &CertificateData,
+        signing_key: &str,
+    ) -> Result<(), CertError> {
+        self.persist_certificate_data(cert_data).await?;
+        self.persist_signing_key(signing_key).await?;
+        self.refresh_material_cache(&cert_data.certificate).await
     }
 
     fn parse_cert_chain_parts(&self, cert_pem: &str) -> Result<CertificateChain, CertError> {
@@ -797,6 +802,14 @@ impl CertManager {
         // Replace eagerly so the next request never hits storage for this key.
         self.cert_chain_cache.replace(cert_key, parts).await;
         Ok(())
+    }
+
+    /// One invalidation path for lifecycle-coupled certificate and key material.
+    async fn refresh_material_cache(&self, cert_pem: &str) -> Result<(), CertError> {
+        self.crypto_material_storage()?
+            .invalidate_material(&self.cert_key(), &self.signing_secret_id())
+            .await?;
+        self.cache_provisioned_chain(cert_pem).await
     }
 
     #[inline]

--- a/src/utils/cert_manager.rs
+++ b/src/utils/cert_manager.rs
@@ -456,10 +456,10 @@ impl CertManager {
             // the provisioning-path `replace` in `cache_provisioned_chain`.
             // If a concurrent `request_certificate` replaces the cache entry
             // between our miss and this insert, we overwrite the fresh chain
-            // with the (still valid) old chain. The stale entry is bounded by
-            // the cache TTL. This is acceptable because the signing key is
-            // stable across renewals, so the old chain remains valid for
-            // token verification.
+            // with the (still valid) old chain. The stale entry persists until
+            // the next provisioning or renewal cycle. This is acceptable
+            // because the signing key is stable across renewals, so the old
+            // chain remains valid for token verification.
             self.cert_chain_cache.insert(cert_key, certs.clone()).await;
             return Ok(Some(certs));
         }
@@ -768,10 +768,10 @@ impl CertManager {
         Ok(())
     }
 
-    /// One invalidation path for lifecycle-coupled certificate and key material.
+    /// Refresh process-local caches after lifecycle-coupled certificate and key material changes.
     async fn refresh_material_cache(&self, cert_pem: &str) -> Result<(), CertError> {
         self.crypto_storage()?
-            .invalidate_material(&self.cert_key(), &self.signing_secret_id())
+            .invalidate_signing_key(&self.signing_secret_id())
             .await?;
         self.cache_provisioned_chain(cert_pem).await
     }

--- a/src/utils/cert_manager.rs
+++ b/src/utils/cert_manager.rs
@@ -9,7 +9,7 @@ pub mod http_client;
 pub mod storage;
 
 use crate::utils::cache::{CertChainCache, CertificateChain};
-use crate::utils::cert_manager::storage::{CryptoMaterialStorage, Storage};
+use crate::utils::cert_manager::storage::{CryptoStorage, Storage};
 use crate::utils::keygen::Keypair;
 pub use builder::CertificateManagerBuilder;
 use challenge::CleanupFuture;
@@ -121,7 +121,7 @@ type ACMEHttpClientFactory = Box<dyn Fn() -> Box<dyn HttpClient> + Send + Sync>;
 /// Struct representing the certificate manager
 pub struct CertManager {
     // Consolidated backend for certificate chain, signing key, and ACME account material.
-    crypto_material_storage: Option<CryptoMaterialStorage>,
+    crypto_storage: Option<CryptoStorage>,
     // ACME challenge handler
     challenge_handler: Option<Box<dyn ChallengeHandler>>,
     // ACME client
@@ -170,7 +170,7 @@ impl CertManager {
         let cert_chain_cache = CertChainCache::new(DEFAULT_CHAIN_CACHE_TTL, domain_label);
 
         Ok(Self {
-            crypto_material_storage: None,
+            crypto_storage: None,
             challenge_handler: None,
             acme_client: Arc::new(Mutex::new(None)),
             acme_http_client_factory: Some(acme_http_client_factory),
@@ -186,26 +186,9 @@ impl CertManager {
         })
     }
 
-    /// Set the storage backend for the certificate.
-    ///
-    /// New code should use [`Self::with_crypto_material_storage`].
-    pub fn with_cert_storage(self, storage: impl Storage + 'static) -> Self {
-        self.with_crypto_material_storage(storage)
-    }
-
-    /// Set the storage backend for the sensitive data.
-    ///
-    /// Compatibility alias for the consolidated cryptographic-material backend.
-    ///
-    /// When used after [`Self::with_cert_storage`], this backend wins so legacy
-    /// call chains converge on the selected secrets/material backend.
-    pub fn with_secrets_storage(self, storage: impl Storage + 'static) -> Self {
-        self.with_crypto_material_storage(storage)
-    }
-
     /// Set the consolidated backend for server certificate and signing-key material.
-    pub fn with_crypto_material_storage(mut self, storage: impl Storage + 'static) -> Self {
-        self.crypto_material_storage = Some(CryptoMaterialStorage::new(storage));
+    pub fn with_crypto_storage(mut self, storage: impl Storage + 'static) -> Self {
+        self.crypto_storage = Some(CryptoStorage::new(storage));
         self
     }
 
@@ -329,7 +312,7 @@ impl CertManager {
     pub(crate) async fn request_acme_certificate(&self) -> Result<CertificateData, CertError> {
         use instant_acme::RetryPolicy;
 
-        self.crypto_material_storage()?;
+        self.crypto_storage()?;
 
         let challenge_handler = self
             .challenge_handler
@@ -438,7 +421,7 @@ impl CertManager {
         const MAX_RETRIES: u32 = 3;
         const RETRY_DELAY: Duration = Duration::from_millis(500);
 
-        let material_storage = self.crypto_material_storage()?;
+        let material_storage = self.crypto_storage()?;
 
         // Try to load the existing signing key
         let secret_id = self.signing_secret_id();
@@ -479,7 +462,7 @@ impl CertManager {
     /// # Errors
     /// Returns an error if the certificate data cannot be parsed or if there was an issue when trying to retrieve the certificate data.
     pub async fn certificate(&self) -> Result<Option<CertificateData>, CertError> {
-        let material_storage = self.crypto_material_storage()?;
+        let material_storage = self.crypto_storage()?;
         let cert_key = self.cert_key();
         if let Some(cert_data) = material_storage.load_certificate_data(&cert_key).await? {
             return Ok(Some(serde_json::from_str(&cert_data)?));
@@ -577,7 +560,7 @@ impl CertManager {
         fields(domains = ?self.domains, email = %self.email)
     )]
     async fn acme_account(&self) -> Result<Account, CertError> {
-        let material_storage = self.crypto_material_storage()?;
+        let material_storage = self.crypto_storage()?;
 
         let mut client_guard = self.acme_client.lock().await;
         if let Some(account) = client_guard.as_ref() {
@@ -726,14 +709,14 @@ impl CertManager {
         ))
     }
 
-    pub(crate) fn crypto_material_storage(&self) -> Result<&CryptoMaterialStorage, CertError> {
-        self.crypto_material_storage
+    pub(crate) fn crypto_storage(&self) -> Result<&CryptoStorage, CertError> {
+        self.crypto_storage
             .as_ref()
             .ok_or_else(|| CertError::Other(eyre!("Cryptographic-material backend not set")))
     }
 
     pub(crate) async fn signing_key_from_storage(&self) -> Result<Option<String>, CertError> {
-        self.crypto_material_storage()?
+        self.crypto_storage()?
             .load_signing_key(&self.signing_secret_id())
             .await
             .map_err(Into::into)
@@ -744,14 +727,26 @@ impl CertManager {
         cert_data: &CertificateData,
     ) -> Result<(), CertError> {
         let serialized_cert_data = serde_json::to_string(cert_data)?;
-        self.crypto_material_storage()?
-            .store_certificate_data(&self.cert_key(), &serialized_cert_data)
-            .await?;
+        let material_storage = self.crypto_storage()?;
+        let cert_key = self.cert_key();
+        if material_storage
+            .load_certificate_data(&cert_key)
+            .await?
+            .is_some()
+        {
+            material_storage
+                .update_certificate_data(&cert_key, &serialized_cert_data)
+                .await?;
+        } else {
+            material_storage
+                .store_certificate_data(&cert_key, &serialized_cert_data)
+                .await?;
+        }
         Ok(())
     }
 
     pub(crate) async fn persist_signing_key(&self, signing_key: &str) -> Result<(), CertError> {
-        let material_storage = self.crypto_material_storage()?;
+        let material_storage = self.crypto_storage()?;
         let secret_id = self.signing_secret_id();
         if material_storage
             .load_signing_key(&secret_id)
@@ -806,7 +801,7 @@ impl CertManager {
 
     /// One invalidation path for lifecycle-coupled certificate and key material.
     async fn refresh_material_cache(&self, cert_pem: &str) -> Result<(), CertError> {
-        self.crypto_material_storage()?
+        self.crypto_storage()?
             .invalidate_material(&self.cert_key(), &self.signing_secret_id())
             .await?;
         self.cache_provisioned_chain(cert_pem).await

--- a/src/utils/cert_manager/builder.rs
+++ b/src/utils/cert_manager/builder.rs
@@ -9,7 +9,7 @@ use super::{
     DEFAULT_CHAIN_CACHE_TTL, RenewalStrategy, StoreProvisioningStrategy,
     challenge::ChallengeHandler,
     http_client::DefaultHttpClient,
-    storage::{CryptoMaterialCachePolicy, CryptoMaterialStorage, Storage},
+    storage::{CryptoCachePolicy, CryptoStorage, Storage},
 };
 use crate::utils::cache::CertChainCache;
 
@@ -25,7 +25,7 @@ type ACMEHttpClientFactory = Box<dyn Fn() -> Box<dyn HttpClient> + Send + Sync>;
 /// - organization: none
 /// - EKU: none
 /// - ACME directory URL: empty string, but required when ACME is selected
-/// - cryptographic-material backend, domains, and ACME challenge handler: not set
+/// - cryptographic material backend, domains, and ACME challenge handler: not set
 ///
 /// Required for all strategies:
 /// - at least one domain
@@ -47,7 +47,7 @@ type ACMEHttpClientFactory = Box<dyn Fn() -> Box<dyn HttpClient> + Send + Sync>;
 ///     .email("support@example.com")
 ///     .organization(Some("example.com"))
 ///     .acme_directory_url("https://acme-v02.api.letsencrypt.org/directory")
-///     .crypto_material_storage(material_storage)
+///     .crypto_storage(material_storage)
 ///     .challenge_handler(challenge_handler)
 ///     .eku(&[1, 3, 6, 1, 5, 5, 7, 3, 30])
 ///     .acme_strategy()
@@ -58,7 +58,7 @@ type ACMEHttpClientFactory = Box<dyn Fn() -> Box<dyn HttpClient> + Send + Sync>;
 /// ```ignore
 /// let manager = CertManager::builder()
 ///     .domains(["statuslist.example.com"])
-///     .crypto_material_storage(material_storage)
+///     .crypto_storage(material_storage)
 ///     .store_strategy(StoreProvisioningStrategy::filesystem(
 ///         "/etc/status-list/tls.crt",
 ///         "/etc/status-list/tls.key",
@@ -66,8 +66,8 @@ type ACMEHttpClientFactory = Box<dyn Fn() -> Box<dyn HttpClient> + Send + Sync>;
 ///     .build()?;
 /// ```
 pub struct CertificateManagerBuilder {
-    crypto_material_storage: Option<CryptoMaterialStorage>,
-    cache_policy: CryptoMaterialCachePolicy,
+    crypto_storage: Option<Box<dyn Storage>>,
+    cache_policy: CryptoCachePolicy,
     challenge_handler: Option<Box<dyn ChallengeHandler>>,
     acme_http_client_factory: Option<ACMEHttpClientFactory>,
     provisioning_strategy: Option<Box<dyn CertProvisioningStrategy>>,
@@ -83,8 +83,8 @@ pub struct CertificateManagerBuilder {
 impl Default for CertificateManagerBuilder {
     fn default() -> Self {
         Self {
-            crypto_material_storage: None,
-            cache_policy: CryptoMaterialCachePolicy::NO_CACHE,
+            crypto_storage: None,
+            cache_policy: CryptoCachePolicy::NO_CACHE,
             challenge_handler: None,
             acme_http_client_factory: None,
             provisioning_strategy: None,
@@ -130,36 +130,15 @@ impl CertificateManagerBuilder {
     }
 
     /// Set the consolidated backend for server certificate and signing-key material.
-    pub fn crypto_material_storage(mut self, storage: impl Storage + 'static) -> Self {
-        self.crypto_material_storage = Some(CryptoMaterialStorage::with_cache_policy(
-            storage,
-            self.cache_policy,
-        ));
+    pub fn crypto_storage(mut self, storage: impl Storage + 'static) -> Self {
+        self.crypto_storage = Some(Box::new(storage));
         self
     }
 
     /// Set cache policy for certificate and signing-key material reads.
-    pub fn crypto_material_cache_policy(mut self, policy: CryptoMaterialCachePolicy) -> Self {
+    pub fn crypto_cache_policy(mut self, policy: CryptoCachePolicy) -> Self {
         self.cache_policy = policy;
         self
-    }
-
-    /// Compatibility alias for the old certificate storage setter.
-    ///
-    /// New code should use [`Self::crypto_material_storage`] so the signing key
-    /// and certificate chain are lifecycle-coupled by one backend.
-    pub fn cert_storage(self, storage: impl Storage + 'static) -> Self {
-        self.crypto_material_storage(storage)
-    }
-
-    /// Compatibility alias for the old split secrets storage setter.
-    ///
-    /// The certificate manager now uses the configured cryptographic-material
-    /// backend for both certificate data and signing keys. When used after
-    /// [`Self::cert_storage`], this backend wins so legacy call chains converge
-    /// on the selected secrets/material backend.
-    pub fn secrets_storage(self, storage: impl Storage + 'static) -> Self {
-        self.crypto_material_storage(storage)
     }
 
     /// Set the ACME challenge handler.
@@ -212,9 +191,10 @@ impl CertificateManagerBuilder {
             ));
         }
 
-        let crypto_material_storage = self.crypto_material_storage.ok_or_else(|| {
-            CertError::Validation("cryptographic-material backend must be configured".to_string())
-        })?;
+        let crypto_storage = self.crypto_storage.ok_or(CertError::Validation(
+            "cryptographic-material backend must be configured".to_string(),
+        ))?;
+        let crypto_storage = CryptoStorage::with_cache_policy(crypto_storage, self.cache_policy);
 
         let default_strategy: Box<dyn CertProvisioningStrategy> =
             Box::new(AcmeProvisioningStrategy);
@@ -256,7 +236,7 @@ impl CertificateManagerBuilder {
         let cert_chain_cache = CertChainCache::new(ttl, domain_label);
 
         Ok(CertManager {
-            crypto_material_storage: Some(crypto_material_storage),
+            crypto_storage: Some(crypto_storage),
             challenge_handler: self.challenge_handler,
             acme_client: Arc::new(Mutex::new(None::<Account>)),
             acme_http_client_factory: http_client_factory,

--- a/src/utils/cert_manager/builder.rs
+++ b/src/utils/cert_manager/builder.rs
@@ -7,7 +7,9 @@ use tokio::sync::Mutex;
 use super::{
     AcmeProvisioningStrategy, CertError, CertManager, CertManagerMetrics, CertProvisioningStrategy,
     DEFAULT_CHAIN_CACHE_TTL, RenewalStrategy, StoreProvisioningStrategy,
-    challenge::ChallengeHandler, http_client::DefaultHttpClient, storage::Storage,
+    challenge::ChallengeHandler,
+    http_client::DefaultHttpClient,
+    storage::{CryptoMaterialCachePolicy, CryptoMaterialStorage, Storage},
 };
 use crate::utils::cache::CertChainCache;
 
@@ -23,12 +25,11 @@ type ACMEHttpClientFactory = Box<dyn Fn() -> Box<dyn HttpClient> + Send + Sync>;
 /// - organization: none
 /// - EKU: none
 /// - ACME directory URL: empty string, but required when ACME is selected
-/// - storage backends, domains, and ACME challenge handler: not set
+/// - cryptographic-material backend, domains, and ACME challenge handler: not set
 ///
 /// Required for all strategies:
 /// - at least one domain
-/// - certificate storage backend
-/// - secrets storage backend
+/// - cryptographic-material backend
 ///
 /// Required for ACME:
 /// - challenge handler
@@ -46,8 +47,7 @@ type ACMEHttpClientFactory = Box<dyn Fn() -> Box<dyn HttpClient> + Send + Sync>;
 ///     .email("support@example.com")
 ///     .organization(Some("example.com"))
 ///     .acme_directory_url("https://acme-v02.api.letsencrypt.org/directory")
-///     .cert_storage(cert_storage)
-///     .secrets_storage(secrets_storage)
+///     .crypto_material_storage(material_storage)
 ///     .challenge_handler(challenge_handler)
 ///     .eku(&[1, 3, 6, 1, 5, 5, 7, 3, 30])
 ///     .acme_strategy()
@@ -58,8 +58,7 @@ type ACMEHttpClientFactory = Box<dyn Fn() -> Box<dyn HttpClient> + Send + Sync>;
 /// ```ignore
 /// let manager = CertManager::builder()
 ///     .domains(["statuslist.example.com"])
-///     .cert_storage(cert_storage)
-///     .secrets_storage(secrets_storage)
+///     .crypto_material_storage(material_storage)
 ///     .store_strategy(StoreProvisioningStrategy::filesystem(
 ///         "/etc/status-list/tls.crt",
 ///         "/etc/status-list/tls.key",
@@ -67,8 +66,8 @@ type ACMEHttpClientFactory = Box<dyn Fn() -> Box<dyn HttpClient> + Send + Sync>;
 ///     .build()?;
 /// ```
 pub struct CertificateManagerBuilder {
-    cert_storage: Option<Box<dyn Storage>>,
-    secrets_storage: Option<Box<dyn Storage>>,
+    crypto_material_storage: Option<CryptoMaterialStorage>,
+    cache_policy: CryptoMaterialCachePolicy,
     challenge_handler: Option<Box<dyn ChallengeHandler>>,
     acme_http_client_factory: Option<ACMEHttpClientFactory>,
     provisioning_strategy: Option<Box<dyn CertProvisioningStrategy>>,
@@ -84,8 +83,8 @@ pub struct CertificateManagerBuilder {
 impl Default for CertificateManagerBuilder {
     fn default() -> Self {
         Self {
-            cert_storage: None,
-            secrets_storage: None,
+            crypto_material_storage: None,
+            cache_policy: CryptoMaterialCachePolicy::NO_CACHE,
             challenge_handler: None,
             acme_http_client_factory: None,
             provisioning_strategy: None,
@@ -130,16 +129,37 @@ impl CertificateManagerBuilder {
         self
     }
 
-    /// Set the certificate storage backend.
-    pub fn cert_storage(mut self, storage: impl Storage + 'static) -> Self {
-        self.cert_storage = Some(Box::new(storage));
+    /// Set the consolidated backend for server certificate and signing-key material.
+    pub fn crypto_material_storage(mut self, storage: impl Storage + 'static) -> Self {
+        self.crypto_material_storage = Some(CryptoMaterialStorage::with_cache_policy(
+            storage,
+            self.cache_policy,
+        ));
         self
     }
 
-    /// Set the signing key and ACME account storage backend.
-    pub fn secrets_storage(mut self, storage: impl Storage + 'static) -> Self {
-        self.secrets_storage = Some(Box::new(storage));
+    /// Set cache policy for certificate and signing-key material reads.
+    pub fn crypto_material_cache_policy(mut self, policy: CryptoMaterialCachePolicy) -> Self {
+        self.cache_policy = policy;
         self
+    }
+
+    /// Compatibility alias for the old certificate storage setter.
+    ///
+    /// New code should use [`Self::crypto_material_storage`] so the signing key
+    /// and certificate chain are lifecycle-coupled by one backend.
+    pub fn cert_storage(self, storage: impl Storage + 'static) -> Self {
+        self.crypto_material_storage(storage)
+    }
+
+    /// Compatibility alias for the old split secrets storage setter.
+    ///
+    /// The certificate manager now uses the configured cryptographic-material
+    /// backend for both certificate data and signing keys. When used after
+    /// [`Self::cert_storage`], this backend wins so legacy call chains converge
+    /// on the selected secrets/material backend.
+    pub fn secrets_storage(self, storage: impl Storage + 'static) -> Self {
+        self.crypto_material_storage(storage)
     }
 
     /// Set the ACME challenge handler.
@@ -192,11 +212,8 @@ impl CertificateManagerBuilder {
             ));
         }
 
-        let cert_storage = self.cert_storage.ok_or_else(|| {
-            CertError::Validation("certificate storage backend must be configured".to_string())
-        })?;
-        let secrets_storage = self.secrets_storage.ok_or_else(|| {
-            CertError::Validation("secrets storage backend must be configured".to_string())
+        let crypto_material_storage = self.crypto_material_storage.ok_or_else(|| {
+            CertError::Validation("cryptographic-material backend must be configured".to_string())
         })?;
 
         let default_strategy: Box<dyn CertProvisioningStrategy> =
@@ -239,8 +256,7 @@ impl CertificateManagerBuilder {
         let cert_chain_cache = CertChainCache::new(ttl, domain_label);
 
         Ok(CertManager {
-            cert_storage: Some(cert_storage),
-            secrets_storage: Some(secrets_storage),
+            crypto_material_storage: Some(crypto_material_storage),
             challenge_handler: self.challenge_handler,
             acme_client: Arc::new(Mutex::new(None::<Account>)),
             acme_http_client_factory: http_client_factory,

--- a/src/utils/cert_manager/builder.rs
+++ b/src/utils/cert_manager/builder.rs
@@ -1,12 +1,10 @@
-use std::sync::Arc;
-use std::time::Duration;
-
 use instant_acme::{Account, HttpClient};
+use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use super::{
     AcmeProvisioningStrategy, CertError, CertManager, CertManagerMetrics, CertProvisioningStrategy,
-    DEFAULT_CHAIN_CACHE_TTL, RenewalStrategy, StoreProvisioningStrategy,
+    RenewalStrategy, StoreProvisioningStrategy,
     challenge::ChallengeHandler,
     http_client::DefaultHttpClient,
     storage::{CryptoCachePolicy, CryptoStorage, Storage},
@@ -72,7 +70,6 @@ pub struct CertificateManagerBuilder {
     acme_http_client_factory: Option<ACMEHttpClientFactory>,
     provisioning_strategy: Option<Box<dyn CertProvisioningStrategy>>,
     renewal_strategy: RenewalStrategy,
-    chain_cache_ttl: Option<Duration>,
     domains: Vec<String>,
     email: Option<String>,
     organization: Option<String>,
@@ -89,7 +86,6 @@ impl Default for CertificateManagerBuilder {
             acme_http_client_factory: None,
             provisioning_strategy: None,
             renewal_strategy: RenewalStrategy::PercentageOfLifetime(None),
-            chain_cache_ttl: None,
             domains: Vec::new(),
             email: None,
             organization: None,
@@ -165,12 +161,6 @@ impl CertificateManagerBuilder {
         self
     }
 
-    /// Set the certificate chain cache TTL.
-    pub fn chain_cache_ttl(mut self, ttl: Duration) -> Self {
-        self.chain_cache_ttl = Some(ttl);
-        self
-    }
-
     /// Use ACME provisioning.
     pub fn acme_strategy(mut self) -> Self {
         self.provisioning_strategy = Some(Box::new(AcmeProvisioningStrategy));
@@ -231,9 +221,8 @@ impl CertificateManagerBuilder {
             None => None,
         };
 
-        let ttl = self.chain_cache_ttl.unwrap_or(DEFAULT_CHAIN_CACHE_TTL);
         let domain_label = self.domains.first().map(String::as_str).unwrap_or_default();
-        let cert_chain_cache = CertChainCache::new(ttl, domain_label);
+        let cert_chain_cache = CertChainCache::new(domain_label);
 
         Ok(CertManager {
             crypto_storage: Some(crypto_storage),

--- a/src/utils/cert_manager/builder.rs
+++ b/src/utils/cert_manager/builder.rs
@@ -81,7 +81,7 @@ impl Default for CertificateManagerBuilder {
     fn default() -> Self {
         Self {
             crypto_storage: None,
-            cache_policy: CryptoCachePolicy::NO_CACHE,
+            cache_policy: CryptoCachePolicy::default(),
             challenge_handler: None,
             acme_http_client_factory: None,
             provisioning_strategy: None,

--- a/src/utils/cert_manager/challenge.rs
+++ b/src/utils/cert_manager/challenge.rs
@@ -1,7 +1,7 @@
 mod dns01;
 mod http01;
 
-#[cfg(feature = "aws")]
+#[cfg(feature = "aws-secrets")]
 pub use dns01::AwsRoute53DnsProvider;
 pub use dns01::{
     AcmeDnsCredentials, AcmeDnsProvider, AzureDnsProvider, CloudflareDnsProvider, Dns01Handler,

--- a/src/utils/cert_manager/challenge/dns01/mod.rs
+++ b/src/utils/cert_manager/challenge/dns01/mod.rs
@@ -3,7 +3,7 @@ mod azure;
 mod cloudflare;
 mod gcloud;
 mod pebble;
-#[cfg(feature = "aws")]
+#[cfg(feature = "aws-secrets")]
 mod route53;
 mod token;
 
@@ -12,7 +12,7 @@ pub use azure::{AzureDnsProvider, ServicePrincipal};
 pub use cloudflare::CloudflareDnsProvider;
 pub use gcloud::GoogleCloudDnsProvider;
 pub use pebble::PebbleDnsProvider;
-#[cfg(feature = "aws")]
+#[cfg(feature = "aws-secrets")]
 pub use route53::AwsRoute53DnsProvider;
 
 use std::{sync::Arc, time::Duration};

--- a/src/utils/cert_manager/storage.rs
+++ b/src/utils/cert_manager/storage.rs
@@ -129,7 +129,8 @@ pub struct CryptoStorage {
 }
 
 impl CryptoStorage {
-    const CACHE_MAX_CAPACITY: u64 = 16;
+    const CERT_CACHE_CAPACITY: u64 = 1;
+    const KEY_CACHE_CAPACITY: u64 = 1;
 
     pub fn new(backend: impl Storage + 'static) -> Self {
         Self::with_cache_policy(backend, CryptoCachePolicy::default())
@@ -137,7 +138,7 @@ impl CryptoStorage {
 
     pub fn with_cache_policy(backend: impl Storage + 'static, policy: CryptoCachePolicy) -> Self {
         let certificate_cache = Cache::builder()
-            .max_capacity(CryptoStorage::CACHE_MAX_CAPACITY)
+            .max_capacity(CryptoStorage::CERT_CACHE_CAPACITY)
             .build();
         let signing_key_cache = cache_for_ttl(policy.signing_key_ttl);
         if policy.signing_key_ttl.is_zero() {
@@ -208,12 +209,7 @@ impl CryptoStorage {
         self.backend.delete(key).await
     }
 
-    pub async fn invalidate_material(
-        &self,
-        certificate_key: &str,
-        signing_key_key: &str,
-    ) -> Result<(), StorageError> {
-        self.certificate_cache.invalidate(certificate_key).await;
+    pub async fn invalidate_signing_key(&self, signing_key_key: &str) -> Result<(), StorageError> {
         if let Some(cache) = &self.signing_key_cache {
             cache.invalidate(signing_key_key).await;
         }
@@ -245,7 +241,7 @@ impl CryptoStorage {
 fn cache_for_ttl(ttl: Duration) -> Option<Cache<String, String>> {
     (!ttl.is_zero()).then(|| {
         Cache::builder()
-            .max_capacity(CryptoStorage::CACHE_MAX_CAPACITY)
+            .max_capacity(CryptoStorage::KEY_CACHE_CAPACITY)
             .time_to_live(ttl)
             .build()
     })

--- a/src/utils/cert_manager/storage.rs
+++ b/src/utils/cert_manager/storage.rs
@@ -100,12 +100,12 @@ impl Storage for MemoryStorage {
 /// deployments can cache public certificate chains while forcing each private
 /// key read to hit the backing secrets system.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct CryptoMaterialCachePolicy {
+pub struct CryptoCachePolicy {
     pub certificate_ttl: Duration,
     pub signing_key_ttl: Duration,
 }
 
-impl CryptoMaterialCachePolicy {
+impl CryptoCachePolicy {
     pub const NO_CACHE: Self = Self {
         certificate_ttl: Duration::ZERO,
         signing_key_ttl: Duration::ZERO,
@@ -119,7 +119,7 @@ impl CryptoMaterialCachePolicy {
     }
 }
 
-impl Default for CryptoMaterialCachePolicy {
+impl Default for CryptoCachePolicy {
     fn default() -> Self {
         Self::NO_CACHE
     }
@@ -127,23 +127,20 @@ impl Default for CryptoMaterialCachePolicy {
 
 /// Consolidated storage backend for the server certificate chain, signing key,
 /// and adjacent ACME account material.
-pub struct CryptoMaterialStorage {
+pub struct CryptoStorage {
     backend: Box<dyn Storage>,
     certificate_cache: Option<Cache<String, String>>,
     signing_key_cache: Option<Cache<String, String>>,
 }
 
-impl CryptoMaterialStorage {
+impl CryptoStorage {
     const CACHE_MAX_CAPACITY: u64 = 16;
 
     pub fn new(backend: impl Storage + 'static) -> Self {
-        Self::with_cache_policy(backend, CryptoMaterialCachePolicy::NO_CACHE)
+        Self::with_cache_policy(backend, CryptoCachePolicy::NO_CACHE)
     }
 
-    pub fn with_cache_policy(
-        backend: impl Storage + 'static,
-        policy: CryptoMaterialCachePolicy,
-    ) -> Self {
+    pub fn with_cache_policy(backend: impl Storage + 'static, policy: CryptoCachePolicy) -> Self {
         let certificate_cache = cache_for_ttl(policy.certificate_ttl);
         let signing_key_cache = cache_for_ttl(policy.signing_key_ttl);
         if policy.signing_key_ttl.is_zero() {
@@ -158,6 +155,18 @@ impl CryptoMaterialStorage {
 
     pub async fn store_certificate_data(&self, key: &str, value: &str) -> Result<(), StorageError> {
         self.backend.store(key, value).await?;
+        if let Some(cache) = &self.certificate_cache {
+            cache.insert(key.to_string(), value.to_string()).await;
+        }
+        Ok(())
+    }
+
+    pub async fn update_certificate_data(
+        &self,
+        key: &str,
+        value: &str,
+    ) -> Result<(), StorageError> {
+        self.backend.update(key, value).await?;
         if let Some(cache) = &self.certificate_cache {
             cache.insert(key.to_string(), value.to_string()).await;
         }
@@ -241,7 +250,7 @@ impl CryptoMaterialStorage {
 fn cache_for_ttl(ttl: Duration) -> Option<Cache<String, String>> {
     (!ttl.is_zero()).then(|| {
         Cache::builder()
-            .max_capacity(CryptoMaterialStorage::CACHE_MAX_CAPACITY)
+            .max_capacity(CryptoStorage::CACHE_MAX_CAPACITY)
             .time_to_live(ttl)
             .build()
     })

--- a/src/utils/cert_manager/storage.rs
+++ b/src/utils/cert_manager/storage.rs
@@ -96,32 +96,27 @@ impl Storage for MemoryStorage {
 
 /// Cache policy for server cryptographic material.
 ///
-/// Certificate material and private-key material are configured separately so
-/// deployments can cache public certificate chains while forcing each private
-/// key read to hit the backing secrets system.
+/// Certificate material is always cached until explicit invalidation during
+/// provisioning or renewal. Private-key material remains policy-controlled so
+/// deployments can force each private-key read to hit the backing secrets system.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CryptoCachePolicy {
-    pub certificate_ttl: Duration,
     pub signing_key_ttl: Duration,
 }
 
 impl CryptoCachePolicy {
-    pub const NO_CACHE: Self = Self {
-        certificate_ttl: Duration::ZERO,
+    pub const NO_PRIVATE_KEY_CACHE: Self = Self {
         signing_key_ttl: Duration::ZERO,
     };
 
-    pub fn new(certificate_ttl: Duration, signing_key_ttl: Duration) -> Self {
-        Self {
-            certificate_ttl,
-            signing_key_ttl,
-        }
+    pub fn new(signing_key_ttl: Duration) -> Self {
+        Self { signing_key_ttl }
     }
 }
 
 impl Default for CryptoCachePolicy {
     fn default() -> Self {
-        Self::NO_CACHE
+        Self::NO_PRIVATE_KEY_CACHE
     }
 }
 
@@ -129,7 +124,7 @@ impl Default for CryptoCachePolicy {
 /// and adjacent ACME account material.
 pub struct CryptoStorage {
     backend: Box<dyn Storage>,
-    certificate_cache: Option<Cache<String, String>>,
+    certificate_cache: Cache<String, String>,
     signing_key_cache: Option<Cache<String, String>>,
 }
 
@@ -137,11 +132,13 @@ impl CryptoStorage {
     const CACHE_MAX_CAPACITY: u64 = 16;
 
     pub fn new(backend: impl Storage + 'static) -> Self {
-        Self::with_cache_policy(backend, CryptoCachePolicy::NO_CACHE)
+        Self::with_cache_policy(backend, CryptoCachePolicy::default())
     }
 
     pub fn with_cache_policy(backend: impl Storage + 'static, policy: CryptoCachePolicy) -> Self {
-        let certificate_cache = cache_for_ttl(policy.certificate_ttl);
+        let certificate_cache = Cache::builder()
+            .max_capacity(CryptoStorage::CACHE_MAX_CAPACITY)
+            .build();
         let signing_key_cache = cache_for_ttl(policy.signing_key_ttl);
         if policy.signing_key_ttl.is_zero() {
             tracing::info!("server signing-key material cache disabled");
@@ -155,9 +152,9 @@ impl CryptoStorage {
 
     pub async fn store_certificate_data(&self, key: &str, value: &str) -> Result<(), StorageError> {
         self.backend.store(key, value).await?;
-        if let Some(cache) = &self.certificate_cache {
-            cache.insert(key.to_string(), value.to_string()).await;
-        }
+        self.certificate_cache
+            .insert(key.to_string(), value.to_string())
+            .await;
         Ok(())
     }
 
@@ -167,14 +164,14 @@ impl CryptoStorage {
         value: &str,
     ) -> Result<(), StorageError> {
         self.backend.update(key, value).await?;
-        if let Some(cache) = &self.certificate_cache {
-            cache.insert(key.to_string(), value.to_string()).await;
-        }
+        self.certificate_cache
+            .insert(key.to_string(), value.to_string())
+            .await;
         Ok(())
     }
 
     pub async fn load_certificate_data(&self, key: &str) -> Result<Option<String>, StorageError> {
-        self.load_with_cache(key, self.certificate_cache.as_ref())
+        self.load_with_cache(key, Some(&self.certificate_cache))
             .await
     }
 
@@ -216,9 +213,7 @@ impl CryptoStorage {
         certificate_key: &str,
         signing_key_key: &str,
     ) -> Result<(), StorageError> {
-        if let Some(cache) = &self.certificate_cache {
-            cache.invalidate(certificate_key).await;
-        }
+        self.certificate_cache.invalidate(certificate_key).await;
         if let Some(cache) = &self.signing_key_cache {
             cache.invalidate(signing_key_key).await;
         }

--- a/src/utils/cert_manager/storage.rs
+++ b/src/utils/cert_manager/storage.rs
@@ -1,7 +1,9 @@
 use async_trait::async_trait;
 use color_eyre::eyre::Error as Report;
+use moka::future::Cache;
 #[cfg(feature = "redis")]
 use redis::RedisError;
+use std::time::Duration;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -90,4 +92,157 @@ impl Storage for MemoryStorage {
         self.values.write().await.remove(key);
         Ok(())
     }
+}
+
+/// Cache policy for server cryptographic material.
+///
+/// Certificate material and private-key material are configured separately so
+/// deployments can cache public certificate chains while forcing each private
+/// key read to hit the backing secrets system.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CryptoMaterialCachePolicy {
+    pub certificate_ttl: Duration,
+    pub signing_key_ttl: Duration,
+}
+
+impl CryptoMaterialCachePolicy {
+    pub const NO_CACHE: Self = Self {
+        certificate_ttl: Duration::ZERO,
+        signing_key_ttl: Duration::ZERO,
+    };
+
+    pub fn new(certificate_ttl: Duration, signing_key_ttl: Duration) -> Self {
+        Self {
+            certificate_ttl,
+            signing_key_ttl,
+        }
+    }
+}
+
+impl Default for CryptoMaterialCachePolicy {
+    fn default() -> Self {
+        Self::NO_CACHE
+    }
+}
+
+/// Consolidated storage backend for the server certificate chain, signing key,
+/// and adjacent ACME account material.
+pub struct CryptoMaterialStorage {
+    backend: Box<dyn Storage>,
+    certificate_cache: Option<Cache<String, String>>,
+    signing_key_cache: Option<Cache<String, String>>,
+}
+
+impl CryptoMaterialStorage {
+    const CACHE_MAX_CAPACITY: u64 = 16;
+
+    pub fn new(backend: impl Storage + 'static) -> Self {
+        Self::with_cache_policy(backend, CryptoMaterialCachePolicy::NO_CACHE)
+    }
+
+    pub fn with_cache_policy(
+        backend: impl Storage + 'static,
+        policy: CryptoMaterialCachePolicy,
+    ) -> Self {
+        let certificate_cache = cache_for_ttl(policy.certificate_ttl);
+        let signing_key_cache = cache_for_ttl(policy.signing_key_ttl);
+        if policy.signing_key_ttl.is_zero() {
+            tracing::info!("server signing-key material cache disabled");
+        }
+        Self {
+            backend: Box::new(backend),
+            certificate_cache,
+            signing_key_cache,
+        }
+    }
+
+    pub async fn store_certificate_data(&self, key: &str, value: &str) -> Result<(), StorageError> {
+        self.backend.store(key, value).await?;
+        if let Some(cache) = &self.certificate_cache {
+            cache.insert(key.to_string(), value.to_string()).await;
+        }
+        Ok(())
+    }
+
+    pub async fn load_certificate_data(&self, key: &str) -> Result<Option<String>, StorageError> {
+        self.load_with_cache(key, self.certificate_cache.as_ref())
+            .await
+    }
+
+    pub async fn store_signing_key(&self, key: &str, value: &str) -> Result<(), StorageError> {
+        self.backend.store(key, value).await?;
+        if let Some(cache) = &self.signing_key_cache {
+            cache.insert(key.to_string(), value.to_string()).await;
+        }
+        Ok(())
+    }
+
+    pub async fn load_signing_key(&self, key: &str) -> Result<Option<String>, StorageError> {
+        self.load_with_cache(key, self.signing_key_cache.as_ref())
+            .await
+    }
+
+    pub async fn update_signing_key(&self, key: &str, value: &str) -> Result<(), StorageError> {
+        self.backend.update(key, value).await?;
+        if let Some(cache) = &self.signing_key_cache {
+            cache.insert(key.to_string(), value.to_string()).await;
+        }
+        Ok(())
+    }
+
+    pub async fn load_secret(&self, key: &str) -> Result<Option<String>, StorageError> {
+        self.backend.load(key).await
+    }
+
+    pub async fn store_secret(&self, key: &str, value: &str) -> Result<(), StorageError> {
+        self.backend.store(key, value).await
+    }
+
+    pub async fn delete_secret(&self, key: &str) -> Result<(), StorageError> {
+        self.backend.delete(key).await
+    }
+
+    pub async fn invalidate_material(
+        &self,
+        certificate_key: &str,
+        signing_key_key: &str,
+    ) -> Result<(), StorageError> {
+        if let Some(cache) = &self.certificate_cache {
+            cache.invalidate(certificate_key).await;
+        }
+        if let Some(cache) = &self.signing_key_cache {
+            cache.invalidate(signing_key_key).await;
+        }
+        Ok(())
+    }
+
+    pub async fn reachable(&self) -> Result<(), StorageError> {
+        self.backend.reachable().await
+    }
+
+    async fn load_with_cache(
+        &self,
+        key: &str,
+        cache: Option<&Cache<String, String>>,
+    ) -> Result<Option<String>, StorageError> {
+        if let Some(cache) = cache
+            && let Some(value) = cache.get(key).await
+        {
+            return Ok(Some(value));
+        }
+        let loaded = self.backend.load(key).await?;
+        if let (Some(cache), Some(value)) = (cache, loaded.as_ref()) {
+            cache.insert(key.to_string(), value.clone()).await;
+        }
+        Ok(loaded)
+    }
+}
+
+fn cache_for_ttl(ttl: Duration) -> Option<Cache<String, String>> {
+    (!ttl.is_zero()).then(|| {
+        Cache::builder()
+            .max_capacity(CryptoMaterialStorage::CACHE_MAX_CAPACITY)
+            .time_to_live(ttl)
+            .build()
+    })
 }

--- a/src/utils/cert_manager/strategy.rs
+++ b/src/utils/cert_manager/strategy.rs
@@ -60,11 +60,6 @@ pub enum StoreProvisioningSource {
         certificate_key: String,
         signing_key_key: String,
     },
-    /// Load PEM-encoded certificate chain and PKCS#8 signing key from the secrets backend.
-    SecretsStorage {
-        certificate_key: String,
-        signing_key_key: String,
-    },
 }
 
 /// Store-based provisioning strategy.
@@ -88,19 +83,6 @@ impl StoreProvisioningStrategy {
     pub fn storage(certificate_key: impl Into<String>, signing_key_key: impl Into<String>) -> Self {
         Self {
             source: StoreProvisioningSource::Storage {
-                certificate_key: certificate_key.into(),
-                signing_key_key: signing_key_key.into(),
-            },
-        }
-    }
-
-    /// Build a store strategy that loads both PEM values from the configured secrets backend.
-    pub fn secrets_storage(
-        certificate_key: impl Into<String>,
-        signing_key_key: impl Into<String>,
-    ) -> Self {
-        Self {
-            source: StoreProvisioningSource::SecretsStorage {
                 certificate_key: certificate_key.into(),
                 signing_key_key: signing_key_key.into(),
             },
@@ -131,7 +113,7 @@ impl StoreProvisioningStrategy {
                 certificate_key,
                 signing_key_key,
             } => {
-                let material_storage = manager.crypto_material_storage()?;
+                let material_storage = manager.crypto_storage()?;
                 let certificate = material_storage
                     .load_secret(certificate_key)
                     .await?
@@ -145,33 +127,7 @@ impl StoreProvisioningStrategy {
                     .await?
                     .ok_or_else(|| {
                         CertError::Validation(format!(
-                            "store signing key key '{signing_key_key}' was not found"
-                        ))
-                    })?;
-                Ok((
-                    decode_text_material(certificate, "certificate")?,
-                    decode_text_material(signing_key, "signing key")?,
-                ))
-            }
-            StoreProvisioningSource::SecretsStorage {
-                certificate_key,
-                signing_key_key,
-            } => {
-                let material_storage = manager.crypto_material_storage()?;
-                let certificate = material_storage
-                    .load_secret(certificate_key)
-                    .await?
-                    .ok_or_else(|| {
-                        CertError::Validation(format!(
-                            "store certificate secret '{certificate_key}' was not found"
-                        ))
-                    })?;
-                let signing_key = material_storage
-                    .load_secret(signing_key_key)
-                    .await?
-                    .ok_or_else(|| {
-                        CertError::Validation(format!(
-                            "store signing key secret '{signing_key_key}' was not found"
+                            "store signing key '{signing_key_key}' was not found"
                         ))
                     })?;
                 Ok((

--- a/src/utils/cert_manager/strategy.rs
+++ b/src/utils/cert_manager/strategy.rs
@@ -55,7 +55,7 @@ pub enum StoreProvisioningSource {
         certificate_path: PathBuf,
         signing_key_path: PathBuf,
     },
-    /// Load PEM-encoded certificate chain and PKCS#8 signing key from configured storage backends.
+    /// Load PEM-encoded certificate chain and PKCS#8 signing key from the configured material backend.
     Storage {
         certificate_key: String,
         signing_key_key: String,
@@ -131,22 +131,23 @@ impl StoreProvisioningStrategy {
                 certificate_key,
                 signing_key_key,
             } => {
-                let cert_storage = manager.cert_storage()?;
-                let secrets_storage = manager.secrets_storage()?;
-                let certificate = cert_storage.load(certificate_key).await?.ok_or_else(|| {
-                    CertError::Validation(format!(
-                        "store certificate key '{certificate_key}' was not found"
-                    ))
-                })?;
-                let signing_key =
-                    secrets_storage
-                        .load(signing_key_key)
-                        .await?
-                        .ok_or_else(|| {
-                            CertError::Validation(format!(
-                                "store signing key key '{signing_key_key}' was not found"
-                            ))
-                        })?;
+                let material_storage = manager.crypto_material_storage()?;
+                let certificate = material_storage
+                    .load_secret(certificate_key)
+                    .await?
+                    .ok_or_else(|| {
+                        CertError::Validation(format!(
+                            "store certificate key '{certificate_key}' was not found"
+                        ))
+                    })?;
+                let signing_key = material_storage
+                    .load_secret(signing_key_key)
+                    .await?
+                    .ok_or_else(|| {
+                        CertError::Validation(format!(
+                            "store signing key key '{signing_key_key}' was not found"
+                        ))
+                    })?;
                 Ok((
                     decode_text_material(certificate, "certificate")?,
                     decode_text_material(signing_key, "signing key")?,
@@ -156,25 +157,23 @@ impl StoreProvisioningStrategy {
                 certificate_key,
                 signing_key_key,
             } => {
-                let secrets_storage = manager.secrets_storage()?;
-                let certificate =
-                    secrets_storage
-                        .load(certificate_key)
-                        .await?
-                        .ok_or_else(|| {
-                            CertError::Validation(format!(
-                                "store certificate secret '{certificate_key}' was not found"
-                            ))
-                        })?;
-                let signing_key =
-                    secrets_storage
-                        .load(signing_key_key)
-                        .await?
-                        .ok_or_else(|| {
-                            CertError::Validation(format!(
-                                "store signing key secret '{signing_key_key}' was not found"
-                            ))
-                        })?;
+                let material_storage = manager.crypto_material_storage()?;
+                let certificate = material_storage
+                    .load_secret(certificate_key)
+                    .await?
+                    .ok_or_else(|| {
+                        CertError::Validation(format!(
+                            "store certificate secret '{certificate_key}' was not found"
+                        ))
+                    })?;
+                let signing_key = material_storage
+                    .load_secret(signing_key_key)
+                    .await?
+                    .ok_or_else(|| {
+                        CertError::Validation(format!(
+                            "store signing key secret '{signing_key_key}' was not found"
+                        ))
+                    })?;
                 Ok((
                     decode_text_material(certificate, "certificate")?,
                     decode_text_material(signing_key, "signing key")?,
@@ -214,10 +213,8 @@ impl CertProvisioningStrategy for StoreProvisioningStrategy {
             return Ok(current_certificate.unwrap_or(certificate_data));
         }
 
-        manager.persist_certificate_data(&certificate_data).await?;
-        manager.persist_signing_key(&signing_key_pem).await?;
         manager
-            .cache_provisioned_chain(&certificate_data.certificate)
+            .persist_crypto_material(&certificate_data, &signing_key_pem)
             .await?;
         info!("Store certificate material refreshed");
         Ok(certificate_data)

--- a/src/utils/cert_manager/tests.rs
+++ b/src/utils/cert_manager/tests.rs
@@ -788,7 +788,7 @@ async fn test_refresh_material_cache_replaces_cached_chain() {
     assert_eq!(material_storage.load_count(), 1);
 
     cert_manager
-        .refresh_material_cache(&replacement.certificate)
+        .cache_provisioned_chain(&replacement.certificate)
         .await
         .unwrap();
     let reloaded = cert_manager.cert_chain_parts().await.unwrap().unwrap();

--- a/src/utils/cert_manager/tests.rs
+++ b/src/utils/cert_manager/tests.rs
@@ -386,10 +386,7 @@ async fn test_crypto_cache_policy_can_skip_private_key_cache() {
 
     let manager = CertManager::builder()
         .domains(["example.com"])
-        .crypto_cache_policy(CryptoCachePolicy::new(
-            Duration::from_secs(60),
-            Duration::ZERO,
-        ))
+        .crypto_cache_policy(CryptoCachePolicy::new(Duration::ZERO))
         .crypto_storage(material_storage.clone())
         .store_strategy(StoreProvisioningStrategy::filesystem(
             "/tmp/example-cert.pem",
@@ -424,10 +421,7 @@ async fn test_crypto_cache_policy_applies_after_storage_setter() {
     let manager = CertManager::builder()
         .domains(["example.com"])
         .crypto_storage(material_storage.clone())
-        .crypto_cache_policy(CryptoCachePolicy::new(
-            Duration::from_secs(60),
-            Duration::ZERO,
-        ))
+        .crypto_cache_policy(CryptoCachePolicy::new(Duration::ZERO))
         .store_strategy(StoreProvisioningStrategy::filesystem(
             "/tmp/example-cert.pem",
             "/tmp/example-key.pem",

--- a/src/utils/cert_manager/tests.rs
+++ b/src/utils/cert_manager/tests.rs
@@ -752,7 +752,7 @@ async fn test_cache_provisioned_chain_replaces_cached_entry() {
 }
 
 #[tokio::test]
-async fn test_cert_chain_cache_invalidation_reloads_chain() {
+async fn test_refresh_material_cache_replaces_cached_chain() {
     init_crypto();
 
     let material_storage = MockStorage::new();
@@ -778,9 +778,8 @@ async fn test_cert_chain_cache_invalidation_reloads_chain() {
         expires_at: 2,
         updated_at: 3,
     };
-    let serialized_replacement = serde_json::to_string(&replacement).unwrap();
-    material_storage
-        .store(&cert_key, &serialized_replacement)
+    cert_manager
+        .persist_certificate_data(&replacement)
         .await
         .unwrap();
 
@@ -788,12 +787,23 @@ async fn test_cert_chain_cache_invalidation_reloads_chain() {
     assert!(Arc::ptr_eq(&first, &stale_cached));
     assert_eq!(material_storage.load_count(), 1);
 
-    cert_manager.cert_chain_cache.invalidate(&cert_key).await;
+    cert_manager
+        .refresh_material_cache(&replacement.certificate)
+        .await
+        .unwrap();
     let reloaded = cert_manager.cert_chain_parts().await.unwrap().unwrap();
 
     assert_eq!(reloaded.len(), 1);
     assert!(!Arc::ptr_eq(&first, &reloaded));
-    assert_eq!(material_storage.load_count(), 2);
+    assert_eq!(material_storage.load_count(), 1);
+
+    let cert_data = cert_manager.certificate().await.unwrap().unwrap();
+    assert_eq!(cert_data.certificate, replacement.certificate);
+    assert_eq!(
+        material_storage.load_count(),
+        1,
+        "certificate material cache should stay hot after renewal refresh"
+    );
 }
 
 fn setup_test_metrics_registry() -> (

--- a/src/utils/cert_manager/tests.rs
+++ b/src/utils/cert_manager/tests.rs
@@ -68,8 +68,7 @@ impl Storage for MockStorage {
 fn test_cert_manager_builder() {
     init_crypto();
 
-    let cert_storage = MockStorage::new();
-    let secrets_storage = MockStorage::new();
+    let material_storage = MockStorage::new();
 
     let manager = CertManager::new(
         vec!["example.com"],
@@ -78,12 +77,10 @@ fn test_cert_manager_builder() {
         "https://acme-staging-v02.api.letsencrypt.org/directory",
     )
     .unwrap()
-    .with_cert_storage(cert_storage)
-    .with_secrets_storage(secrets_storage)
+    .with_crypto_material_storage(material_storage)
     .with_eku(&[1, 2, 3, 4]);
 
-    assert!(manager.cert_storage.is_some());
-    assert!(manager.secrets_storage.is_some());
+    assert!(manager.crypto_material_storage.is_some());
     assert!(manager.challenge_handler.is_none());
     assert_eq!(manager.eku, Some(vec![1, 2, 3, 4]));
 }
@@ -96,8 +93,7 @@ fn test_acme_builder_requires_challenge_handler() {
         .domains(["example.com"])
         .email("test@example.com")
         .acme_directory_url("https://acme.example.com/directory")
-        .cert_storage(MockStorage::new())
-        .secrets_storage(MockStorage::new())
+        .crypto_material_storage(MockStorage::new())
         .acme_strategy()
         .build();
 
@@ -115,8 +111,7 @@ fn test_store_builder_does_not_require_acme_components() {
 
     let result = CertManager::builder()
         .domains(["example.com"])
-        .cert_storage(MockStorage::new())
-        .secrets_storage(MockStorage::new())
+        .crypto_material_storage(MockStorage::new())
         .store_strategy(StoreProvisioningStrategy::filesystem(
             "/tmp/example-cert.pem",
             "/tmp/example-key.pem",
@@ -241,7 +236,7 @@ async fn test_renewal_strategy_fixed_interval() {
 async fn test_certificate_returns_none_if_not_found() {
     init_crypto();
 
-    let cert_storage = MockStorage::new();
+    let material_storage = MockStorage::new();
     let cert_manager = CertManager::new(
         vec!["example.com"],
         "test@example.com",
@@ -249,7 +244,7 @@ async fn test_certificate_returns_none_if_not_found() {
         "https://acme-staging-v02.api.letsencrypt.org/directory",
     )
     .unwrap()
-    .with_cert_storage(cert_storage);
+    .with_crypto_material_storage(material_storage);
 
     let cert = cert_manager.certificate().await.unwrap();
     assert!(cert.is_none());
@@ -259,7 +254,7 @@ async fn test_certificate_returns_none_if_not_found() {
 async fn test_certificate_storage_and_retrieval() {
     init_crypto();
 
-    let cert_storage = MockStorage::new();
+    let material_storage = MockStorage::new();
 
     let manager = CertManager::new(
         vec!["example.com"],
@@ -268,7 +263,7 @@ async fn test_certificate_storage_and_retrieval() {
         "https://acme-staging-v02.api.letsencrypt.org/directory",
     )
     .unwrap()
-    .with_cert_storage(cert_storage.clone());
+    .with_crypto_material_storage(material_storage.clone());
 
     let cert = manager.certificate().await.unwrap();
     assert!(cert.is_none());
@@ -278,7 +273,7 @@ async fn test_certificate_storage_and_retrieval() {
     let cert_data: CertificateData = serde_json::from_str(serialized).unwrap();
 
     let cert_key = manager.cert_key();
-    cert_storage.store(&cert_key, serialized).await.unwrap();
+    material_storage.store(&cert_key, serialized).await.unwrap();
 
     let retrieved_cert = manager.certificate().await.unwrap();
     assert!(retrieved_cert.is_some());
@@ -292,7 +287,7 @@ async fn test_certificate_storage_and_retrieval() {
 async fn test_signing_key_generation_and_storage() {
     init_crypto();
 
-    let secrets_storage = MockStorage::new();
+    let material_storage = MockStorage::new();
 
     let manager = CertManager::new(
         vec!["example.com"],
@@ -301,7 +296,7 @@ async fn test_signing_key_generation_and_storage() {
         "https://acme-staging-v02.api.letsencrypt.org/directory",
     )
     .unwrap()
-    .with_secrets_storage(secrets_storage.clone());
+    .with_crypto_material_storage(material_storage.clone());
 
     // First call should generate and store a new key
     let generated_key = manager.signing_key_pem().await.unwrap();
@@ -313,12 +308,54 @@ async fn test_signing_key_generation_and_storage() {
     assert_eq!(key, generated_key);
 
     // The key should have been stored
-    let stored_key = secrets_storage
+    let stored_key = material_storage
         .load("keys-example.com")
         .await
         .unwrap()
         .unwrap();
     assert_eq!(key, stored_key);
+}
+
+#[tokio::test]
+async fn test_crypto_material_cache_policy_can_skip_private_key_cache() {
+    use crate::cert_manager::storage::CryptoMaterialCachePolicy;
+    use std::time::Duration;
+
+    init_crypto();
+
+    let material_storage = MockStorage::new();
+    let serialized = include_str!("../../../test_data/cert_data.json");
+    let key_pem = include_str!("../../../test_data/ec-private.pem");
+    material_storage
+        .store("certs-example.com-cert_data.json", serialized)
+        .await
+        .unwrap();
+    material_storage
+        .store("keys-example.com", key_pem)
+        .await
+        .unwrap();
+
+    let manager = CertManager::builder()
+        .domains(["example.com"])
+        .crypto_material_cache_policy(CryptoMaterialCachePolicy::new(
+            Duration::from_secs(60),
+            Duration::ZERO,
+        ))
+        .crypto_material_storage(material_storage.clone())
+        .store_strategy(StoreProvisioningStrategy::filesystem(
+            "/tmp/example-cert.pem",
+            "/tmp/example-key.pem",
+        ))
+        .build()
+        .unwrap();
+
+    manager.certificate().await.unwrap();
+    manager.certificate().await.unwrap();
+    assert_eq!(material_storage.load_count(), 1);
+
+    assert_eq!(manager.signing_key_pem().await.unwrap(), key_pem);
+    assert_eq!(manager.signing_key_pem().await.unwrap(), key_pem);
+    assert_eq!(material_storage.load_count(), 3);
 }
 
 #[tokio::test]
@@ -342,8 +379,7 @@ async fn test_store_filesystem_strategy_persists_material() {
 
     let manager = CertManager::builder()
         .domains(["example.com"])
-        .cert_storage(MockStorage::new())
-        .secrets_storage(MockStorage::new())
+        .crypto_material_storage(MockStorage::new())
         .store_strategy(StoreProvisioningStrategy::filesystem(cert_path, key_path))
         .build()
         .unwrap();
@@ -386,8 +422,7 @@ async fn test_store_filesystem_strategy_accepts_der_material() {
 
     let manager = CertManager::builder()
         .domains(["example.com"])
-        .cert_storage(MockStorage::new())
-        .secrets_storage(MockStorage::new())
+        .crypto_material_storage(MockStorage::new())
         .store_strategy(StoreProvisioningStrategy::filesystem(cert_path, key_path))
         .build()
         .unwrap();
@@ -407,23 +442,21 @@ async fn test_store_filesystem_strategy_accepts_der_material() {
 async fn test_store_secrets_strategy_persists_material() {
     init_crypto();
 
-    let cert_storage = MockStorage::new();
-    let secrets_storage = MockStorage::new();
+    let material_storage = MockStorage::new();
     let source_cert_data: CertificateData =
         serde_json::from_str(include_str!("../../../test_data/cert_data.json")).unwrap();
     let cert_pem = source_cert_data.certificate.as_str();
     let key_pem = include_str!("../../../test_data/ec-private.pem");
 
-    secrets_storage
+    material_storage
         .store("source-cert", cert_pem)
         .await
         .unwrap();
-    secrets_storage.store("source-key", key_pem).await.unwrap();
+    material_storage.store("source-key", key_pem).await.unwrap();
 
     let manager = CertManager::builder()
         .domains(["example.com"])
-        .cert_storage(cert_storage)
-        .secrets_storage(secrets_storage)
+        .crypto_material_storage(material_storage)
         .store_strategy(StoreProvisioningStrategy::secrets_storage(
             "source-cert",
             "source-key",
@@ -443,8 +476,7 @@ async fn test_store_secrets_strategy_accepts_base64_der_material() {
 
     init_crypto();
 
-    let cert_storage = MockStorage::new();
-    let secrets_storage = MockStorage::new();
+    let material_storage = MockStorage::new();
     let source_cert_data: CertificateData =
         serde_json::from_str(include_str!("../../../test_data/cert_data.json")).unwrap();
     let cert_pem = source_cert_data.certificate.as_str();
@@ -455,19 +487,18 @@ async fn test_store_secrets_strategy_accepts_base64_der_material() {
         .to_pkcs8_der_bytes()
         .unwrap();
 
-    secrets_storage
+    material_storage
         .store("source-cert", &BASE64_STANDARD.encode(cert_der.contents))
         .await
         .unwrap();
-    secrets_storage
+    material_storage
         .store("source-key", &BASE64_URL_SAFE_NO_PAD.encode(key_der))
         .await
         .unwrap();
 
     let manager = CertManager::builder()
         .domains(["example.com"])
-        .cert_storage(cert_storage)
-        .secrets_storage(secrets_storage)
+        .crypto_material_storage(material_storage)
         .store_strategy(StoreProvisioningStrategy::secrets_storage(
             "source-cert",
             "source-key",
@@ -515,7 +546,7 @@ fn test_ts_to_local_helper() {
 async fn test_cert_chain_parts() {
     init_crypto();
 
-    let cert_storage = MockStorage::new();
+    let material_storage = MockStorage::new();
     let cert_manager = CertManager::new(
         vec!["example.com"],
         "test@example.com",
@@ -523,11 +554,11 @@ async fn test_cert_chain_parts() {
         "https://acme-staging-v02.api.letsencrypt.org/directory",
     )
     .unwrap()
-    .with_cert_storage(cert_storage.clone());
+    .with_crypto_material_storage(material_storage.clone());
 
     // there are 2 parts in the certificate chain
     let serialized = include_str!("../../../test_data/cert_data.json");
-    cert_storage
+    material_storage
         .store("certs-example.com-cert_data.json", serialized)
         .await
         .unwrap();
@@ -540,7 +571,7 @@ async fn test_cert_chain_parts() {
 async fn test_cert_chain_parts_are_cached_after_first_load() {
     init_crypto();
 
-    let cert_storage = MockStorage::new();
+    let material_storage = MockStorage::new();
     let cert_manager = CertManager::new(
         vec!["example.com"],
         "test@example.com",
@@ -548,10 +579,10 @@ async fn test_cert_chain_parts_are_cached_after_first_load() {
         "https://acme-staging-v02.api.letsencrypt.org/directory",
     )
     .unwrap()
-    .with_cert_storage(cert_storage.clone());
+    .with_crypto_material_storage(material_storage.clone());
 
     let serialized = include_str!("../../../test_data/cert_data.json");
-    cert_storage
+    material_storage
         .store("certs-example.com-cert_data.json", serialized)
         .await
         .unwrap();
@@ -561,14 +592,14 @@ async fn test_cert_chain_parts_are_cached_after_first_load() {
 
     assert_eq!(first.len(), 2);
     assert!(Arc::ptr_eq(&first, &second));
-    assert_eq!(cert_storage.load_count(), 1);
+    assert_eq!(material_storage.load_count(), 1);
 }
 
 #[tokio::test]
 async fn test_cache_provisioned_chain_replaces_cached_entry() {
     init_crypto();
 
-    let cert_storage = MockStorage::new();
+    let material_storage = MockStorage::new();
     let cert_manager = CertManager::new(
         vec!["example.com"],
         "test@example.com",
@@ -576,16 +607,16 @@ async fn test_cache_provisioned_chain_replaces_cached_entry() {
         "https://acme-staging-v02.api.letsencrypt.org/directory",
     )
     .unwrap()
-    .with_cert_storage(cert_storage.clone());
+    .with_crypto_material_storage(material_storage.clone());
 
     let cert_key = cert_manager.cert_key();
     let serialized = include_str!("../../../test_data/cert_data.json");
-    cert_storage.store(&cert_key, serialized).await.unwrap();
+    material_storage.store(&cert_key, serialized).await.unwrap();
 
     // First read populates the cache from storage.
     let first = cert_manager.cert_chain_parts().await.unwrap().unwrap();
     assert_eq!(first.len(), 2);
-    assert_eq!(cert_storage.load_count(), 1);
+    assert_eq!(material_storage.load_count(), 1);
 
     // Simulate re-provisioning with a different certificate by invoking the
     // same hook `request_certificate` calls after storing a new cert.
@@ -599,14 +630,14 @@ async fn test_cache_provisioned_chain_replaces_cached_entry() {
     let reloaded = cert_manager.cert_chain_parts().await.unwrap().unwrap();
     assert_eq!(reloaded.len(), 1);
     assert!(!Arc::ptr_eq(&first, &reloaded));
-    assert_eq!(cert_storage.load_count(), 1);
+    assert_eq!(material_storage.load_count(), 1);
 }
 
 #[tokio::test]
 async fn test_cert_chain_cache_invalidation_reloads_chain() {
     init_crypto();
 
-    let cert_storage = MockStorage::new();
+    let material_storage = MockStorage::new();
     let cert_manager = CertManager::new(
         vec!["example.com"],
         "test@example.com",
@@ -614,11 +645,11 @@ async fn test_cert_chain_cache_invalidation_reloads_chain() {
         "https://acme-staging-v02.api.letsencrypt.org/directory",
     )
     .unwrap()
-    .with_cert_storage(cert_storage.clone());
+    .with_crypto_material_storage(material_storage.clone());
 
     let cert_key = cert_manager.cert_key();
     let serialized = include_str!("../../../test_data/cert_data.json");
-    cert_storage.store(&cert_key, serialized).await.unwrap();
+    material_storage.store(&cert_key, serialized).await.unwrap();
 
     let first = cert_manager.cert_chain_parts().await.unwrap().unwrap();
     assert_eq!(first.len(), 2);
@@ -630,21 +661,21 @@ async fn test_cert_chain_cache_invalidation_reloads_chain() {
         updated_at: 3,
     };
     let serialized_replacement = serde_json::to_string(&replacement).unwrap();
-    cert_storage
+    material_storage
         .store(&cert_key, &serialized_replacement)
         .await
         .unwrap();
 
     let stale_cached = cert_manager.cert_chain_parts().await.unwrap().unwrap();
     assert!(Arc::ptr_eq(&first, &stale_cached));
-    assert_eq!(cert_storage.load_count(), 1);
+    assert_eq!(material_storage.load_count(), 1);
 
     cert_manager.cert_chain_cache.invalidate(&cert_key).await;
     let reloaded = cert_manager.cert_chain_parts().await.unwrap().unwrap();
 
     assert_eq!(reloaded.len(), 1);
     assert!(!Arc::ptr_eq(&first, &reloaded));
-    assert_eq!(cert_storage.load_count(), 2);
+    assert_eq!(material_storage.load_count(), 2);
 }
 
 fn setup_test_metrics_registry() -> prometheus::Registry {
@@ -789,8 +820,7 @@ fn test_renewal_attempts_metric_via_manager() {
     init_crypto();
     let registry = setup_test_metrics_registry();
 
-    let cert_storage = MockStorage::new();
-    let secrets_storage = MockStorage::new();
+    let material_storage = MockStorage::new();
 
     let cert_manager = CertManager::new(
         vec!["example.com"],
@@ -799,8 +829,7 @@ fn test_renewal_attempts_metric_via_manager() {
         "https://acme-staging-v02.api.letsencrypt.org/directory",
     )
     .unwrap()
-    .with_cert_storage(cert_storage)
-    .with_secrets_storage(secrets_storage);
+    .with_crypto_material_storage(material_storage);
 
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()

--- a/src/utils/cert_manager/tests.rs
+++ b/src/utils/cert_manager/tests.rs
@@ -1,6 +1,6 @@
 use crate::{
     cert_manager::storage::{Storage, StorageError},
-    utils::keygen::Keypair,
+    utils::{keygen::Keypair, metrics::metrics_test_lock},
 };
 
 use super::*;
@@ -43,6 +43,55 @@ impl MockStorage {
     }
 }
 
+#[derive(Clone)]
+struct CreateIfAbsentStorage {
+    data: Arc<Mutex<HashMap<String, String>>>,
+    update_count: Arc<AtomicUsize>,
+}
+
+impl CreateIfAbsentStorage {
+    fn new() -> Self {
+        Self {
+            data: Arc::new(Mutex::new(HashMap::new())),
+            update_count: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn update_count(&self) -> usize {
+        self.update_count.load(Ordering::Relaxed)
+    }
+}
+
+#[async_trait]
+impl Storage for CreateIfAbsentStorage {
+    async fn store(&self, key: &str, value: &str) -> Result<(), StorageError> {
+        self.data
+            .lock()
+            .await
+            .entry(key.to_string())
+            .or_insert_with(|| value.to_string());
+        Ok(())
+    }
+
+    async fn load(&self, key: &str) -> Result<Option<String>, StorageError> {
+        Ok(self.data.lock().await.get(key).cloned())
+    }
+
+    async fn update(&self, key: &str, value: &str) -> Result<(), StorageError> {
+        self.update_count.fetch_add(1, Ordering::Relaxed);
+        self.data
+            .lock()
+            .await
+            .insert(key.to_string(), value.to_string());
+        Ok(())
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), StorageError> {
+        self.data.lock().await.remove(key);
+        Ok(())
+    }
+}
+
 #[async_trait]
 impl Storage for MockStorage {
     async fn store(&self, key: &str, value: &str) -> Result<(), StorageError> {
@@ -77,10 +126,10 @@ fn test_cert_manager_builder() {
         "https://acme-staging-v02.api.letsencrypt.org/directory",
     )
     .unwrap()
-    .with_crypto_material_storage(material_storage)
+    .with_crypto_storage(material_storage)
     .with_eku(&[1, 2, 3, 4]);
 
-    assert!(manager.crypto_material_storage.is_some());
+    assert!(manager.crypto_storage.is_some());
     assert!(manager.challenge_handler.is_none());
     assert_eq!(manager.eku, Some(vec![1, 2, 3, 4]));
 }
@@ -93,7 +142,7 @@ fn test_acme_builder_requires_challenge_handler() {
         .domains(["example.com"])
         .email("test@example.com")
         .acme_directory_url("https://acme.example.com/directory")
-        .crypto_material_storage(MockStorage::new())
+        .crypto_storage(MockStorage::new())
         .acme_strategy()
         .build();
 
@@ -111,7 +160,7 @@ fn test_store_builder_does_not_require_acme_components() {
 
     let result = CertManager::builder()
         .domains(["example.com"])
-        .crypto_material_storage(MockStorage::new())
+        .crypto_storage(MockStorage::new())
         .store_strategy(StoreProvisioningStrategy::filesystem(
             "/tmp/example-cert.pem",
             "/tmp/example-key.pem",
@@ -244,7 +293,7 @@ async fn test_certificate_returns_none_if_not_found() {
         "https://acme-staging-v02.api.letsencrypt.org/directory",
     )
     .unwrap()
-    .with_crypto_material_storage(material_storage);
+    .with_crypto_storage(material_storage);
 
     let cert = cert_manager.certificate().await.unwrap();
     assert!(cert.is_none());
@@ -263,7 +312,7 @@ async fn test_certificate_storage_and_retrieval() {
         "https://acme-staging-v02.api.letsencrypt.org/directory",
     )
     .unwrap()
-    .with_crypto_material_storage(material_storage.clone());
+    .with_crypto_storage(material_storage.clone());
 
     let cert = manager.certificate().await.unwrap();
     assert!(cert.is_none());
@@ -296,7 +345,7 @@ async fn test_signing_key_generation_and_storage() {
         "https://acme-staging-v02.api.letsencrypt.org/directory",
     )
     .unwrap()
-    .with_crypto_material_storage(material_storage.clone());
+    .with_crypto_storage(material_storage.clone());
 
     // First call should generate and store a new key
     let generated_key = manager.signing_key_pem().await.unwrap();
@@ -317,8 +366,8 @@ async fn test_signing_key_generation_and_storage() {
 }
 
 #[tokio::test]
-async fn test_crypto_material_cache_policy_can_skip_private_key_cache() {
-    use crate::cert_manager::storage::CryptoMaterialCachePolicy;
+async fn test_crypto_cache_policy_can_skip_private_key_cache() {
+    use crate::cert_manager::storage::CryptoCachePolicy;
     use std::time::Duration;
 
     init_crypto();
@@ -337,11 +386,11 @@ async fn test_crypto_material_cache_policy_can_skip_private_key_cache() {
 
     let manager = CertManager::builder()
         .domains(["example.com"])
-        .crypto_material_cache_policy(CryptoMaterialCachePolicy::new(
+        .crypto_cache_policy(CryptoCachePolicy::new(
             Duration::from_secs(60),
             Duration::ZERO,
         ))
-        .crypto_material_storage(material_storage.clone())
+        .crypto_storage(material_storage.clone())
         .store_strategy(StoreProvisioningStrategy::filesystem(
             "/tmp/example-cert.pem",
             "/tmp/example-key.pem",
@@ -356,6 +405,81 @@ async fn test_crypto_material_cache_policy_can_skip_private_key_cache() {
     assert_eq!(manager.signing_key_pem().await.unwrap(), key_pem);
     assert_eq!(manager.signing_key_pem().await.unwrap(), key_pem);
     assert_eq!(material_storage.load_count(), 3);
+}
+
+#[tokio::test]
+async fn test_crypto_cache_policy_applies_after_storage_setter() {
+    use crate::cert_manager::storage::CryptoCachePolicy;
+    use std::time::Duration;
+
+    init_crypto();
+
+    let material_storage = MockStorage::new();
+    let serialized = include_str!("../../../test_data/cert_data.json");
+    material_storage
+        .store("certs-example.com-cert_data.json", serialized)
+        .await
+        .unwrap();
+
+    let manager = CertManager::builder()
+        .domains(["example.com"])
+        .crypto_storage(material_storage.clone())
+        .crypto_cache_policy(CryptoCachePolicy::new(
+            Duration::from_secs(60),
+            Duration::ZERO,
+        ))
+        .store_strategy(StoreProvisioningStrategy::filesystem(
+            "/tmp/example-cert.pem",
+            "/tmp/example-key.pem",
+        ))
+        .build()
+        .unwrap();
+
+    manager.certificate().await.unwrap();
+    manager.certificate().await.unwrap();
+
+    assert_eq!(material_storage.load_count(), 1);
+}
+
+#[tokio::test]
+async fn test_persist_certificate_data_updates_existing_material() {
+    init_crypto();
+
+    let material_storage = CreateIfAbsentStorage::new();
+    let manager = CertManager::builder()
+        .domains(["example.com"])
+        .crypto_storage(material_storage.clone())
+        .store_strategy(StoreProvisioningStrategy::filesystem(
+            "/tmp/example-cert.pem",
+            "/tmp/example-key.pem",
+        ))
+        .build()
+        .unwrap();
+
+    let first_cert: CertificateData =
+        serde_json::from_str(include_str!("../../../test_data/cert_data.json")).unwrap();
+    let replacement_cert = CertificateData {
+        certificate: include_str!("../../../test_data/test_cert2.pem").to_string(),
+        valid_from: 1,
+        expires_at: 2,
+        updated_at: 3,
+    };
+
+    manager.persist_certificate_data(&first_cert).await.unwrap();
+    manager
+        .persist_certificate_data(&replacement_cert)
+        .await
+        .unwrap();
+
+    let stored = material_storage
+        .load(&manager.cert_key())
+        .await
+        .unwrap()
+        .unwrap();
+    let stored: CertificateData = serde_json::from_str(&stored).unwrap();
+
+    assert_eq!(stored.certificate, replacement_cert.certificate);
+    assert_eq!(material_storage.update_count(), 1);
 }
 
 #[tokio::test]
@@ -379,7 +503,7 @@ async fn test_store_filesystem_strategy_persists_material() {
 
     let manager = CertManager::builder()
         .domains(["example.com"])
-        .crypto_material_storage(MockStorage::new())
+        .crypto_storage(MockStorage::new())
         .store_strategy(StoreProvisioningStrategy::filesystem(cert_path, key_path))
         .build()
         .unwrap();
@@ -422,7 +546,7 @@ async fn test_store_filesystem_strategy_accepts_der_material() {
 
     let manager = CertManager::builder()
         .domains(["example.com"])
-        .crypto_material_storage(MockStorage::new())
+        .crypto_storage(MockStorage::new())
         .store_strategy(StoreProvisioningStrategy::filesystem(cert_path, key_path))
         .build()
         .unwrap();
@@ -439,7 +563,7 @@ async fn test_store_filesystem_strategy_accepts_der_material() {
 }
 
 #[tokio::test]
-async fn test_store_secrets_strategy_persists_material() {
+async fn test_store_storage_strategy_persists_material() {
     init_crypto();
 
     let material_storage = MockStorage::new();
@@ -456,8 +580,8 @@ async fn test_store_secrets_strategy_persists_material() {
 
     let manager = CertManager::builder()
         .domains(["example.com"])
-        .crypto_material_storage(material_storage)
-        .store_strategy(StoreProvisioningStrategy::secrets_storage(
+        .crypto_storage(material_storage)
+        .store_strategy(StoreProvisioningStrategy::storage(
             "source-cert",
             "source-key",
         ))
@@ -471,7 +595,7 @@ async fn test_store_secrets_strategy_persists_material() {
 }
 
 #[tokio::test]
-async fn test_store_secrets_strategy_accepts_base64_der_material() {
+async fn test_store_storage_strategy_accepts_base64_der_material() {
     use base64::prelude::{BASE64_STANDARD, BASE64_URL_SAFE_NO_PAD, Engine as _};
 
     init_crypto();
@@ -498,8 +622,8 @@ async fn test_store_secrets_strategy_accepts_base64_der_material() {
 
     let manager = CertManager::builder()
         .domains(["example.com"])
-        .crypto_material_storage(material_storage)
-        .store_strategy(StoreProvisioningStrategy::secrets_storage(
+        .crypto_storage(material_storage)
+        .store_strategy(StoreProvisioningStrategy::storage(
             "source-cert",
             "source-key",
         ))
@@ -554,7 +678,7 @@ async fn test_cert_chain_parts() {
         "https://acme-staging-v02.api.letsencrypt.org/directory",
     )
     .unwrap()
-    .with_crypto_material_storage(material_storage.clone());
+    .with_crypto_storage(material_storage.clone());
 
     // there are 2 parts in the certificate chain
     let serialized = include_str!("../../../test_data/cert_data.json");
@@ -579,7 +703,7 @@ async fn test_cert_chain_parts_are_cached_after_first_load() {
         "https://acme-staging-v02.api.letsencrypt.org/directory",
     )
     .unwrap()
-    .with_crypto_material_storage(material_storage.clone());
+    .with_crypto_storage(material_storage.clone());
 
     let serialized = include_str!("../../../test_data/cert_data.json");
     material_storage
@@ -607,7 +731,7 @@ async fn test_cache_provisioned_chain_replaces_cached_entry() {
         "https://acme-staging-v02.api.letsencrypt.org/directory",
     )
     .unwrap()
-    .with_crypto_material_storage(material_storage.clone());
+    .with_crypto_storage(material_storage.clone());
 
     let cert_key = cert_manager.cert_key();
     let serialized = include_str!("../../../test_data/cert_data.json");
@@ -645,7 +769,7 @@ async fn test_cert_chain_cache_invalidation_reloads_chain() {
         "https://acme-staging-v02.api.letsencrypt.org/directory",
     )
     .unwrap()
-    .with_crypto_material_storage(material_storage.clone());
+    .with_crypto_storage(material_storage.clone());
 
     let cert_key = cert_manager.cert_key();
     let serialized = include_str!("../../../test_data/cert_data.json");
@@ -678,11 +802,16 @@ async fn test_cert_chain_cache_invalidation_reloads_chain() {
     assert_eq!(material_storage.load_count(), 2);
 }
 
-fn setup_test_metrics_registry() -> prometheus::Registry {
+fn setup_test_metrics_registry() -> (
+    std::sync::MutexGuard<'static, ()>,
+    prometheus::Registry,
+    opentelemetry_sdk::metrics::SdkMeterProvider,
+) {
     use crate::config::{TelemetryConfig, TelemetryEnvironment};
     use crate::utils::metrics::setup_metrics;
     use opentelemetry_sdk::Resource;
 
+    let metrics_guard = metrics_test_lock();
     let registry = prometheus::Registry::new();
     let config = TelemetryConfig {
         environment: TelemetryEnvironment::Development,
@@ -690,14 +819,15 @@ fn setup_test_metrics_registry() -> prometheus::Registry {
         sampler_ratio: 1.0,
         enabled: false,
     };
-    let _ = setup_metrics(
+    let meter_provider = setup_metrics(
         &registry,
         &config,
         Resource::builder()
             .with_service_name("cert-manager-test")
             .build(),
-    );
-    registry
+    )
+    .expect("metrics setup");
+    (metrics_guard, registry, meter_provider)
 }
 
 fn counter_value(registry: &prometheus::Registry, name: &str) -> f64 {
@@ -721,7 +851,7 @@ fn gauge_value(registry: &prometheus::Registry, name: &str) -> f64 {
 #[test]
 fn test_init_renewal_counters_registers_zero_values() {
     init_crypto();
-    let registry = setup_test_metrics_registry();
+    let (_metrics_guard, registry, _meter_provider) = setup_test_metrics_registry();
 
     let cert_manager = CertManager::new(
         vec!["example.com"],
@@ -741,7 +871,7 @@ fn test_init_renewal_counters_registers_zero_values() {
 #[test]
 fn test_update_time_to_expiry_sets_gauge() {
     init_crypto();
-    let registry = setup_test_metrics_registry();
+    let (_metrics_guard, registry, _meter_provider) = setup_test_metrics_registry();
 
     let cert_manager = CertManager::new(
         vec!["example.com"],
@@ -772,7 +902,7 @@ fn test_update_time_to_expiry_sets_gauge() {
 #[test]
 fn test_record_successful_renewal_updates_counters_and_gauge() {
     init_crypto();
-    let registry = setup_test_metrics_registry();
+    let (_metrics_guard, registry, _meter_provider) = setup_test_metrics_registry();
 
     let cert_manager = CertManager::new(
         vec!["example.com"],
@@ -798,7 +928,7 @@ fn test_record_successful_renewal_updates_counters_and_gauge() {
 #[test]
 fn test_record_failed_renewal_increments_failure_counter() {
     init_crypto();
-    let registry = setup_test_metrics_registry();
+    let (_metrics_guard, registry, _meter_provider) = setup_test_metrics_registry();
 
     let cert_manager = CertManager::new(
         vec!["example.com"],
@@ -818,7 +948,7 @@ fn test_record_failed_renewal_increments_failure_counter() {
 #[test]
 fn test_renewal_attempts_metric_via_manager() {
     init_crypto();
-    let registry = setup_test_metrics_registry();
+    let (_metrics_guard, registry, _meter_provider) = setup_test_metrics_registry();
 
     let material_storage = MockStorage::new();
 
@@ -829,7 +959,7 @@ fn test_renewal_attempts_metric_via_manager() {
         "https://acme-staging-v02.api.letsencrypt.org/directory",
     )
     .unwrap()
-    .with_crypto_material_storage(material_storage);
+    .with_crypto_storage(material_storage);
 
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()

--- a/src/utils/metrics.rs
+++ b/src/utils/metrics.rs
@@ -12,6 +12,16 @@ use std::time::{Duration, Instant};
 
 use crate::config::TelemetryConfig;
 
+#[cfg(test)]
+static METRICS_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+#[cfg(test)]
+pub(crate) fn metrics_test_lock() -> std::sync::MutexGuard<'static, ()> {
+    METRICS_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 /// Initialize the OpenTelemetry metrics pipeline before any instruments are
 /// created. Metrics are always exposed through the in-process Prometheus
 /// registry. In production, they are also pushed to the Collector over OTLP.
@@ -203,6 +213,7 @@ mod tests {
 
     #[test]
     fn setup_metrics_registers_process_metric_families() {
+        let _metrics_guard = metrics_test_lock();
         let registry = Registry::new();
         let config = TelemetryConfig {
             environment: TelemetryEnvironment::Development,

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -232,7 +232,7 @@ version = "0.1.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.cc]]
-version = "1.4.2"
+version = "1.4.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.cexpr]]
@@ -592,7 +592,7 @@ version = "0.14.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.find-msvc-tools]]
-version = "0.1.10"
+version = "0.1.11"
 criteria = "safe-to-deploy"
 
 [[exemptions.flate2]]
@@ -708,7 +708,7 @@ version = "0.14.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.h2]]
-version = "0.4.15"
+version = "0.4.16"
 criteria = "safe-to-deploy"
 
 [[exemptions.half]]
@@ -788,7 +788,7 @@ version = "1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.http-body-util]]
-version = "0.1.4"
+version = "0.1.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.httparse]]
@@ -832,31 +832,31 @@ version = "0.1.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.icu_collections]]
-version = "2.2.0"
+version = "2.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.icu_locale_core]]
-version = "2.2.0"
+version = "2.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.icu_normalizer]]
-version = "2.2.0"
+version = "2.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.icu_normalizer_data]]
-version = "2.2.0"
+version = "2.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.icu_properties]]
-version = "2.2.0"
+version = "2.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.icu_properties_data]]
-version = "2.2.0"
+version = "2.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.icu_provider]]
-version = "2.2.0"
+version = "2.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.ident_case]]
@@ -972,7 +972,7 @@ version = "0.14.11"
 criteria = "safe-to-deploy"
 
 [[exemptions.libredox]]
-version = "0.1.19"
+version = "0.1.20"
 criteria = "safe-to-deploy"
 
 [[exemptions.libsqlite3-sys]]
@@ -984,7 +984,7 @@ version = "0.12.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.litemap]]
-version = "0.8.2"
+version = "0.8.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.lock_api]]
@@ -1081,6 +1081,10 @@ criteria = "safe-to-run"
 
 [[exemptions.num-bigint]]
 version = "0.4.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.num-bigint]]
+version = "0.5.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.num-bigint-dig]]
@@ -1232,19 +1236,19 @@ version = "2.3.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.pest]]
-version = "2.8.8"
+version = "2.9.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.pest_derive]]
-version = "2.8.8"
+version = "2.9.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.pest_generator]]
-version = "2.8.8"
+version = "2.9.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.pest_meta]]
-version = "2.8.8"
+version = "2.9.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.pgvector]]
@@ -1288,7 +1292,7 @@ version = "0.11.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.pkg-config]]
-version = "0.3.33"
+version = "0.3.34"
 criteria = "safe-to-deploy"
 
 [[exemptions.plain]]
@@ -1304,7 +1308,7 @@ version = "0.2.7"
 criteria = "safe-to-run"
 
 [[exemptions.potential_utf]]
-version = "0.1.5"
+version = "0.1.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.powerfmt]]
@@ -1392,7 +1396,7 @@ version = "0.11.11"
 criteria = "safe-to-deploy"
 
 [[exemptions.quinn-proto]]
-version = "0.11.16"
+version = "0.11.17"
 criteria = "safe-to-deploy"
 
 [[exemptions.quinn-udp]]
@@ -1452,7 +1456,7 @@ version = "0.14.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.redis]]
-version = "1.5.0"
+version = "1.6.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.redox_syscall]]
@@ -1460,7 +1464,7 @@ version = "0.5.18"
 criteria = "safe-to-deploy"
 
 [[exemptions.redox_syscall]]
-version = "0.9.1"
+version = "0.9.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.ref-cast]]
@@ -1976,7 +1980,7 @@ version = "2.0.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.tinystr]]
-version = "0.8.3"
+version = "0.8.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.tinyvec_macros]]
@@ -2160,7 +2164,7 @@ version = "1.0.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.uuid]]
-version = "1.24.0"
+version = "1.24.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.valuable]]
@@ -2404,7 +2408,7 @@ version = "0.14.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.writeable]]
-version = "0.6.3"
+version = "0.6.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.wyz]]
@@ -2428,7 +2432,7 @@ version = "0.8.18"
 criteria = "safe-to-deploy"
 
 [[exemptions.yaml-rust2]]
-version = "0.11.0"
+version = "0.11.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.yansi]]
@@ -2472,15 +2476,15 @@ version = "1.5.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerotrie]]
-version = "0.2.4"
+version = "0.2.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerovec]]
-version = "0.11.6"
+version = "0.11.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerovec-derive]]
-version = "0.11.3"
+version = "0.11.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.zmij]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -23,29 +23,29 @@ user-login = "aws-sdk-rust-ci"
 user-name = "AWS SDK Rust Bot"
 
 [[publisher.aws-sdk-route53]]
-version = "1.118.0"
-when = "2026-07-24"
+version = "1.119.0"
+when = "2026-08-17"
 user-id = 160111
 user-login = "aws-sdk-rust-ci"
 user-name = "AWS SDK Rust Bot"
 
 [[publisher.aws-sdk-s3]]
-version = "1.141.0"
-when = "2026-08-06"
+version = "1.142.0"
+when = "2026-08-17"
 user-id = 160111
 user-login = "aws-sdk-rust-ci"
 user-name = "AWS SDK Rust Bot"
 
 [[publisher.aws-sdk-secretsmanager]]
-version = "1.111.0"
-when = "2026-07-24"
+version = "1.112.0"
+when = "2026-08-17"
 user-id = 160111
 user-login = "aws-sdk-rust-ci"
 user-name = "AWS SDK Rust Bot"
 
 [[publisher.aws-sdk-sts]]
-version = "1.110.0"
-when = "2026-07-24"
+version = "1.111.0"
+when = "2026-08-17"
 user-id = 160111
 user-login = "aws-sdk-rust-ci"
 user-name = "AWS SDK Rust Bot"
@@ -72,8 +72,8 @@ user-login = "aws-sdk-rust-ci"
 user-name = "AWS SDK Rust Bot"
 
 [[publisher.aws-smithy-eventstream]]
-version = "0.61.1"
-when = "2026-07-07"
+version = "0.61.2"
+when = "2026-08-12"
 user-id = 160111
 user-login = "aws-sdk-rust-ci"
 user-name = "AWS SDK Rust Bot"
@@ -86,8 +86,8 @@ user-login = "aws-sdk-rust-ci"
 user-name = "AWS SDK Rust Bot"
 
 [[publisher.aws-smithy-http-client]]
-version = "1.2.0"
-when = "2026-07-07"
+version = "1.3.0"
+when = "2026-08-12"
 user-id = 160111
 user-login = "aws-sdk-rust-ci"
 user-name = "AWS SDK Rust Bot"
@@ -114,8 +114,8 @@ user-login = "aws-sdk-rust-ci"
 user-name = "AWS SDK Rust Bot"
 
 [[publisher.aws-smithy-runtime]]
-version = "1.12.1"
-when = "2026-07-23"
+version = "1.13.1"
+when = "2026-08-12"
 user-id = 160111
 user-login = "aws-sdk-rust-ci"
 user-name = "AWS SDK Rust Bot"
@@ -142,8 +142,8 @@ user-login = "aws-sdk-rust-ci"
 user-name = "AWS SDK Rust Bot"
 
 [[publisher.aws-smithy-types]]
-version = "1.6.1"
-when = "2026-07-07"
+version = "1.6.2"
+when = "2026-08-12"
 user-id = 160111
 user-login = "aws-sdk-rust-ci"
 user-name = "AWS SDK Rust Bot"

--- a/tests/cert_provisioning.rs
+++ b/tests/cert_provisioning.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "aws")]
+#![cfg(feature = "aws-secrets")]
 
 //! Integration tests for the ACME certificate provisioning flow.
 //!

--- a/tests/cert_provisioning.rs
+++ b/tests/cert_provisioning.rs
@@ -377,7 +377,8 @@ async fn test_cert_provisioning_with_hashicorp_vault() {
     let vault_port = _vault_container.get_host_port_ipv4(8200).await.unwrap();
 
     let (role_id, secret_id) = setup_vault_approle(vault_port).await;
-    let secrets_storage = build_vault_storage(vault_port, role_id.clone(), secret_id.clone()).await;
+    let material_storage =
+        build_vault_storage(vault_port, role_id.clone(), secret_id.clone()).await;
     let cert_manager = infra
         .build_cert_manager("vault.example.com", material_storage)
         .await;

--- a/tests/cert_provisioning.rs
+++ b/tests/cert_provisioning.rs
@@ -1,18 +1,16 @@
-#![cfg(all(feature = "aws", feature = "redis"))]
+#![cfg(feature = "aws")]
 
 //! Integration tests for the ACME certificate provisioning flow.
 //!
 //! These tests require Docker to be running. They spin up:
 //! - **Pebble** (ACME CA test server)
 //! - **challtestsrv** (DNS server for Pebble)
-//! - **LocalStack** (S3 + Secrets Manager)
-//! - **Redis** (S3 cache layer)
+//! - **LocalStack** (Secrets Manager)
 //! - **Vault** (if enabled) or **OpenBao** (if enabled)
 
 use std::{sync::Arc, time::Duration};
 
 use aws_config::BehaviorVersion;
-use aws_sdk_s3::Client as S3Client;
 #[cfg(feature = "vault")]
 use secrecy::SecretString;
 #[cfg(feature = "vault")]
@@ -23,14 +21,12 @@ use status_list_server::{
         challenge::{Dns01Handler, PebbleDnsProvider},
         http_client::DefaultHttpClient,
     },
-    outbound::aws::{AwsS3, AwsSecretsManager},
-    outbound::redis::Redis as RedisStorage,
+    outbound::aws::AwsSecretsManager,
 };
 #[cfg(feature = "vault")]
 use testcontainers_modules::hashicorp_vault::HashicorpVault;
 use testcontainers_modules::{
     localstack::LocalStack,
-    redis::Redis,
     testcontainers::{
         ContainerAsync, GenericImage, ImageExt,
         core::{IntoContainerPort, WaitFor},
@@ -44,7 +40,6 @@ const PEBBLE_TAG: &str = "2.10";
 const CHALLTESTSRV_IMAGE: &str = "ghcr.io/letsencrypt/pebble-challtestsrv";
 const CHALLTESTSRV_TAG: &str = "2.10";
 
-const BUCKET_NAME: &str = "status-list-adorsys";
 const AWS_REGION: &str = "us-east-1";
 
 #[cfg(feature = "vault")]
@@ -61,12 +56,10 @@ struct TestInfra {
     _challtestsrv: ContainerAsync<GenericImage>,
     _pebble: ContainerAsync<GenericImage>,
     _localstack: ContainerAsync<LocalStack>,
-    _redis: ContainerAsync<Redis>,
 
     pebble_acme_port: u16,
     challtestsrv_port: u16,
     localstack_port: u16,
-    redis_port: u16,
 }
 
 impl TestInfra {
@@ -113,31 +106,22 @@ impl TestInfra {
 
         let localstack = LocalStack::default()
             .with_tag("4.14")
-            .with_env_var("SERVICES", "s3,secretsmanager")
+            .with_env_var("SERVICES", "secretsmanager")
             .start()
             .await
             .expect("Failed to start LocalStack");
 
-        let redis = Redis::default()
-            .with_tag("8.6")
-            .start()
-            .await
-            .expect("Failed to start Redis");
-
         let pebble_acme_port = pebble.get_host_port_ipv4(14000).await.unwrap();
         let challtestsrv_port = challtestsrv.get_host_port_ipv4(8055).await.unwrap();
         let localstack_port = localstack.get_host_port_ipv4(4566).await.unwrap();
-        let redis_port = redis.get_host_port_ipv4(6379).await.unwrap();
 
         Self {
             _challtestsrv: challtestsrv,
             _pebble: pebble,
             _localstack: localstack,
-            _redis: redis,
             pebble_acme_port,
             challtestsrv_port,
             localstack_port,
-            redis_port,
         }
     }
 
@@ -151,29 +135,13 @@ impl TestInfra {
             .await
     }
 
-    /// Create a Redis connection manager for the cache layer.
-    async fn redis_connection(&self) -> redis::aio::ConnectionManager {
-        let url = format!("redis://127.0.0.1:{}", self.redis_port);
-        let client = redis::Client::open(url).expect("Failed to create Redis client");
-        client
-            .get_connection_manager()
-            .await
-            .expect("Failed to get Redis connection manager")
-    }
-
-    /// Build a `CertManager` with `AwsS3` + `Redis` cache for cert storage,
-    /// and the provided `secrets_storage` backend for signing keys.
+    /// Build a `CertManager` with one cryptographic-material backend for both
+    /// certificate chains and signing keys.
     async fn build_cert_manager(
         &self,
         domain: &str,
-        secrets_storage: impl Storage + 'static,
+        material_storage: impl Storage + 'static,
     ) -> CertManager {
-        let aws_config = self.aws_config().await;
-        let redis_conn = self.redis_connection().await;
-
-        let cache = RedisStorage::new(redis_conn);
-        let cert_storage = AwsS3::new(&aws_config, BUCKET_NAME, AWS_REGION, "").with_cache(cache);
-
         let challtestsrv_url = format!("http://127.0.0.1:{}", self.challtestsrv_port);
         let dns_provider = PebbleDnsProvider::new(&challtestsrv_url);
         let challenge_handler = Dns01Handler::new(dns_provider);
@@ -189,18 +157,9 @@ impl TestInfra {
             &acme_directory_url,
         )
         .expect("Failed to create CertManager")
-        .with_cert_storage(cert_storage)
-        .with_secrets_storage(secrets_storage)
+        .with_crypto_material_storage(material_storage)
         .with_challenge_handler(challenge_handler)
         .with_acme_http_client(http_client)
-    }
-
-    /// Create an S3 client (path-style).
-    async fn s3_client(&self) -> S3Client {
-        let aws_config = self.aws_config().await;
-        let c = S3Client::new(&aws_config);
-        let dev_config = c.config().to_builder().force_path_style(true).build();
-        S3Client::from_conf(dev_config)
     }
 }
 
@@ -221,11 +180,11 @@ async fn test_cert_provisioning_with_aws_secrets_manager() {
 
     let infra = TestInfra::start("provision").await;
     let aws_config = infra.aws_config().await;
-    let secrets_storage = AwsSecretsManager::new(&aws_config, Duration::from_millis(0))
+    let material_storage = AwsSecretsManager::new(&aws_config, Duration::from_millis(0))
         .await
         .expect("Failed to create AwsSecretsManager");
     let cert_manager = infra
-        .build_cert_manager("test.example.com", secrets_storage)
+        .build_cert_manager("test.example.com", material_storage)
         .await;
 
     // Request a certificate
@@ -243,18 +202,7 @@ async fn test_cert_provisioning_with_aws_secrets_manager() {
     assert!(cert_data.valid_from < cert_data.expires_at);
     assert!(cert_data.updated_at > 0);
 
-    // Verify certificate is persisted in S3
-    let s3 = infra.s3_client().await;
-    let objects = s3
-        .list_objects_v2()
-        .bucket(BUCKET_NAME)
-        .send()
-        .await
-        .expect("Failed to list S3 objects");
-    let keys: Vec<_> = objects.contents().iter().filter_map(|o| o.key()).collect();
-    assert!(keys.iter().any(|k| k.contains("cert_data.json")));
-
-    // Verify signing key is in Secrets Manager
+    // Verify certificate and signing key are in the same material backend.
     let aws_config = infra.aws_config().await;
     let secrets = aws_sdk_secretsmanager::Client::new(&aws_config)
         .list_secrets()
@@ -266,7 +214,14 @@ async fn test_cert_provisioning_with_aws_secrets_manager() {
         .iter()
         .filter_map(|s| s.name())
         .collect();
-    assert!(!names.is_empty());
+    assert!(
+        names.iter().any(|name| name.contains("cert_data.json")),
+        "certificate data should be present in Secrets Manager"
+    );
+    assert!(
+        names.iter().any(|name| *name == "keys-test.example.com"),
+        "signing key should be present in Secrets Manager"
+    );
 
     // Verify cert chain extraction
     let cert_chain = cert_manager
@@ -284,12 +239,12 @@ async fn test_certificate_renewal_with_existing_cert() {
 
     let infra = TestInfra::start("renew").await;
     let aws_config = infra.aws_config().await;
-    let secrets_storage = AwsSecretsManager::new(&aws_config, Duration::from_millis(0))
+    let material_storage = AwsSecretsManager::new(&aws_config, Duration::from_millis(0))
         .await
         .expect("Failed to create AwsSecretsManager");
     let cert_manager = Arc::new(
         infra
-            .build_cert_manager("renew.example.com", secrets_storage)
+            .build_cert_manager("renew.example.com", material_storage)
             .await,
     );
 
@@ -330,16 +285,16 @@ async fn test_cert_provisioning_with_hashicorp_vault() {
         .expect("Failed to start HashicorpVault container");
     let vault_port = _vault_container.get_host_port_ipv4(8200).await.unwrap();
 
-    let secrets_storage = build_vault_storage(vault_port);
+    let material_storage = build_vault_storage(vault_port);
     let cert_manager = infra
-        .build_cert_manager("vault.example.com", secrets_storage)
+        .build_cert_manager("vault.example.com", material_storage)
         .await;
 
     // Request a certificate
     let cert_data = cert_manager
         .request_certificate()
         .await
-        .expect("Certificate provisioning failed with Vault secrets backend");
+        .expect("Certificate provisioning failed with Vault material backend");
 
     // Verify the certificate content
     assert!(
@@ -350,19 +305,15 @@ async fn test_cert_provisioning_with_hashicorp_vault() {
     assert!(cert_data.valid_from < cert_data.expires_at);
     assert!(cert_data.updated_at > 0);
 
-    // Verify certificate is persisted in S3 (cert storage)
-    let s3 = infra.s3_client().await;
-    let objects = s3
-        .list_objects_v2()
-        .bucket(BUCKET_NAME)
-        .send()
-        .await
-        .expect("Failed to list S3 objects");
-    let keys: Vec<_> = objects.contents().iter().filter_map(|o| o.key()).collect();
-    assert!(keys.iter().any(|k| k.contains("cert_data.json")));
-
-    // Verify signing key was stored in Vault (secrets storage)
+    // Verify certificate and signing key were stored in Vault through one material backend.
     let vault_reader = build_vault_storage(vault_port);
+    let certificate = Storage::load(&vault_reader, "certs-example.com-cert_data.json")
+        .await
+        .expect("Failed to load certificate data from Vault");
+    assert!(
+        certificate.is_some(),
+        "certificate data should be present in Vault"
+    );
     let signing_key = Storage::load(&vault_reader, "keys-vault.example.com")
         .await
         .expect("Failed to load signing_key from Vault");
@@ -399,16 +350,16 @@ async fn test_cert_provisioning_with_openbao() {
         .expect("Failed to start OpenBao container");
     let openbao_port = _openbao_container.get_host_port_ipv4(8200).await.unwrap();
 
-    let secrets_storage = build_vault_storage(openbao_port);
+    let material_storage = build_vault_storage(openbao_port);
     let cert_manager = infra
-        .build_cert_manager("openbao.example.com", secrets_storage)
+        .build_cert_manager("openbao.example.com", material_storage)
         .await;
 
     // Request a certificate
     let cert_data = cert_manager
         .request_certificate()
         .await
-        .expect("Certificate provisioning failed with OpenBao secrets backend");
+        .expect("Certificate provisioning failed with OpenBao material backend");
 
     // Verify the certificate content
     assert!(
@@ -419,19 +370,15 @@ async fn test_cert_provisioning_with_openbao() {
     assert!(cert_data.valid_from < cert_data.expires_at);
     assert!(cert_data.updated_at > 0);
 
-    // Verify certificate is persisted in S3 (cert storage)
-    let s3 = infra.s3_client().await;
-    let objects = s3
-        .list_objects_v2()
-        .bucket(BUCKET_NAME)
-        .send()
-        .await
-        .expect("Failed to list S3 objects");
-    let keys: Vec<_> = objects.contents().iter().filter_map(|o| o.key()).collect();
-    assert!(keys.iter().any(|k| k.contains("cert_data.json")));
-
-    // Verify signing key was stored in OpenBao (secrets storage)
+    // Verify certificate and signing key were stored in OpenBao through one material backend.
     let openbao_reader = build_vault_storage(openbao_port);
+    let certificate = Storage::load(&openbao_reader, "certs-example.com-cert_data.json")
+        .await
+        .expect("Failed to load certificate data from OpenBao");
+    assert!(
+        certificate.is_some(),
+        "certificate data should be present in OpenBao"
+    );
     let signing_key = Storage::load(&openbao_reader, "keys-openbao.example.com")
         .await
         .expect("Failed to load signing_key from OpenBao");

--- a/tests/cert_provisioning.rs
+++ b/tests/cert_provisioning.rs
@@ -219,7 +219,7 @@ async fn test_cert_provisioning_with_aws_secrets_manager() {
         "certificate data should be present in Secrets Manager"
     );
     assert!(
-        names.iter().any(|name| *name == "keys-test.example.com"),
+        names.contains(&"keys-test.example.com"),
         "signing key should be present in Secrets Manager"
     );
 

--- a/tests/cert_provisioning.rs
+++ b/tests/cert_provisioning.rs
@@ -157,7 +157,7 @@ impl TestInfra {
             &acme_directory_url,
         )
         .expect("Failed to create CertManager")
-        .with_crypto_material_storage(material_storage)
+        .with_crypto_storage(material_storage)
         .with_challenge_handler(challenge_handler)
         .with_acme_http_client(http_client)
     }


### PR DESCRIPTION
**Description**
This PR consolidates server certificate-chain and signing-key management behind a single cryptographic-material backend. The selected material backend now owns the lifecycle-coupled server signing key, certificate chain, and related ACME account material by default.

**Changes**
- Added `CryptoMaterialStorage` and `CryptoMaterialCachePolicy`.
- Added primary config keys:
  - `server.cert.material_backend`
  - `server.cert.material_cache_ttl`
  - `server.cert.signing_key_cache_ttl`
- Updated `CertManager` and builder wiring to use one `crypto_material_storage(...)` backend.
- Kept legacy `cert_storage` / `secrets_storage` builder methods as compatibility aliases.
- Updated ACME and store provisioning to persist certificate and signing key through the same material backend.
- Preserved filesystem store provisioning for externally managed cert/key material.
- Added optional material read caching, with explicit no-cache support for private key reads via `signing_key_cache_ttl = 0`.
- Reworked cache refresh/invalidation so certificate data, parsed certificate chain, and signing-key cache entries are invalidated through one path.
- Updated readiness checks to probe the single material backend.
- Updated tests, integration harness expectations, and docs to reflect the consolidated backend model.

**Verification**
- `cargo check --all-features`
- `cargo test --all-features --no-run`
- `cargo test --lib --features acme utils::cert_manager::tests:: -- --test-threads=1`
- `cargo test --lib --features acme test_config_loading`
- `cargo test --lib --features acme ready_fails_when_crypto_material_backend_is_unreachable`