### PR TITLE
feat: add vault and openbao approle authentication

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -135,8 +135,10 @@ APP_AWS__S3_KEY_PREFIX=
 # APP_VAULT__AUTH_MOUNT=approle
 # APP_VAULT__ROLE_ID=
 # APP_VAULT__SECRET_ID=
+# Alternatively, specify a file path to load secret_id from disk:
+# APP_VAULT__SECRET_ID_PATH=/vault/secrets/secret-id
 # Note on production security: Never hard-code or store secret_id in plain text.
-# Deliver secret_id via a secrets injector (Vault Agent, K8s Secret CSI, etc.).
+# Deliver secret_id via a secrets injector (Vault Agent, K8s Secret CSI, volume mount, etc.).
 #
 # KV v2 engine mount path
 # APP_VAULT__MOUNT=secret

--- a/.env.template
+++ b/.env.template
@@ -129,9 +129,14 @@ APP_AWS__S3_KEY_PREFIX=
 # Vault / OpenBao KV v2 configuration (feature = "vault")
 # When compiled with `vault` feature, Vault/OpenBao is used
 # as the secrets backend for signing-key material.
+# Authentication is performed exclusively via AppRole.
 #
 # APP_VAULT__ADDR=http://vault:8200
-# APP_VAULT__TOKEN=hvs.XXXXXXXXXXXXXXXXXXXXXXXX
+# APP_VAULT__AUTH_MOUNT=approle
+# APP_VAULT__ROLE_ID=
+# APP_VAULT__SECRET_ID=
+# Note on production security: Never hard-code or store secret_id in plain text.
+# Deliver secret_id via a secrets injector (Vault Agent, K8s Secret CSI, etc.).
 #
 # KV v2 engine mount path
 # APP_VAULT__MOUNT=secret

--- a/docs/database-backends.md
+++ b/docs/database-backends.md
@@ -33,7 +33,7 @@ SQLite is not a distributed database, so it is not a good match for horizontally
 
 Every client-facing write — publishing a list, updating one, the snapshot each writes alongside it, and credential registration — runs in a transaction pinned to **READ COMMITTED** on PostgreSQL and MySQL. The level is set by the application, not inherited from the server, so both backends behave identically instead of running at their differing defaults (PostgreSQL READ COMMITTED, InnoDB REPEATABLE READ).
 
-The one write that is **not** pinned is the retention sweep (`delete_older_than`); see *Other notes* below.
+The one write that is **not** pinned is the retention sweep (`delete_older_than`); see _Other notes_ below.
 
 The guard itself does not depend on this. The guarded update is `UPDATE ... WHERE list_id = ? AND updated_at = ?`, a compare-and-set whose match count decides the outcome. That is a current read on both engines, so it sees the latest committed row at either level, and no write transaction issues a `SELECT` whose view could go stale.
 
@@ -50,7 +50,7 @@ SET GLOBAL transaction_isolation = 'SERIALIZABLE';
 
 then without the pin these transactions would inherit it, and a routine race between two writers — normally a clean `409 update_conflict` telling the client to re-read — would instead surface as a serialization failure. Note that this is deliberately **not overridable**: the compare-and-set is the concurrency mechanism here and it wants READ COMMITTED, regardless of what else shares the database.
 
-**Materially fewer deadlocks on MySQL.** This is the larger effect in practice, and it applies to every stock MySQL deployment, not just misconfigured ones — REPEATABLE READ *is* the InnoDB default. At REPEATABLE READ InnoDB takes next-key (gap) locks; at READ COMMITTED it locks index records only. Concretely: every snapshot insert writes `exp = now + token_exp_secs`, so concurrent inserts for unrelated lists land in the same gap of `idx_status_list_history_exp`, while the retention sweep deletes a range of that same index. Those are the ingredients of an insert-intention deadlock. Pinning removes the gap locks and with them that entire class of `1213`.
+**Materially fewer deadlocks on MySQL.** This is the larger effect in practice, and it applies to every stock MySQL deployment, not just misconfigured ones — REPEATABLE READ _is_ the InnoDB default. At REPEATABLE READ InnoDB takes next-key (gap) locks; at READ COMMITTED it locks index records only. Concretely: every snapshot insert writes `exp = now + token_exp_secs`, so concurrent inserts for unrelated lists land in the same gap of `idx_status_list_history_exp`, while the retention sweep deletes a range of that same index. Those are the ingredients of an insert-intention deadlock. Pinning removes the gap locks and with them that entire class of `1213`.
 
 ### MySQL: binary logging must be ROW or MIXED
 

--- a/docs/secrets-backends.md
+++ b/docs/secrets-backends.md
@@ -4,7 +4,7 @@ The server supports storing sensitive cryptographic materials (such as ACME acco
 
 The supported secrets backends include:
 
-- **HashiCorp Vault / OpenBao** (KV v2 engine)
+- **HashiCorp Vault / OpenBao**
 - **AWS Secrets Manager**
 - **In-Memory** (for development and testing)
 
@@ -12,54 +12,142 @@ The supported secrets backends include:
 
 Both HashiCorp Vault and OpenBao share the KV v2 REST API interface and are supported natively when the `vault` feature flag is enabled.
 
+Authentication is strictly performed via **AppRole**, which is the industry standard machine-to-machine authentication mechanism for production deployments.
+
 ### Configuration Variables
 
 | Variable                       | Type              | Default                             | Description                                                              |
 | ------------------------------ | ----------------- | ----------------------------------- | ------------------------------------------------------------------------ |
 | `APP_VAULT__ADDR`              | String            | `http://127.0.0.1:8200`             | Base URL of the Vault / OpenBao cluster                                  |
-| `APP_VAULT__TOKEN`             | String            | _(Mandatory when Vault is enabled)_ | Authentication token (`X-Vault-Token`)                                   |
+| `APP_VAULT__AUTH_MOUNT`        | String            | `"approle"`                         | Mount path of the AppRole auth engine                                    |
+| `APP_VAULT__ROLE_ID`           | String            | _(Mandatory when Vault is enabled)_ | AppRole Role ID identifier                                               |
+| `APP_VAULT__SECRET_ID`         | String (Secret)   | _(Mandatory when Vault is enabled)_ | AppRole Secret ID credential                                             |
 | `APP_VAULT__MOUNT`             | String            | `"secret"`                          | KV v2 secrets engine mount point                                         |
 | `APP_VAULT__PATH_PREFIX`       | String            | `""`                                | Optional prefix prepended to all secret keys (e.g. `status-list-server`) |
 | `APP_VAULT__NAMESPACE`         | String            | `None`                              | Optional Enterprise/OpenBao namespace header (`X-Vault-Namespace`)       |
 | `APP_VAULT__SECRETS_CACHE_TTL` | Integer (seconds) | `300` (5 minutes)                   | In-memory cache TTL in seconds. Set to `0` to disable caching.           |
 | `APP_VAULT__TIMEOUT_SECS`      | Integer (seconds) | `30`                                | HTTP request timeout duration in seconds                                 |
 
+### Least-Privilege Vault / OpenBao Policy
+
+Create a dedicated ACL policy for the status-list-server with minimal permissions on the KV v2 mount:
+
+```hcl
+# status-list-policy.hcl
+# Allow full CRUD on data under the secrets path
+path "secret/data/status-list-server/*" {
+  capabilities = ["create", "read", "update", "delete"]
+}
+
+# Allow reading/deleting metadata for versions and keys
+path "secret/metadata/status-list-server/*" {
+  capabilities = ["read", "delete", "list"]
+}
+
+# Allow proactive token renewal
+path "auth/token/renew-self" {
+  capabilities = ["update"]
+}
+```
+
+Write the policy to Vault / OpenBao:
+
+```bash
+vault policy write status-list-policy status-list-policy.hcl
+```
+
+### Provisioning AppRole Credentials
+
+1. **Enable AppRole auth engine**:
+
+   ```bash
+   vault auth enable approle
+   ```
+
+2. **Create the application role**:
+
+   ```bash
+   vault write auth/approle/role/status-list-role \
+     token_policies="status-list-policy" \
+     token_ttl=1h \
+     token_max_ttl=4h \
+     secret_id_ttl=0
+   ```
+
+3. **Retrieve the `role_id`**:
+
+   ```bash
+   vault read -field=role_id auth/approle/role/status-list-role/role-id
+   ```
+
+4. **Generate a `secret_id`**:
+
+   ```bash
+   vault write -f -field=secret_id auth/approle/role/status-list-role/secret-id
+   ```
+
 ### Example 1: Local Development with HashiCorp Vault
 
-Start a local Vault dev server:
+Start a local Vault dev container:
 
 ```bash
 docker run -d --name vault -p 8200:8200 -e 'VAULT_DEV_ROOT_TOKEN_ID=root' hashicorp/vault:2.0
+```
+
+Configure AppRole:
+
+```bash
+export VAULT_ADDR="http://127.0.0.1:8200"
+export VAULT_TOKEN="root"
+
+vault auth enable approle
+vault policy write status-list-policy - <<EOF
+path "secret/*" { capabilities = ["create", "read", "update", "delete", "list"] }
+path "auth/token/renew-self" { capabilities = ["update"] }
+EOF
+
+vault write auth/approle/role/status-list-role \
+  token_policies="status-list-policy" \
+  token_ttl=1h
+
+ROLE_ID=$(vault read -field=role_id auth/approle/role/status-list-role/role-id)
+SECRET_ID=$(vault write -f -field=secret_id auth/approle/role/status-list-role/secret-id)
 ```
 
 Configure your `.env` file:
 
 ```env
 APP_VAULT__ADDR=http://127.0.0.1:8200
-APP_VAULT__TOKEN=root
+APP_VAULT__AUTH_MOUNT=approle
+APP_VAULT__ROLE_ID=your-role-id-here
+APP_VAULT__SECRET_ID=your-secret-id-here
 APP_VAULT__MOUNT=secret
 APP_VAULT__PATH_PREFIX=dev/status-list
 APP_VAULT__SECRETS_CACHE_TTL=300
 ```
 
-### Example 2: Deployment with OpenBao
+### Example 2: Production Deployment with OpenBao / Vault
 
-Start an OpenBao container:
-
-```bash
-docker run -d --name openbao -p 8200:8200 -e 'BAO_DEV_ROOT_TOKEN_ID=root' openbao/openbao:2.6
-```
-
-Configure environment variables:
+In Kubernetes or ECS, inject the `role_id` and `secret_id` via Kubernetes Secrets or IAM-bound orchestration:
 
 ```env
 APP_VAULT__ADDR=http://openbao-service.openbao.svc.cluster.local:8200
-APP_VAULT__TOKEN=s.xxxxxxxxx
+APP_VAULT__AUTH_MOUNT=approle
+APP_VAULT__ROLE_ID=ba0a1234-5678-90ab-cdef-1234567890ab
+APP_VAULT__SECRET_ID=fe987654-3210-fedc-ba09-876543210fed
 APP_VAULT__MOUNT=secret
 APP_VAULT__PATH_PREFIX=production/status-list
 APP_VAULT__NAMESPACE=my-org-namespace
 APP_VAULT__SECRETS_CACHE_TTL=600
 ```
+
+### Automated Token Lifecycle & Renewal
+
+The server features an automated token manager:
+
+- **Initial Login**: Exchanged via `POST /v1/auth/{auth_mount}/login` at application startup.
+- **Proactive Renewal**: Tokens are automatically renewed via `POST /v1/auth/token/renew-self` when 80% of their lease TTL has elapsed.
+- **Re-authentication Fallback**: If renewal fails (e.g. token expired or revoked), the client seamlessly re-authenticates using the AppRole credentials.
 
 ### Cache Behavior
 

--- a/docs/secrets-backends.md
+++ b/docs/secrets-backends.md
@@ -21,7 +21,8 @@ Authentication is strictly performed via **AppRole**, which is the industry stan
 | `APP_VAULT__ADDR`              | String            | `http://127.0.0.1:8200`             | Base URL of the Vault / OpenBao cluster                                  |
 | `APP_VAULT__AUTH_MOUNT`        | String            | `"approle"`                         | Mount path of the AppRole auth engine                                    |
 | `APP_VAULT__ROLE_ID`           | String            | _(Mandatory when Vault is enabled)_ | AppRole Role ID identifier                                               |
-| `APP_VAULT__SECRET_ID`         | String (Secret)   | _(Mandatory when Vault is enabled)_ | AppRole Secret ID credential                                             |
+| `APP_VAULT__SECRET_ID`         | String (Secret)   | _(Optional if path is used)_        | AppRole Secret ID credential                                             |
+| `APP_VAULT__SECRET_ID_PATH`    | Path              | `None`                              | File path containing AppRole Secret ID (e.g. K8s volume mount)           |
 | `APP_VAULT__MOUNT`             | String            | `"secret"`                          | KV v2 secrets engine mount point                                         |
 | `APP_VAULT__PATH_PREFIX`       | String            | `""`                                | Optional prefix prepended to all secret keys (e.g. `status-list-server`) |
 | `APP_VAULT__NAMESPACE`         | String            | `None`                              | Optional Enterprise/OpenBao namespace header (`X-Vault-Namespace`)       |
@@ -141,13 +142,17 @@ APP_VAULT__NAMESPACE=my-org-namespace
 APP_VAULT__SECRETS_CACHE_TTL=600
 ```
 
-### Automated Token Lifecycle & Renewal
+### Automated Token Lifecycle & Resilience
 
-The server features an automated token manager:
+The server features an enterprise-grade automated token manager:
 
 - **Initial Login**: Exchanged via `POST /v1/auth/{auth_mount}/login` at application startup.
 - **Proactive Renewal**: Tokens are automatically renewed via `POST /v1/auth/token/renew-self` when 80% of their lease TTL has elapsed.
 - **Re-authentication Fallback**: If renewal fails (e.g. token expired or revoked), the client seamlessly re-authenticates using the AppRole credentials.
+
+### Observability & Metrics
+
+Vault authentication and token operations emit OpenTelemetry counters for successful initial logins, renewals, and re-authentications.
 
 ### Cache Behavior
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::{collections::HashMap, fmt, marker::PhantomData};
 
 use config::builder::DefaultState;
@@ -606,8 +607,12 @@ pub struct VaultConfig {
     pub addr: String,
     /// AppRole role_id (can be baked into config).
     pub role_id: String,
-    /// AppRole secret_id (deliver via secrets injector in production — never log).
-    pub secret_id: SecretString,
+    /// AppRole secret_id (deliver via env/secrets injector in production).
+    #[serde(default)]
+    pub secret_id: Option<SecretString>,
+    /// Optional path to file containing AppRole secret_id (e.g. Kubernetes volume mount or Docker secret).
+    #[serde(default)]
+    pub secret_id_path: Option<PathBuf>,
     /// AppRole auth engine mount path (default: `approle`).
     pub auth_mount: String,
     /// KV v2 engine mount path.
@@ -622,6 +627,38 @@ pub struct VaultConfig {
     pub secrets_cache_ttl: u64,
     /// HTTP request timeout in seconds.
     pub timeout_secs: u64,
+}
+
+impl VaultConfig {
+    /// Resolve the AppRole secret_id either directly from `secret_id`
+    /// or by reading from `secret_id_path` on disk.
+    pub fn resolve_secret_id(&self) -> Result<SecretString, ConfigError> {
+        if let Some(secret_id) = &self.secret_id
+            && !secret_id.expose_secret().trim().is_empty()
+        {
+            return Ok(secret_id.clone());
+        }
+
+        if let Some(path) = &self.secret_id_path {
+            let content = std::fs::read_to_string(path).map_err(|e| {
+                ConfigError::Message(format!(
+                    "Failed to read Vault secret_id from file {path:?}: {e}"
+                ))
+            })?;
+            let trimmed = content.trim();
+            if trimmed.is_empty() {
+                return Err(ConfigError::Message(format!(
+                    "Vault secret_id file {path:?} is empty"
+                )));
+            }
+            return Ok(SecretString::from(trimmed.to_string()));
+        }
+
+        Err(ConfigError::Message(
+            "Vault configuration missing secret_id: provide 'secret_id' or 'secret_id_path'"
+                .to_string(),
+        ))
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -839,7 +876,8 @@ fn base_builder() -> Result<ConfigBuilder<DefaultState>, ConfigError> {
         .set_default("aws.region", "us-east-1")?
         .set_default("vault.addr", "http://localhost:8200")?
         .set_default("vault.role_id", "")?
-        .set_default("vault.secret_id", "")?
+        .set_default("vault.secret_id", Option::<String>::None)?
+        .set_default("vault.secret_id_path", Option::<String>::None)?
         .set_default("vault.auth_mount", "approle")?
         .set_default("vault.mount", "secret")?
         .set_default("vault.path_prefix", "")?
@@ -1538,15 +1576,17 @@ mod tests {
         // Vault AppRole defaults
         assert_eq!(default_config.vault.addr, "http://localhost:8200");
         assert_eq!(default_config.vault.role_id, "");
-        assert_eq!(default_config.vault.secret_id.expose_secret(), "");
+        assert!(default_config.vault.secret_id.is_none());
+        assert_eq!(default_config.vault.secret_id_path, None);
         assert_eq!(default_config.vault.auth_mount, "approle");
         assert_eq!(default_config.vault.mount, "secret");
         assert_eq!(default_config.vault.path_prefix, "");
         assert_eq!(default_config.vault.namespace, None);
         assert_eq!(default_config.vault.secrets_cache_ttl, 300);
         assert_eq!(default_config.vault.timeout_secs, 30);
+        assert!(default_config.vault.resolve_secret_id().is_err());
 
-        // Vault AppRole overrides
+        // Vault AppRole overrides with inline secret_id
         let overridden_config = Config::load_from_overrides(&[
             ("vault.addr", "http://vault.example.com:8200"),
             ("vault.role_id", "my-role-id"),
@@ -1566,7 +1606,11 @@ mod tests {
         );
         assert_eq!(overridden_config.vault.role_id, "my-role-id");
         assert_eq!(
-            overridden_config.vault.secret_id.expose_secret(),
+            overridden_config
+                .vault
+                .resolve_secret_id()
+                .expect("failed to resolve secret_id")
+                .expose_secret(),
             "my-secret-id"
         );
         assert_eq!(overridden_config.vault.auth_mount, "custom-approle");
@@ -1578,5 +1622,28 @@ mod tests {
         );
         assert_eq!(overridden_config.vault.secrets_cache_ttl, 60);
         assert_eq!(overridden_config.vault.timeout_secs, 15);
+
+        // Vault AppRole overrides with secret_id_path
+        let secret_file = std::env::temp_dir().join(format!(
+            "vault_secret_id_test_{}.txt",
+            time::UtcDateTime::now().nanosecond()
+        ));
+        std::fs::write(&secret_file, "  file-secret-id-value \n").expect("write secret file");
+
+        let file_auth_config = Config::load_from_overrides(&[
+            ("vault.role_id", "my-file-role"),
+            ("vault.secret_id_path", secret_file.to_str().unwrap()),
+        ])
+        .expect("Failed to load file auth config");
+
+        assert_eq!(
+            file_auth_config
+                .vault
+                .resolve_secret_id()
+                .expect("failed to resolve secret_id from path")
+                .expose_secret(),
+            "file-secret-id-value"
+        );
+        let _ = std::fs::remove_file(&secret_file);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -604,8 +604,12 @@ pub struct AwsConfig {
 pub struct VaultConfig {
     /// Vault / OpenBao API address (e.g. `http://vault:8200`).
     pub addr: String,
-    /// Authentication token.
-    pub token: SecretString,
+    /// AppRole role_id (can be baked into config).
+    pub role_id: String,
+    /// AppRole secret_id (deliver via secrets injector in production — never log).
+    pub secret_id: SecretString,
+    /// AppRole auth engine mount path (default: `approle`).
+    pub auth_mount: String,
     /// KV v2 engine mount path.
     pub mount: String,
     /// Prefix prepended to all secret paths. Default: empty.
@@ -834,7 +838,9 @@ fn base_builder() -> Result<ConfigBuilder<DefaultState>, ConfigError> {
         .set_default("server.cert.store.signing_key_key", Option::<String>::None)?
         .set_default("aws.region", "us-east-1")?
         .set_default("vault.addr", "http://localhost:8200")?
-        .set_default("vault.token", "")?
+        .set_default("vault.role_id", "")?
+        .set_default("vault.secret_id", "")?
+        .set_default("vault.auth_mount", "approle")?
         .set_default("vault.mount", "secret")?
         .set_default("vault.path_prefix", "")?
         .set_default("vault.namespace", Option::<String>::None)?
@@ -1528,5 +1534,49 @@ mod tests {
                 "Default config signing_key_key references test_data: {key}"
             );
         }
+
+        // Vault AppRole defaults
+        assert_eq!(default_config.vault.addr, "http://localhost:8200");
+        assert_eq!(default_config.vault.role_id, "");
+        assert_eq!(default_config.vault.secret_id.expose_secret(), "");
+        assert_eq!(default_config.vault.auth_mount, "approle");
+        assert_eq!(default_config.vault.mount, "secret");
+        assert_eq!(default_config.vault.path_prefix, "");
+        assert_eq!(default_config.vault.namespace, None);
+        assert_eq!(default_config.vault.secrets_cache_ttl, 300);
+        assert_eq!(default_config.vault.timeout_secs, 30);
+
+        // Vault AppRole overrides
+        let overridden_config = Config::load_from_overrides(&[
+            ("vault.addr", "http://vault.example.com:8200"),
+            ("vault.role_id", "my-role-id"),
+            ("vault.secret_id", "my-secret-id"),
+            ("vault.auth_mount", "custom-approle"),
+            ("vault.mount", "kv-secrets"),
+            ("vault.path_prefix", "services/status-list"),
+            ("vault.namespace", "tenant-1"),
+            ("vault.secrets_cache_ttl", "60"),
+            ("vault.timeout_secs", "15"),
+        ])
+        .expect("Failed to load overridden config");
+
+        assert_eq!(
+            overridden_config.vault.addr,
+            "http://vault.example.com:8200"
+        );
+        assert_eq!(overridden_config.vault.role_id, "my-role-id");
+        assert_eq!(
+            overridden_config.vault.secret_id.expose_secret(),
+            "my-secret-id"
+        );
+        assert_eq!(overridden_config.vault.auth_mount, "custom-approle");
+        assert_eq!(overridden_config.vault.mount, "kv-secrets");
+        assert_eq!(overridden_config.vault.path_prefix, "services/status-list");
+        assert_eq!(
+            overridden_config.vault.namespace,
+            Some("tenant-1".to_string())
+        );
+        assert_eq!(overridden_config.vault.secrets_cache_ttl, 60);
+        assert_eq!(overridden_config.vault.timeout_secs, 15);
     }
 }

--- a/src/outbound/vault.rs
+++ b/src/outbound/vault.rs
@@ -1,10 +1,11 @@
 //! Vault / OpenBao KV v2 secrets-storage adapter implementing [`Storage`].
 //!
 //! Both HashiCorp Vault and OpenBao expose the same KV v2 HTTP API, so this
-//! single adapter covers both.  Only **token auth** is supported in this
-//! initial implementation.
+//! single adapter covers both.  Authentication is performed exclusively via
+//! the **AppRole** auth method.
 
-use std::time::Duration;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use color_eyre::eyre::eyre;
@@ -12,21 +13,20 @@ use moka::future::Cache;
 use reqwest::{Client, StatusCode, Url};
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
-use tracing::info;
+use tokio::sync::RwLock;
+use tracing::{info, warn};
 
 use crate::cert_manager::storage::{Storage, StorageError};
 
 /// Vault / OpenBao KV v2 storage adapter.
 ///
 /// Implements the [`Storage`] trait so it can be used as a secrets backend
-/// by the certificate manager.
+/// by the certificate manager.  Authentication is performed via **AppRole**.
 #[derive(Debug)]
 pub struct VaultClient {
     client: Client,
     /// Vault/OpenBao API address (e.g. `http://vault:8200`).
     addr: String,
-    /// Authentication token (never logged).
-    token: SecretString,
     /// KV v2 engine mount path (default `secret`).
     mount: String,
     /// Prefix prepended to all secret paths.
@@ -35,6 +35,8 @@ pub struct VaultClient {
     namespace: Option<String>,
     /// Optional in-process TTL cache.
     cache: Option<Cache<String, String>>,
+    /// AppRole token manager.
+    auth: Arc<TokenManager>,
 }
 
 impl VaultClient {
@@ -44,9 +46,13 @@ impl VaultClient {
     const CACHE_MAX_CAPACITY: u64 = 100;
 
     /// Return a [`VaultClientBuilder`] for constructing a [`VaultClient`] adapter
-    /// with the given address and token.
-    pub fn builder(addr: impl Into<String>, token: SecretString) -> VaultClientBuilder {
-        VaultClientBuilder::new(addr, token)
+    /// with AppRole authentication.
+    pub fn builder(
+        addr: impl Into<String>,
+        role_id: impl Into<String>,
+        secret_id: SecretString,
+    ) -> VaultClientBuilder {
+        VaultClientBuilder::new(addr, role_id, secret_id)
     }
 
     /// Build the full URL for KV v2 `data` operations.
@@ -116,30 +122,41 @@ impl VaultClient {
         out
     }
 
-    /// Add common headers (token + optional namespace) to a request builder.
-    fn add_auth_headers(&self, builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
-        let builder = builder.header("X-Vault-Token", self.token.expose_secret());
+    /// Ensure the AppRole token is valid, then add common headers to a request.
+    async fn add_auth_headers(
+        &self,
+        builder: reqwest::RequestBuilder,
+    ) -> Result<reqwest::RequestBuilder, StorageError> {
+        self.auth
+            .ensure_valid(&self.client, &self.addr, self.namespace.as_deref())
+            .await?;
+
+        let token = self.auth.current_token().await;
+        let builder = builder.header("X-Vault-Token", token.expose_secret());
         if let Some(ns) = &self.namespace {
-            builder.header("X-Vault-Namespace", ns)
+            Ok(builder.header("X-Vault-Namespace", ns))
         } else {
-            builder
+            Ok(builder)
         }
     }
 }
 
-/// Builder for constructing a [`VaultClient`] adapter.
+/// Builder for constructing a [`VaultClient`] adapter with AppRole authentication.
 ///
 /// # Optional Fields & Default Behavior
 /// - `mount`: KV v2 secret engine mount path. **Default**: `"secret"`
 /// - `path_prefix`: Prefix prepended to all secret keys. **Default**: `""` (no prefix)
 /// - `namespace`: Optional Vault Enterprise / OpenBao namespace header (`X-Vault-Namespace`). **Default**: `None`
+/// - `auth_mount`: AppRole auth engine mount path. **Default**: `"approle"`
 /// - `secrets_cache_ttl`: In-memory TTL cache duration for fetched secrets. Setting to `Duration::ZERO` disables caching. **Default**: 5 minutes
 /// - `timeout`: HTTP client request timeout. **Default**: 30 seconds
 #[derive(Debug, Clone)]
 pub struct VaultClientBuilder {
     addr: String,
-    token: SecretString,
+    role_id: String,
+    secret_id: SecretString,
     mount: String,
+    auth_mount: String,
     path_prefix: String,
     namespace: Option<String>,
     secrets_cache_ttl: Duration,
@@ -147,12 +164,18 @@ pub struct VaultClientBuilder {
 }
 
 impl VaultClientBuilder {
-    /// Create a new [`VaultClientBuilder`] with the Vault address and token.
-    pub fn new(addr: impl Into<String>, token: SecretString) -> Self {
+    /// Create a new [`VaultClientBuilder`] with AppRole credentials.
+    pub fn new(
+        addr: impl Into<String>,
+        role_id: impl Into<String>,
+        secret_id: SecretString,
+    ) -> Self {
         Self {
             addr: addr.into(),
-            token,
+            role_id: role_id.into(),
+            secret_id,
             mount: "secret".to_string(),
+            auth_mount: "approle".to_string(),
             path_prefix: String::new(),
             namespace: None,
             secrets_cache_ttl: Duration::from_secs(300),
@@ -165,6 +188,14 @@ impl VaultClientBuilder {
     /// **Default**: `"secret"`
     pub fn mount(mut self, mount: impl Into<String>) -> Self {
         self.mount = mount.into();
+        self
+    }
+
+    /// Set the AppRole auth engine mount path.
+    ///
+    /// **Default**: `"approle"`
+    pub fn auth_mount(mut self, auth_mount: impl Into<String>) -> Self {
+        self.auth_mount = auth_mount.into();
         self
     }
 
@@ -204,13 +235,17 @@ impl VaultClientBuilder {
 
     /// Build the [`VaultClient`] adapter instance.
     ///
+    /// Performs the initial AppRole login during construction.
+    ///
     /// # Errors
     ///
     /// Returns `StorageError::Backend` if:
     /// - `addr` is empty or not a valid URL.
-    /// - The authentication token is empty.
+    /// - `role_id` is empty.
+    /// - `secret_id` is empty.
     /// - `mount` is empty.
-    pub fn build(self) -> Result<VaultClient, StorageError> {
+    /// - The initial AppRole login fails.
+    pub async fn build(self) -> Result<VaultClient, StorageError> {
         // Validate address, must be non-empty and parseable as a URL.
         if self.addr.trim().is_empty() {
             return Err(StorageError::Backend(eyre!(
@@ -221,10 +256,17 @@ impl VaultClientBuilder {
             StorageError::Backend(eyre!("Vault configuration error: invalid address: {e}"))
         })?;
 
-        // Validate token, must be non-empty.
-        if self.token.expose_secret().trim().is_empty() {
+        // Validate role_id, must be non-empty.
+        if self.role_id.trim().is_empty() {
             return Err(StorageError::Backend(eyre!(
-                "Vault configuration error: token must not be empty"
+                "Vault configuration error: role_id must not be empty"
+            )));
+        }
+
+        // Validate secret_id, must be non-empty.
+        if self.secret_id.expose_secret().trim().is_empty() {
+            return Err(StorageError::Backend(eyre!(
+                "Vault configuration error: secret_id must not be empty"
             )));
         }
 
@@ -232,6 +274,13 @@ impl VaultClientBuilder {
         if self.mount.trim().is_empty() {
             return Err(StorageError::Backend(eyre!(
                 "Vault configuration error: mount path must not be empty"
+            )));
+        }
+
+        // Auth mount must be non-empty.
+        if self.auth_mount.trim().is_empty() {
+            return Err(StorageError::Backend(eyre!(
+                "Vault configuration error: auth_mount must not be empty"
             )));
         }
 
@@ -251,15 +300,245 @@ impl VaultClientBuilder {
             info!("Vault secrets cache disabled (TTL=0)");
         }
 
+        let addr = self.addr.trim_end_matches('/').to_string();
+
+        // Perform initial AppRole login
+        let auth = TokenManager::login(
+            &client,
+            &addr,
+            self.role_id,
+            self.secret_id,
+            self.auth_mount,
+            self.namespace.as_deref(),
+        )
+        .await?;
+
         Ok(VaultClient {
             client,
-            addr: self.addr.trim_end_matches('/').to_string(),
-            token: self.token,
+            addr,
             mount: self.mount,
             path_prefix: self.path_prefix,
             namespace: self.namespace,
             cache,
+            auth: Arc::new(auth),
         })
+    }
+}
+
+/// Manages the Vault client token obtained via AppRole login.
+///
+/// Handles:
+/// - Initial login via `POST /v1/auth/{mount}/login`
+/// - Proactive renewal at 80% of TTL via `POST /v1/auth/token/renew-self`
+/// - Full re-authentication when renewal fails or the token exceeds `max_ttl`
+#[derive(Debug)]
+struct TokenManager {
+    /// Current client token, swapped atomically on renewal/re-login.
+    token: RwLock<SecretString>,
+    /// When the current token was issued.
+    issued_at: RwLock<Instant>,
+    /// TTL in seconds from the last login or renewal response.
+    lease_duration: RwLock<u64>,
+    /// Whether the current token is renewable.
+    renewable: RwLock<bool>,
+    /// AppRole role ID.
+    role_id: String,
+    /// AppRole secret ID.
+    secret_id: SecretString,
+    /// Auth engine mount path (default `approle`).
+    auth_mount: String,
+}
+
+/// Response from `POST /v1/auth/{mount}/login` and `POST /v1/auth/token/renew-self`
+#[derive(Deserialize)]
+struct LoginOrRenewResponse {
+    auth: AuthData,
+}
+
+#[derive(Deserialize)]
+struct AuthData {
+    client_token: String,
+    lease_duration: u64,
+    renewable: bool,
+}
+
+/// Request body for `POST /v1/auth/{mount}/login`.
+#[derive(Serialize)]
+struct LoginRequest<'a> {
+    role_id: String,
+    secret_id: &'a str,
+}
+
+impl TokenManager {
+    /// Percentage of TTL at which we proactively renew/re-login.
+    const RENEW_MARGIN_PCT: u64 = 800;
+
+    /// Perform the initial AppRole login and return a ready manager.
+    async fn login(
+        client: &Client,
+        addr: &str,
+        role_id: String,
+        secret_id: SecretString,
+        auth_mount: String,
+        namespace: Option<&str>,
+    ) -> Result<Self, StorageError> {
+        let (token, lease_duration, renewable) =
+            Self::perform_login(client, addr, &role_id, &secret_id, &auth_mount, namespace).await?;
+
+        Ok(Self {
+            token: RwLock::new(token),
+            issued_at: RwLock::new(Instant::now()),
+            lease_duration: RwLock::new(lease_duration),
+            renewable: RwLock::new(renewable),
+            role_id,
+            secret_id,
+            auth_mount,
+        })
+    }
+
+    /// Execute the AppRole login HTTP call.
+    async fn perform_login(
+        client: &Client,
+        addr: &str,
+        role_id: &str,
+        secret_id: &SecretString,
+        auth_mount: &str,
+        namespace: Option<&str>,
+    ) -> Result<(SecretString, u64, bool), StorageError> {
+        let url = format!("{addr}/v1/auth/{auth_mount}/login");
+        let body = LoginRequest {
+            role_id: role_id.to_string(),
+            secret_id: secret_id.expose_secret(),
+        };
+
+        let mut builder = client.post(&url).json(&body);
+        if let Some(ns) = namespace {
+            builder = builder.header("X-Vault-Namespace", ns);
+        }
+
+        let resp = builder.send().await?;
+        let status = resp.status();
+
+        if status.is_success() {
+            let login: LoginOrRenewResponse = resp.json().await?;
+            info!(
+                lease_duration = login.auth.lease_duration,
+                renewable = login.auth.renewable,
+                "AppRole login successful"
+            );
+            Ok((
+                SecretString::from(login.auth.client_token),
+                login.auth.lease_duration,
+                login.auth.renewable,
+            ))
+        } else if status == StatusCode::FORBIDDEN {
+            Err(StorageError::Backend(eyre!(
+                "vault AppRole login denied (HTTP 403)"
+            )))
+        } else {
+            let body_text = resp.text().await.unwrap_or_default();
+            Err(StorageError::Backend(eyre!(
+                "vault AppRole login failed: HTTP {status}: {body_text}"
+            )))
+        }
+    }
+
+    /// Ensure the current token is still valid, renewing or re-authenticating
+    /// as needed. This is called before every KV request.
+    async fn ensure_valid(
+        &self,
+        client: &Client,
+        addr: &str,
+        namespace: Option<&str>,
+    ) -> Result<(), StorageError> {
+        let elapsed = self.issued_at.read().await.elapsed();
+        let ttl = *self.lease_duration.read().await;
+
+        // No renewal needed if we're within the safe window (80% of TTL)
+        let safe_window = Duration::from_millis(ttl.saturating_mul(Self::RENEW_MARGIN_PCT));
+        if ttl == 0 || elapsed < safe_window {
+            return Ok(());
+        }
+
+        // Try renewal first if the token is renewable
+        if *self.renewable.read().await {
+            match self.try_renew(client, addr, namespace).await {
+                Ok(()) => return Ok(()),
+                Err(e) => {
+                    warn!("Token renewal failed, re-authenticating: {e}");
+                }
+            }
+        }
+        // Full re-login
+        self.re_login(client, addr, namespace).await
+    }
+
+    /// Attempt to renew the current token via `POST /v1/auth/token/renew-self`.
+    async fn try_renew(
+        &self,
+        client: &Client,
+        addr: &str,
+        namespace: Option<&str>,
+    ) -> Result<(), StorageError> {
+        let url = format!("{addr}/v1/auth/token/renew-self");
+        let token = self.token.read().await.clone();
+
+        let mut builder = client
+            .post(&url)
+            .header("X-Vault-Token", token.expose_secret());
+        if let Some(ns) = namespace {
+            builder = builder.header("X-Vault-Namespace", ns);
+        }
+
+        let resp = builder.send().await?;
+        let status = resp.status();
+
+        if status.is_success() {
+            let renew: LoginOrRenewResponse = resp.json().await?;
+            info!(
+                lease_duration = renew.auth.lease_duration,
+                renewable = renew.auth.renewable,
+                "Token renewal successful"
+            );
+            *self.token.write().await = SecretString::from(renew.auth.client_token);
+            *self.issued_at.write().await = Instant::now();
+            *self.lease_duration.write().await = renew.auth.lease_duration;
+            *self.renewable.write().await = renew.auth.renewable;
+            Ok(())
+        } else {
+            Err(StorageError::Backend(eyre!(
+                "token renewal failed: HTTP {status}"
+            )))
+        }
+    }
+
+    /// Perform a full re-login via AppRole.
+    async fn re_login(
+        &self,
+        client: &Client,
+        addr: &str,
+        namespace: Option<&str>,
+    ) -> Result<(), StorageError> {
+        let (new_token, lease_duration, renewable) = Self::perform_login(
+            client,
+            addr,
+            &self.role_id,
+            &self.secret_id,
+            &self.auth_mount,
+            namespace,
+        )
+        .await?;
+
+        *self.token.write().await = new_token;
+        *self.issued_at.write().await = Instant::now();
+        *self.lease_duration.write().await = lease_duration;
+        *self.renewable.write().await = renewable;
+        Ok(())
+    }
+
+    /// Return the current client token.
+    async fn current_token(&self) -> SecretString {
+        self.token.read().await.clone()
     }
 }
 
@@ -294,6 +573,7 @@ impl Storage for VaultClient {
 
         let resp = self
             .add_auth_headers(self.client.post(&url))
+            .await?
             .json(&body)
             .send()
             .await?;
@@ -327,7 +607,11 @@ impl Storage for VaultClient {
         }
 
         let url = self.data_url(key);
-        let resp = self.add_auth_headers(self.client.get(&url)).send().await?;
+        let resp = self
+            .add_auth_headers(self.client.get(&url))
+            .await?
+            .send()
+            .await?;
 
         let status = resp.status();
         match status {
@@ -358,6 +642,7 @@ impl Storage for VaultClient {
         let url = self.metadata_url(key);
         let resp = self
             .add_auth_headers(self.client.delete(&url))
+            .await?
             .send()
             .await?;
 
@@ -384,7 +669,11 @@ impl Storage for VaultClient {
     /// is accessible with the provided credentials.
     async fn reachable(&self) -> Result<(), StorageError> {
         let url = format!("{}/v1/{}/config", self.addr, self.mount);
-        let resp = self.add_auth_headers(self.client.get(&url)).send().await?;
+        let resp = self
+            .add_auth_headers(self.client.get(&url))
+            .await?
+            .send()
+            .await?;
 
         let status = resp.status();
         if status.is_success() {
@@ -414,178 +703,279 @@ mod tests {
     use std::time::Duration;
 
     use secrecy::SecretString;
-    use wiremock::matchers::{header, method, path};
+    use serde_json::json;
+    use wiremock::matchers::{body_json, header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use super::*;
-    use crate::cert_manager::storage::StorageError;
 
-    fn valid_token() -> SecretString {
-        SecretString::from("root")
+    fn valid_role_id() -> String {
+        "test-role-id".to_string()
     }
 
-    /// Panics with a descriptive message when the assertion fails.
-    fn assert_matches_backend_error(err: &StorageError, expected_fragment: &str) {
-        match err {
-            StorageError::Backend(e) => {
-                let msg = format!("{e}");
-                assert!(
-                    msg.contains(expected_fragment),
-                    "expected error to contain '{expected_fragment}', got: {msg}"
-                );
+    fn valid_secret_id() -> SecretString {
+        SecretString::from("test-secret-id")
+    }
+
+    fn auth_response(token: &str, lease_duration: u64) -> serde_json::Value {
+        json!({
+            "auth": {
+                "client_token": token,
+                "lease_duration": lease_duration,
+                "renewable": true,
+                "accessor": "test-accessor",
+                "policies": ["default"]
             }
-            other => panic!("expected StorageError::Backend, got: {other:?}"),
+        })
+    }
+
+    async fn mock_approle_login(server: &MockServer, token: &str, lease_duration: u64) {
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/approle/login"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(auth_response(token, lease_duration)),
+            )
+            .mount(server)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn build_validates_required_fields() {
+        let cases: Vec<(VaultClientBuilder, &str)> = vec![
+            (
+                VaultClient::builder("", valid_role_id(), valid_secret_id()),
+                "address must not be empty",
+            ),
+            (
+                VaultClient::builder("   ", valid_role_id(), valid_secret_id()),
+                "address must not be empty",
+            ),
+            (
+                VaultClient::builder("not a url @@", valid_role_id(), valid_secret_id()),
+                "invalid address",
+            ),
+            (
+                VaultClient::builder("http://vault:8200", "", valid_secret_id()),
+                "role_id must not be empty",
+            ),
+            (
+                VaultClient::builder("http://vault:8200", valid_role_id(), SecretString::from("")),
+                "secret_id must not be empty",
+            ),
+            (
+                VaultClient::builder("http://vault:8200", valid_role_id(), valid_secret_id())
+                    .mount(""),
+                "mount path must not be empty",
+            ),
+            (
+                VaultClient::builder("http://vault:8200", valid_role_id(), valid_secret_id())
+                    .auth_mount(""),
+                "auth_mount must not be empty",
+            ),
+        ];
+
+        for (builder, expected_err) in cases {
+            let err = builder.build().await.unwrap_err();
+            assert!(
+                err.to_string().contains(expected_err),
+                "expected error containing '{expected_err}', got: {err}"
+            );
         }
     }
 
-    #[test]
-    fn build_rejects_empty_address() {
-        let err = VaultClient::builder("", valid_token())
-            .mount("secret")
-            .build()
-            .unwrap_err();
-        assert_matches_backend_error(&err, "address must not be empty");
-    }
-
-    #[test]
-    fn build_rejects_whitespace_only_address() {
-        let err = VaultClient::builder("   ", valid_token())
-            .mount("secret")
-            .build()
-            .unwrap_err();
-        assert_matches_backend_error(&err, "address must not be empty");
-    }
-
-    #[test]
-    fn build_rejects_invalid_url() {
-        let err = VaultClient::builder("not a url @@", valid_token())
-            .mount("secret")
-            .build()
-            .unwrap_err();
-        assert_matches_backend_error(&err, "invalid address");
-    }
-
-    #[test]
-    fn build_rejects_empty_token() {
-        let err = VaultClient::builder("http://vault:8200", SecretString::from(""))
-            .mount("secret")
-            .build()
-            .unwrap_err();
-        assert_matches_backend_error(&err, "token must not be empty");
-    }
-
-    #[test]
-    fn build_rejects_whitespace_only_token() {
-        let err = VaultClient::builder("http://vault:8200", SecretString::from("  "))
-            .mount("secret")
-            .build()
-            .unwrap_err();
-        assert_matches_backend_error(&err, "token must not be empty");
-    }
-
-    #[test]
-    fn build_rejects_empty_mount() {
-        let err = VaultClient::builder("http://vault:8200", valid_token())
-            .mount("")
-            .build()
-            .unwrap_err();
-        assert_matches_backend_error(&err, "mount path must not be empty");
-    }
-
-    #[test]
-    fn build_succeeds_with_valid_inputs() {
-        VaultClient::builder("http://vault:8200", valid_token())
-            .mount("secret")
-            .path_prefix("certs")
-            .secrets_cache_ttl(Duration::from_secs(60))
-            .build()
-            .expect("should build without error");
-    }
-
-    #[test]
-    fn build_succeeds_with_cache_disabled() {
-        VaultClient::builder("http://vault:8200", valid_token())
-            .mount("secret")
-            .secrets_cache_ttl(Duration::ZERO)
-            .build()
-            .expect("should build with cache disabled");
-    }
-
     #[tokio::test]
-    async fn reachable_returns_ok_on_200() {
+    async fn approle_login_and_kv_round_trip() {
         let server = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/v1/secret/config"))
-            .and(header("X-Vault-Token", "root"))
-            .respond_with(ResponseTemplate::new(200))
+        mock_approle_login(&server, "s.test-token", 3600).await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/secret/data/my-key"))
+            .and(header("X-Vault-Token", "s.test-token"))
+            .and(body_json(json!({ "data": { "value": "secret-payload" } })))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({ "data": { "version": 1 } })),
+            )
             .mount(&server)
             .await;
 
-        let client = VaultClient::builder(server.uri(), valid_token())
-            .mount("secret")
+        Mock::given(method("GET"))
+            .and(path("/v1/secret/data/my-key"))
+            .and(header("X-Vault-Token", "s.test-token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": { "data": { "value": "secret-payload" } }
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("DELETE"))
+            .and(path("/v1/secret/metadata/my-key"))
+            .and(header("X-Vault-Token", "s.test-token"))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let client = VaultClient::builder(server.uri(), valid_role_id(), valid_secret_id())
+            .secrets_cache_ttl(Duration::ZERO)
             .build()
+            .await
             .unwrap();
 
-        assert!(client.reachable().await.is_ok());
+        client.store("my-key", "secret-payload").await.unwrap();
+        let loaded = client.load("my-key").await.unwrap();
+        assert_eq!(loaded, Some("secret-payload".to_string()));
+        client.delete("my-key").await.unwrap();
     }
 
     #[tokio::test]
-    async fn reachable_returns_error_on_403() {
+    async fn approle_login_failure_modes() {
         let server = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/v1/secret/config"))
-            .and(header("X-Vault-Token", "root"))
+
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/approle/login"))
             .respond_with(ResponseTemplate::new(403))
             .mount(&server)
             .await;
 
-        let client = VaultClient::builder(server.uri(), valid_token())
-            .mount("secret")
+        let err = VaultClient::builder(server.uri(), valid_role_id(), valid_secret_id())
             .build()
-            .unwrap();
-
-        let err = client.reachable().await.unwrap_err();
-        assert_matches_backend_error(&err, "vault access denied for mount 'secret'");
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("AppRole login denied"));
     }
 
     #[tokio::test]
-    async fn reachable_returns_error_on_503() {
+    async fn approle_login_custom_mount_and_namespace() {
         let server = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/v1/secret/config"))
-            .respond_with(ResponseTemplate::new(503))
+
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/custom-auth/login"))
+            .and(header("X-Vault-Namespace", "tenant-corp"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(auth_response("s.ns-token", 3600)),
+            )
             .mount(&server)
             .await;
 
-        let client = VaultClient::builder(server.uri(), valid_token())
-            .mount("secret")
+        let client = VaultClient::builder(server.uri(), valid_role_id(), valid_secret_id())
+            .auth_mount("custom-auth")
+            .namespace(Some("tenant-corp"))
             .build()
-            .unwrap();
+            .await
+            .expect("should authenticate with custom auth mount and namespace");
 
-        let err = client.reachable().await.unwrap_err();
-        assert_matches_backend_error(
-            &err,
-            "vault readiness check failed for mount 'secret': HTTP 503",
+        assert_eq!(
+            client.auth.current_token().await.expose_secret(),
+            "s.ns-token"
         );
     }
 
     #[tokio::test]
-    async fn reachable_passes_namespace_header_when_configured() {
+    async fn reachable_endpoint_status_handling() {
         let server = MockServer::start().await;
+        mock_approle_login(&server, "s.test-token", 3600).await;
+
         Mock::given(method("GET"))
-            .and(path("/v1/custom-mount/config"))
-            .and(header("X-Vault-Token", "root"))
-            .and(header("X-Vault-Namespace", "tenant-a"))
+            .and(path("/v1/secret/config"))
             .respond_with(ResponseTemplate::new(200))
             .mount(&server)
             .await;
 
-        let client = VaultClient::builder(server.uri(), valid_token())
-            .mount("custom-mount")
-            .namespace(Some("tenant-a"))
+        let client = VaultClient::builder(server.uri(), valid_role_id(), valid_secret_id())
             .build()
+            .await
             .unwrap();
 
         assert!(client.reachable().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn reachable_returns_error_on_failure() {
+        let server = MockServer::start().await;
+        mock_approle_login(&server, "s.test-token", 3600).await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/secret/config"))
+            .respond_with(ResponseTemplate::new(403))
+            .mount(&server)
+            .await;
+
+        let client = VaultClient::builder(server.uri(), valid_role_id(), valid_secret_id())
+            .build()
+            .await
+            .unwrap();
+
+        let err = client.reachable().await.unwrap_err();
+        assert!(err.to_string().contains("access denied"));
+    }
+
+    #[tokio::test]
+    async fn token_renewal_and_reauth_flows() {
+        let server = MockServer::start().await;
+
+        // Initial login (short 1s TTL)
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/approle/login"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(auth_response("s.token-1", 1)))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+
+        // Token renewal succeeds
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/token/renew-self"))
+            .and(header("X-Vault-Token", "s.token-1"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(auth_response("s.token-renewed", 1)),
+            )
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+
+        // Subsequent renewal fails with 403, triggering re-login
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/token/renew-self"))
+            .and(header("X-Vault-Token", "s.token-renewed"))
+            .respond_with(ResponseTemplate::new(403))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/approle/login"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(auth_response("s.token-relogged", 3600)),
+            )
+            .mount(&server)
+            .await;
+
+        // Data mock accepting requests
+        Mock::given(method("GET"))
+            .and(path("/v1/secret/data/key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": { "data": { "value": "val" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = VaultClient::builder(server.uri(), valid_role_id(), valid_secret_id())
+            .secrets_cache_ttl(Duration::ZERO)
+            .build()
+            .await
+            .unwrap();
+
+        // Near expiry -> renewal triggers
+        tokio::time::sleep(Duration::from_millis(850)).await;
+        client.load("key").await.unwrap();
+        assert_eq!(
+            client.auth.current_token().await.expose_secret(),
+            "s.token-renewed"
+        );
+
+        // Renewal failure -> re-login triggers
+        tokio::time::sleep(Duration::from_millis(850)).await;
+        client.load("key").await.unwrap();
+        assert_eq!(
+            client.auth.current_token().await.expose_secret(),
+            "s.token-relogged"
+        );
     }
 }

--- a/src/outbound/vault.rs
+++ b/src/outbound/vault.rs
@@ -1,7 +1,7 @@
 //! Vault / OpenBao KV v2 secrets-storage adapter implementing [`Storage`].
 //!
 //! Both HashiCorp Vault and OpenBao expose the same KV v2 HTTP API, so this
-//! single adapter covers both.  Authentication is performed exclusively via
+//! single adapter covers both. Authentication is performed exclusively via
 //! the **AppRole** auth method.
 
 use std::sync::Arc;
@@ -21,7 +21,7 @@ use crate::cert_manager::storage::{Storage, StorageError};
 /// Vault / OpenBao KV v2 storage adapter.
 ///
 /// Implements the [`Storage`] trait so it can be used as a secrets backend
-/// by the certificate manager.  Authentication is performed via **AppRole**.
+/// by the certificate manager. Authentication is performed via **AppRole**.
 #[derive(Debug)]
 pub struct VaultClient {
     client: Client,
@@ -58,13 +58,15 @@ impl VaultClient {
     /// Build the full URL for KV v2 `data` operations.
     fn data_url(&self, key: &str) -> String {
         let path = self.qualify_key(key);
-        format!("{}/v1/{}/data/{}", self.addr, self.mount, path)
+        let encoded_mount = Self::encode_path_segment(&self.mount);
+        format!("{}/v1/{}/data/{}", self.addr, encoded_mount, path)
     }
 
     /// Build the full URL for KV v2 `metadata` (used by hard-delete).
     fn metadata_url(&self, key: &str) -> String {
         let path = self.qualify_key(key);
-        format!("{}/v1/{}/metadata/{}", self.addr, self.mount, path)
+        let encoded_mount = Self::encode_path_segment(&self.mount);
+        format!("{}/v1/{}/metadata/{}", self.addr, encoded_mount, path)
     }
 
     /// Qualify a key by prepending the configured path prefix, then
@@ -89,7 +91,7 @@ impl VaultClient {
     /// Unreserved characters (`A-Z a-z 0-9 - _ . ~`) and sub-delimiters
     /// allowed in path segments (`! $ & ' ( ) * + , ; = : @`) are left as-is;
     /// everything else (including `?`, `#`, ` `, `%`) is percent-encoded.
-    fn encode_path_segment(segment: &str) -> String {
+    pub(crate) fn encode_path_segment(segment: &str) -> String {
         let mut out = String::with_capacity(segment.len());
         for b in segment.bytes() {
             if b.is_ascii_alphanumeric()
@@ -244,20 +246,27 @@ impl VaultClientBuilder {
     /// - `role_id` is empty.
     /// - `secret_id` is empty.
     /// - `mount` is empty.
+    /// - `auth_mount` is empty.
     /// - The initial AppRole login fails.
     pub async fn build(self) -> Result<VaultClient, StorageError> {
+        let addr = self.addr.trim().trim_end_matches('/').to_string();
+        let role_id = self.role_id.trim().to_string();
+        let auth_mount = self.auth_mount.trim().to_string();
+        let mount = self.mount.trim().to_string();
+        let path_prefix = self.path_prefix.trim().to_string();
+
         // Validate address, must be non-empty and parseable as a URL.
-        if self.addr.trim().is_empty() {
+        if addr.is_empty() {
             return Err(StorageError::Backend(eyre!(
                 "Vault configuration error: address must not be empty"
             )));
         }
-        Url::parse(&self.addr).map_err(|e| {
+        Url::parse(&addr).map_err(|e| {
             StorageError::Backend(eyre!("Vault configuration error: invalid address: {e}"))
         })?;
 
         // Validate role_id, must be non-empty.
-        if self.role_id.trim().is_empty() {
+        if role_id.is_empty() {
             return Err(StorageError::Backend(eyre!(
                 "Vault configuration error: role_id must not be empty"
             )));
@@ -271,14 +280,14 @@ impl VaultClientBuilder {
         }
 
         // Mount must be non-empty.
-        if self.mount.trim().is_empty() {
+        if mount.is_empty() {
             return Err(StorageError::Backend(eyre!(
                 "Vault configuration error: mount path must not be empty"
             )));
         }
 
         // Auth mount must be non-empty.
-        if self.auth_mount.trim().is_empty() {
+        if auth_mount.is_empty() {
             return Err(StorageError::Backend(eyre!(
                 "Vault configuration error: auth_mount must not be empty"
             )));
@@ -300,15 +309,13 @@ impl VaultClientBuilder {
             info!("Vault secrets cache disabled (TTL=0)");
         }
 
-        let addr = self.addr.trim_end_matches('/').to_string();
-
         // Perform initial AppRole login
         let auth = TokenManager::login(
             &client,
             &addr,
-            self.role_id,
+            role_id,
             self.secret_id,
-            self.auth_mount,
+            auth_mount,
             self.namespace.as_deref(),
         )
         .await?;
@@ -316,13 +323,54 @@ impl VaultClientBuilder {
         Ok(VaultClient {
             client,
             addr,
-            mount: self.mount,
-            path_prefix: self.path_prefix,
+            mount,
+            path_prefix,
             namespace: self.namespace,
             cache,
             auth: Arc::new(auth),
         })
     }
+}
+
+/// Helper functions for OpenTelemetry Vault auth metrics.
+fn record_vault_login() {
+    opentelemetry::global::meter("status-list-server")
+        .u64_counter("vault_auth_logins_total")
+        .with_description("Total number of successful Vault AppRole logins.")
+        .build()
+        .add(1, &[]);
+}
+
+fn record_vault_renewal() {
+    opentelemetry::global::meter("status-list-server")
+        .u64_counter("vault_auth_renewals_total")
+        .with_description("Total number of successful Vault token renewals.")
+        .build()
+        .add(1, &[]);
+}
+
+fn record_vault_reauth() {
+    opentelemetry::global::meter("status-list-server")
+        .u64_counter("vault_auth_reauth_total")
+        .with_description(
+            "Total number of Vault re-authentications after token expiration or renewal failure.",
+        )
+        .build()
+        .add(1, &[]);
+}
+
+fn record_vault_auth_failure(operation: &'static str, result: &'static str) {
+    opentelemetry::global::meter("status-list-server")
+        .u64_counter("vault_auth_failures_total")
+        .with_description("Total number of Vault authentication and renewal failures.")
+        .build()
+        .add(
+            1,
+            &[
+                opentelemetry::KeyValue::new("operation", operation),
+                opentelemetry::KeyValue::new("result", result),
+            ],
+        );
 }
 
 /// Manages the Vault client token obtained via AppRole login.
@@ -331,6 +379,8 @@ impl VaultClientBuilder {
 /// - Initial login via `POST /v1/auth/{mount}/login`
 /// - Proactive renewal at 80% of TTL via `POST /v1/auth/token/renew-self`
 /// - Full re-authentication when renewal fails or the token exceeds `max_ttl`
+/// - Double-checked locking to serialize token renewals and prevent concurrency stampedes
+/// - Failure cooldown backoff to protect degraded/unreachable Vault instances
 #[derive(Debug)]
 struct TokenManager {
     /// Current client token, swapped atomically on renewal/re-login.
@@ -347,6 +397,10 @@ struct TokenManager {
     secret_id: SecretString,
     /// Auth engine mount path (default `approle`).
     auth_mount: String,
+    /// Mutex serializing proactive renewal and re-login across concurrent requests.
+    renewal_lock: tokio::sync::Mutex<()>,
+    /// Timestamp of last auth/renewal failure for backoff cooldown.
+    last_failure: RwLock<Option<Instant>>,
 }
 
 /// Response from `POST /v1/auth/{mount}/login` and `POST /v1/auth/token/renew-self`
@@ -365,13 +419,16 @@ struct AuthData {
 /// Request body for `POST /v1/auth/{mount}/login`.
 #[derive(Serialize)]
 struct LoginRequest<'a> {
-    role_id: String,
+    role_id: &'a str,
     secret_id: &'a str,
 }
 
 impl TokenManager {
-    /// Percentage of TTL at which we proactively renew/re-login.
-    const RENEW_MARGIN_PCT: u64 = 800;
+    /// Fraction of TTL elapsed before proactive renewal/re-login (80%).
+    const RENEW_MARGIN: f64 = 0.8;
+
+    /// Cooldown window after an auth failure before retrying.
+    const FAILURE_COOLDOWN: Duration = Duration::from_secs(5);
 
     /// Perform the initial AppRole login and return a ready manager.
     async fn login(
@@ -393,6 +450,8 @@ impl TokenManager {
             role_id,
             secret_id,
             auth_mount,
+            renewal_lock: tokio::sync::Mutex::new(()),
+            last_failure: RwLock::new(None),
         })
     }
 
@@ -405,9 +464,10 @@ impl TokenManager {
         auth_mount: &str,
         namespace: Option<&str>,
     ) -> Result<(SecretString, u64, bool), StorageError> {
-        let url = format!("{addr}/v1/auth/{auth_mount}/login");
+        let encoded_auth_mount = VaultClient::encode_path_segment(auth_mount);
+        let url = format!("{addr}/v1/auth/{encoded_auth_mount}/login");
         let body = LoginRequest {
-            role_id: role_id.to_string(),
+            role_id,
             secret_id: secret_id.expose_secret(),
         };
 
@@ -416,27 +476,43 @@ impl TokenManager {
             builder = builder.header("X-Vault-Namespace", ns);
         }
 
-        let resp = builder.send().await?;
+        let resp = match builder.send().await {
+            Ok(resp) => resp,
+            Err(e) => {
+                record_vault_auth_failure("login", "network_error");
+                return Err(StorageError::Backend(e.into()));
+            }
+        };
+
         let status = resp.status();
 
         if status.is_success() {
-            let login: LoginOrRenewResponse = resp.json().await?;
+            let login: LoginOrRenewResponse = match resp.json().await {
+                Ok(data) => data,
+                Err(e) => {
+                    record_vault_auth_failure("login", "deserialization_error");
+                    return Err(StorageError::Backend(e.into()));
+                }
+            };
             info!(
                 lease_duration = login.auth.lease_duration,
                 renewable = login.auth.renewable,
                 "AppRole login successful"
             );
+            record_vault_login();
             Ok((
                 SecretString::from(login.auth.client_token),
                 login.auth.lease_duration,
                 login.auth.renewable,
             ))
         } else if status == StatusCode::FORBIDDEN {
+            record_vault_auth_failure("login", "forbidden");
             Err(StorageError::Backend(eyre!(
                 "vault AppRole login denied (HTTP 403)"
             )))
         } else {
             let body_text = resp.text().await.unwrap_or_default();
+            record_vault_auth_failure("login", "http_error");
             Err(StorageError::Backend(eyre!(
                 "vault AppRole login failed: HTTP {status}: {body_text}"
             )))
@@ -444,33 +520,68 @@ impl TokenManager {
     }
 
     /// Ensure the current token is still valid, renewing or re-authenticating
-    /// as needed. This is called before every KV request.
+    /// as needed. Uses double-checked locking to serialize token renewal and prevent
+    /// thundering-herd stampedes under high concurrency.
     async fn ensure_valid(
         &self,
         client: &Client,
         addr: &str,
         namespace: Option<&str>,
     ) -> Result<(), StorageError> {
+        // Fast path: check under read lock if current token is still within safe window
+        {
+            let elapsed = self.issued_at.read().await.elapsed();
+            let ttl = *self.lease_duration.read().await;
+            let safe_window = Duration::from_secs_f64(ttl as f64 * Self::RENEW_MARGIN);
+            if ttl == 0 || elapsed < safe_window {
+                return Ok(());
+            }
+        }
+
+        // Acquire serialization lock to prevent concurrent renew/login stampedes
+        let _guard = self.renewal_lock.lock().await;
+
+        // Re-check after acquiring lock in case another task already renewed/re-logged-in
         let elapsed = self.issued_at.read().await.elapsed();
         let ttl = *self.lease_duration.read().await;
-
-        // No renewal needed if we're within the safe window (80% of TTL)
-        let safe_window = Duration::from_millis(ttl.saturating_mul(Self::RENEW_MARGIN_PCT));
+        let safe_window = Duration::from_secs_f64(ttl as f64 * Self::RENEW_MARGIN);
         if ttl == 0 || elapsed < safe_window {
             return Ok(());
+        }
+
+        // Check failure cooldown backoff to protect degraded/unreachable Vault
+        if let Some(last_fail) = *self.last_failure.read().await
+            && last_fail.elapsed() < Self::FAILURE_COOLDOWN
+        {
+            return Err(StorageError::Backend(eyre!(
+                "vault authentication in cooldown backoff after recent failure"
+            )));
         }
 
         // Try renewal first if the token is renewable
         if *self.renewable.read().await {
             match self.try_renew(client, addr, namespace).await {
-                Ok(()) => return Ok(()),
+                Ok(()) => {
+                    *self.last_failure.write().await = None;
+                    return Ok(());
+                }
                 Err(e) => {
                     warn!("Token renewal failed, re-authenticating: {e}");
                 }
             }
         }
+
         // Full re-login
-        self.re_login(client, addr, namespace).await
+        match self.re_login(client, addr, namespace).await {
+            Ok(()) => {
+                *self.last_failure.write().await = None;
+                Ok(())
+            }
+            Err(e) => {
+                *self.last_failure.write().await = Some(Instant::now());
+                Err(e)
+            }
+        }
     }
 
     /// Attempt to renew the current token via `POST /v1/auth/token/renew-self`.
@@ -490,24 +601,40 @@ impl TokenManager {
             builder = builder.header("X-Vault-Namespace", ns);
         }
 
-        let resp = builder.send().await?;
+        let resp = match builder.send().await {
+            Ok(resp) => resp,
+            Err(e) => {
+                record_vault_auth_failure("renewal", "network_error");
+                return Err(StorageError::Backend(e.into()));
+            }
+        };
+
         let status = resp.status();
 
         if status.is_success() {
-            let renew: LoginOrRenewResponse = resp.json().await?;
+            let renew: LoginOrRenewResponse = match resp.json().await {
+                Ok(data) => data,
+                Err(e) => {
+                    record_vault_auth_failure("renewal", "deserialization_error");
+                    return Err(StorageError::Backend(e.into()));
+                }
+            };
             info!(
                 lease_duration = renew.auth.lease_duration,
                 renewable = renew.auth.renewable,
                 "Token renewal successful"
             );
+            record_vault_renewal();
             *self.token.write().await = SecretString::from(renew.auth.client_token);
             *self.issued_at.write().await = Instant::now();
             *self.lease_duration.write().await = renew.auth.lease_duration;
             *self.renewable.write().await = renew.auth.renewable;
             Ok(())
         } else {
+            let body_text = resp.text().await.unwrap_or_default();
+            record_vault_auth_failure("renewal", "http_error");
             Err(StorageError::Backend(eyre!(
-                "token renewal failed: HTTP {status}"
+                "token renewal failed: HTTP {status}: {body_text}"
             )))
         }
     }
@@ -519,7 +646,7 @@ impl TokenManager {
         addr: &str,
         namespace: Option<&str>,
     ) -> Result<(), StorageError> {
-        let (new_token, lease_duration, renewable) = Self::perform_login(
+        let (new_token, lease_duration, renewable) = match Self::perform_login(
             client,
             addr,
             &self.role_id,
@@ -527,8 +654,16 @@ impl TokenManager {
             &self.auth_mount,
             namespace,
         )
-        .await?;
+        .await
+        {
+            Ok(res) => res,
+            Err(e) => {
+                record_vault_auth_failure("reauth", "login_error");
+                return Err(e);
+            }
+        };
 
+        record_vault_reauth();
         *self.token.write().await = new_token;
         *self.issued_at.write().await = Instant::now();
         *self.lease_duration.write().await = lease_duration;
@@ -668,7 +803,8 @@ impl Storage for VaultClient {
     /// Verify the Vault/OpenBao endpoint is reachable and the configured mount
     /// is accessible with the provided credentials.
     async fn reachable(&self) -> Result<(), StorageError> {
-        let url = format!("{}/v1/{}/config", self.addr, self.mount);
+        let encoded_mount = Self::encode_path_segment(&self.mount);
+        let url = format!("{}/v1/{}/config", self.addr, encoded_mount);
         let resp = self
             .add_auth_headers(self.client.get(&url))
             .await?
@@ -976,6 +1112,169 @@ mod tests {
         assert_eq!(
             client.auth.current_token().await.expose_secret(),
             "s.token-relogged"
+        );
+    }
+
+    #[tokio::test]
+    async fn vault_redaction_in_debug_and_errors() {
+        let server = MockServer::start().await;
+
+        // Mock 403 forbidden login
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/approle/login"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("denied by policy"))
+            .mount(&server)
+            .await;
+
+        let secret = SecretString::from("super-sensitive-secret-id");
+        let err = VaultClient::builder(server.uri(), "my-role", secret.clone())
+            .build()
+            .await
+            .unwrap_err();
+
+        let err_debug = format!("{err:?}");
+        let err_display = format!("{err}");
+        assert!(!err_debug.contains("super-sensitive-secret-id"));
+        assert!(!err_display.contains("super-sensitive-secret-id"));
+
+        // Now test successful login and check Debug representation
+        let server_ok = MockServer::start().await;
+        mock_approle_login(&server_ok, "s.secret-token-xyz", 3600).await;
+
+        let client = VaultClient::builder(server_ok.uri(), "my-role", secret)
+            .build()
+            .await
+            .unwrap();
+
+        let auth_debug = format!("{:?}", client.auth);
+        assert!(!auth_debug.contains("super-sensitive-secret-id"));
+        assert!(!auth_debug.contains("s.secret-token-xyz"));
+        assert!(auth_debug.contains("[REDACTED]"));
+    }
+
+    #[tokio::test]
+    async fn vault_concurrency_renewal_stampede_prevention() {
+        let server = MockServer::start().await;
+
+        // Initial login with short 1s TTL
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/approle/login"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(auth_response("s.initial-token", 1)),
+            )
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+
+        // Exact 1 renewal call should be made despite concurrent requests
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/token/renew-self"))
+            .and(header("X-Vault-Token", "s.initial-token"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(auth_response("s.renewed-token-concurrent", 3600)),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/secret/data/concurrent-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": { "data": { "value": "concurrent-val" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = Arc::new(
+            VaultClient::builder(server.uri(), valid_role_id(), valid_secret_id())
+                .secrets_cache_ttl(Duration::ZERO)
+                .build()
+                .await
+                .unwrap(),
+        );
+
+        // Wait past renewal threshold (0.8s)
+        tokio::time::sleep(Duration::from_millis(850)).await;
+
+        // Launch 10 concurrent requests
+        let mut handles = Vec::new();
+        for _ in 0..10 {
+            let client_clone = Arc::clone(&client);
+            handles.push(tokio::spawn(async move {
+                client_clone.load("concurrent-key").await
+            }));
+        }
+
+        for handle in handles {
+            let res = handle.await.unwrap();
+            assert_eq!(res.unwrap(), Some("concurrent-val".to_string()));
+        }
+
+        server.verify().await;
+        assert_eq!(
+            client.auth.current_token().await.expose_secret(),
+            "s.renewed-token-concurrent"
+        );
+    }
+
+    #[tokio::test]
+    async fn vault_auth_cooldown_backoff() {
+        let server = MockServer::start().await;
+
+        // Initial login with short 1s TTL (non-renewable to force re-login)
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/approle/login"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "auth": {
+                    "client_token": "s.token-1",
+                    "lease_duration": 1,
+                    "renewable": false
+                }
+            })))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+
+        // Re-login fails with 500
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/approle/login"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("internal error"))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+
+        let client = VaultClient::builder(server.uri(), valid_role_id(), valid_secret_id())
+            .secrets_cache_ttl(Duration::ZERO)
+            .build()
+            .await
+            .unwrap();
+
+        // Wait past TTL
+        tokio::time::sleep(Duration::from_millis(850)).await;
+
+        // First attempt triggers re-login and fails
+        let err1 = client.load("key").await.unwrap_err();
+        assert!(err1.to_string().contains("HTTP 500"));
+
+        // Immediate second attempt should hit cooldown backoff
+        let err2 = client.load("key").await.unwrap_err();
+        assert!(err2.to_string().contains("cooldown backoff"));
+    }
+
+    #[test]
+    fn vault_url_encoding_special_characters() {
+        assert_eq!(
+            VaultClient::encode_path_segment("standard-name_123.test~"),
+            "standard-name_123.test~"
+        );
+        assert_eq!(
+            VaultClient::encode_path_segment("name with spaces"),
+            "name%20with%20spaces"
+        );
+        assert_eq!(
+            VaultClient::encode_path_segment("mount?query#fragment/slash"),
+            "mount%3Fquery%23fragment%2Fslash"
         );
     }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -222,20 +222,17 @@ async fn build_state_impl(config: &AppConfig) -> EyeResult<BuildStateResult> {
             #[cfg(feature = "vault")]
             {
                 tracing::info!("Using Vault KV v2 as secrets backend");
+                let secret_id = config.vault.resolve_secret_id()?;
                 Box::new(
-                    VaultClient::builder(
-                        &config.vault.addr,
-                        &config.vault.role_id,
-                        config.vault.secret_id.clone(),
-                    )
-                    .auth_mount(&config.vault.auth_mount)
-                    .mount(&config.vault.mount)
-                    .path_prefix(&config.vault.path_prefix)
-                    .namespace(config.vault.namespace.as_deref())
-                    .secrets_cache_ttl(Duration::from_secs(config.vault.secrets_cache_ttl))
-                    .timeout(Duration::from_secs(config.vault.timeout_secs))
-                    .build()
-                    .await?,
+                    VaultClient::builder(&config.vault.addr, &config.vault.role_id, secret_id)
+                        .auth_mount(&config.vault.auth_mount)
+                        .mount(&config.vault.mount)
+                        .path_prefix(&config.vault.path_prefix)
+                        .namespace(config.vault.namespace.as_deref())
+                        .secrets_cache_ttl(Duration::from_secs(config.vault.secrets_cache_ttl))
+                        .timeout(Duration::from_secs(config.vault.timeout_secs))
+                        .build()
+                        .await?,
                 )
             }
             #[cfg(not(feature = "vault"))]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -223,13 +223,19 @@ async fn build_state_impl(config: &AppConfig) -> EyeResult<BuildStateResult> {
             {
                 tracing::info!("Using Vault KV v2 as secrets backend");
                 Box::new(
-                    VaultClient::builder(&config.vault.addr, config.vault.token.clone())
-                        .mount(&config.vault.mount)
-                        .path_prefix(&config.vault.path_prefix)
-                        .namespace(config.vault.namespace.as_deref())
-                        .secrets_cache_ttl(Duration::from_secs(config.vault.secrets_cache_ttl))
-                        .timeout(Duration::from_secs(config.vault.timeout_secs))
-                        .build()?,
+                    VaultClient::builder(
+                        &config.vault.addr,
+                        &config.vault.role_id,
+                        config.vault.secret_id.clone(),
+                    )
+                    .auth_mount(&config.vault.auth_mount)
+                    .mount(&config.vault.mount)
+                    .path_prefix(&config.vault.path_prefix)
+                    .namespace(config.vault.namespace.as_deref())
+                    .secrets_cache_ttl(Duration::from_secs(config.vault.secrets_cache_ttl))
+                    .timeout(Duration::from_secs(config.vault.timeout_secs))
+                    .build()
+                    .await?,
                 )
             }
             #[cfg(not(feature = "vault"))]
@@ -753,21 +759,43 @@ mod general_tests {
     /// Verifies that build_state succeeds with AppConfig::load_from_overrides defaults under
     /// the default feature set, catching missing test_data/ or config mismatch issues.
     /// When SQL features are enabled, uses memory backend to avoid requiring a real database.
-    #[test]
-    fn build_state_succeeds_under_default_config() {
+    #[tokio::test]
+    async fn build_state_succeeds_under_default_config() {
         let _ = rustls::crypto::ring::default_provider().install_default();
+        #[cfg(feature = "vault")]
+        let mock_vault = {
+            let server = wiremock::MockServer::start().await;
+            wiremock::Mock::given(wiremock::matchers::method("POST"))
+                .and(wiremock::matchers::path("/v1/auth/approle/login"))
+                .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(
+                    serde_json::json!({
+                        "auth": {
+                            "client_token": "s.mock-token",
+                            "lease_duration": 3600,
+                            "renewable": true
+                        }
+                    }),
+                ))
+                .mount(&server)
+                .await;
+            server
+        };
+
         let config = AppConfig::load_from_overrides(&[
             ("APP_DATABASE__BACKEND", "memory"),
             ("APP_DATABASE__URL", "memory:"),
             #[cfg(feature = "vault")]
-            ("APP_VAULT__TOKEN", "root"),
+            ("APP_VAULT__ADDR", &mock_vault.uri()),
+            #[cfg(feature = "vault")]
+            ("APP_VAULT__ROLE_ID", "test-role"),
+            #[cfg(feature = "vault")]
+            ("APP_VAULT__SECRET_ID", "test-secret"),
         ])
         .expect("Failed to load config");
-        tokio::runtime::Runtime::new().unwrap().block_on(async {
-            if let Err(ref e) = build_state(&config).await {
-                panic!("build_state failed under default configuration: {e:?}");
-            }
-        });
+
+        if let Err(ref e) = build_state(&config).await {
+            panic!("build_state failed under default configuration: {e:?}");
+        }
     }
 
     /// Verifies that a saturated pool returns an error within `acquire_timeout`

--- a/tests/cert_provisioning.rs
+++ b/tests/cert_provisioning.rs
@@ -205,13 +205,92 @@ impl TestInfra {
 }
 
 #[cfg(feature = "vault")]
-fn build_vault_storage(vault_port: u16) -> VaultClient {
+async fn setup_vault_approle(vault_port: u16) -> (String, SecretString) {
     let vault_url = format!("http://127.0.0.1:{vault_port}");
-    VaultClient::builder(vault_url, SecretString::from("root".to_string()))
+    let client = reqwest::Client::new();
+
+    // Enable approle auth engine
+    let _ = client
+        .post(format!("{vault_url}/v1/sys/auth/approle"))
+        .header("X-Vault-Token", "root")
+        .json(&serde_json::json!({
+            "type": "approle"
+        }))
+        .send()
+        .await;
+
+    // Create a policy granting full access to secrets
+    let _ = client
+        .put(format!("{vault_url}/v1/sys/policy/test-policy"))
+        .header("X-Vault-Token", "root")
+        .json(&serde_json::json!({
+            "policy": "path \"*\" { capabilities = [\"create\", \"read\", \"update\", \"delete\", \"list\"] }"
+        }))
+        .send()
+        .await;
+
+    // Create a role with test-policy
+    let resp = client
+        .post(format!("{vault_url}/v1/auth/approle/role/status-list-role"))
+        .header("X-Vault-Token", "root")
+        .json(&serde_json::json!({
+            "token_policies": ["test-policy"],
+            "token_ttl": "1h",
+            "token_max_ttl": "4h"
+        }))
+        .send()
+        .await
+        .expect("Failed to create AppRole");
+    assert!(resp.status().is_success());
+
+    // Read role-id
+    let resp = client
+        .get(format!(
+            "{vault_url}/v1/auth/approle/role/status-list-role/role-id"
+        ))
+        .header("X-Vault-Token", "root")
+        .send()
+        .await
+        .expect("Failed to get role-id");
+    let role_data: serde_json::Value = resp.json().await.expect("Failed to parse role-id response");
+    let role_id = role_data["data"]["role_id"].as_str().unwrap().to_string();
+
+    // Generate secret-id
+    let resp = client
+        .post(format!(
+            "{vault_url}/v1/auth/approle/role/status-list-role/secret-id"
+        ))
+        .header("X-Vault-Token", "root")
+        .send()
+        .await
+        .expect("Failed to generate secret-id");
+    let secret_data: serde_json::Value = resp
+        .json()
+        .await
+        .expect("Failed to parse secret-id response");
+    let secret_id = SecretString::from(
+        secret_data["data"]["secret_id"]
+            .as_str()
+            .unwrap()
+            .to_string(),
+    );
+
+    (role_id, secret_id)
+}
+
+#[cfg(feature = "vault")]
+async fn build_vault_storage(
+    vault_port: u16,
+    role_id: String,
+    secret_id: SecretString,
+) -> VaultClient {
+    let vault_url = format!("http://127.0.0.1:{vault_port}");
+    VaultClient::builder(vault_url, role_id, secret_id)
         .mount("secret")
         .path_prefix("status-list")
         .secrets_cache_ttl(Duration::ZERO)
         .build()
+        .await
         .expect("Failed to build VaultClient")
 }
 
@@ -330,7 +409,8 @@ async fn test_cert_provisioning_with_hashicorp_vault() {
         .expect("Failed to start HashicorpVault container");
     let vault_port = _vault_container.get_host_port_ipv4(8200).await.unwrap();
 
-    let secrets_storage = build_vault_storage(vault_port);
+    let (role_id, secret_id) = setup_vault_approle(vault_port).await;
+    let secrets_storage = build_vault_storage(vault_port, role_id.clone(), secret_id.clone()).await;
     let cert_manager = infra
         .build_cert_manager("vault.example.com", secrets_storage)
         .await;
@@ -362,7 +442,7 @@ async fn test_cert_provisioning_with_hashicorp_vault() {
     assert!(keys.iter().any(|k| k.contains("cert_data.json")));
 
     // Verify signing key was stored in Vault (secrets storage)
-    let vault_reader = build_vault_storage(vault_port);
+    let vault_reader = build_vault_storage(vault_port, role_id, secret_id).await;
     let signing_key = Storage::load(&vault_reader, "keys-vault.example.com")
         .await
         .expect("Failed to load signing_key from Vault");
@@ -399,7 +479,9 @@ async fn test_cert_provisioning_with_openbao() {
         .expect("Failed to start OpenBao container");
     let openbao_port = _openbao_container.get_host_port_ipv4(8200).await.unwrap();
 
-    let secrets_storage = build_vault_storage(openbao_port);
+    let (role_id, secret_id) = setup_vault_approle(openbao_port).await;
+    let secrets_storage =
+        build_vault_storage(openbao_port, role_id.clone(), secret_id.clone()).await;
     let cert_manager = infra
         .build_cert_manager("openbao.example.com", secrets_storage)
         .await;
@@ -431,7 +513,7 @@ async fn test_cert_provisioning_with_openbao() {
     assert!(keys.iter().any(|k| k.contains("cert_data.json")));
 
     // Verify signing key was stored in OpenBao (secrets storage)
-    let openbao_reader = build_vault_storage(openbao_port);
+    let openbao_reader = build_vault_storage(openbao_port, role_id, secret_id).await;
     let signing_key = Storage::load(&openbao_reader, "keys-openbao.example.com")
         .await
         .expect("Failed to load signing_key from OpenBao");

--- a/tests/cert_provisioning.rs
+++ b/tests/cert_provisioning.rs
@@ -210,24 +210,36 @@ async fn setup_vault_approle(vault_port: u16) -> (String, SecretString) {
     let client = reqwest::Client::new();
 
     // Enable approle auth engine
-    let _ = client
+    let resp = client
         .post(format!("{vault_url}/v1/sys/auth/approle"))
         .header("X-Vault-Token", "root")
         .json(&serde_json::json!({
             "type": "approle"
         }))
         .send()
-        .await;
+        .await
+        .expect("Failed to enable AppRole auth engine");
+    assert!(
+        resp.status().is_success() || resp.status() == reqwest::StatusCode::BAD_REQUEST,
+        "unexpected status enabling approle: {}",
+        resp.status()
+    );
 
     // Create a policy granting full access to secrets
-    let _ = client
+    let resp = client
         .put(format!("{vault_url}/v1/sys/policy/test-policy"))
         .header("X-Vault-Token", "root")
         .json(&serde_json::json!({
             "policy": "path \"*\" { capabilities = [\"create\", \"read\", \"update\", \"delete\", \"list\"] }"
         }))
         .send()
-        .await;
+        .await
+        .expect("Failed to create test-policy");
+    assert!(
+        resp.status().is_success(),
+        "failed to create test-policy: {}",
+        resp.status()
+    );
 
     // Create a role with test-policy
     let resp = client


### PR DESCRIPTION
Added Vault/OpenBao AppRole authentication in replacement to token-based authentication. Vault/OpenBao token authentication is useful for local tests and simple setups, but AppRole is a common production machine-to-machine authentication mechanism. It lets operators provision a `role_id` and protected `secret_id`, issue scoped tokens, and rotate credentials without embedding long-lived root/operator tokens in the server environment.

## Acceptance Criteria

- [x] Vault/OpenBao backends work with token auth and AppRole auth.
- [x] AppRole credentials are treated as secrets and can themselves be loaded through the runtime credential mechanism where practical.
- [x] Token renewal/reacquisition is observable through safe logs/metrics.
- [x] Failure modes are clear and do not leak `secret_id`, tokens, signing keys, or certificate material.