### PR TITLE
feat: helm-based staging and production deploys (closes #248)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,19 +7,24 @@ on:
       - v*.*.*
 env:
   IMAGE_NAME: status-list-server
-  NAMESPACE: statuslist
   CLUSTER_NAME: datev-wallet-cluster
   AWS_REGION: eu-central-1
   REGISTRY: ghcr.io
 jobs:
+  ci:
+    name: CI
+    uses: ./.github/workflows/CI.yml
+
   build-and-push:
     name: Build and Push Docker Image to GHCR
     runs-on: ubuntu-latest
+    needs: ci
     permissions:
       contents: read
       packages: write
     outputs:
       image_tag: ${{ steps.vars.outputs.SHORT_SHA }}
+      deploy_tag: ${{ steps.vars.outputs.DEPLOY_TAG }}
     steps:
       - name: Checkout source code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -33,7 +38,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Get short commit SHA
         id: vars
-        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+        run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+          echo "SHORT_SHA=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            echo "DEPLOY_TAG=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "DEPLOY_TAG=sha-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          fi
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
@@ -51,26 +63,83 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
-  deploy-to-eks:
-    name: Deploy to EKS
+
+  deploy-staging:
+    name: Deploy to Staging
     runs-on: ubuntu-latest
     needs: build-and-push
+    if: ${{ github.ref == 'refs/heads/main' }}
+    environment: staging
     permissions:
       contents: read
       id-token: write
     steps:
+      - name: Checkout source code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install kubectl
-        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5
+        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.0.1
+      - name: Install Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          role-session-name: status-list-server-staging-deploy
           aws-region: ${{ env.AWS_REGION }}
       - name: Update kubeconfig for EKS
         run: aws eks update-kubeconfig --name ${{ env.CLUSTER_NAME }} --region ${{ env.AWS_REGION }}
-      - name: Deploy updated image to Kubernetes
+      - name: Build Helm dependencies
         run: |
-          kubectl set image deployment/statuslist-status-list-server-deployment \
-            status-list-server=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:sha-${{ needs.build-and-push.outputs.image_tag }} \
-            -n ${{ env.NAMESPACE }}
+          helm repo add dandydeveloper https://dandydeveloper.github.io/charts
+          helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+          helm dependency build helm/chart
+      - name: Deploy chart to staging
+        run: |
+          helm upgrade --install statuslist helm/chart \
+            --namespace statuslist-staging \
+            --create-namespace \
+            --atomic \
+            --wait \
+            --timeout 10m \
+            --set-string statuslist.image.repository=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }} \
+            --set-string statuslist.image.tag=${{ needs.build-and-push.outputs.deploy_tag }}
+
+  deploy-production:
+    name: Deploy to Production
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    environment: production
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Install kubectl
+        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.0.1
+      - name: Install Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          role-session-name: status-list-server-production-deploy
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Update kubeconfig for EKS
+        run: aws eks update-kubeconfig --name ${{ env.CLUSTER_NAME }} --region ${{ env.AWS_REGION }}
+      - name: Build Helm dependencies
+        run: |
+          helm repo add dandydeveloper https://dandydeveloper.github.io/charts
+          helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+          helm dependency build helm/chart
+      - name: Deploy chart to production
+        run: |
+          helm upgrade --install statuslist helm/chart \
+            --namespace statuslist-production \
+            --create-namespace \
+            --atomic \
+            --wait \
+            --timeout 10m \
+            --set-string statuslist.image.repository=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }} \
+            --set-string statuslist.image.tag=${{ needs.build-and-push.outputs.deploy_tag }}

--- a/docs/deployment-runbook.md
+++ b/docs/deployment-runbook.md
@@ -1,0 +1,211 @@
+# Deployment Runbook
+
+This runbook describes the GitHub Actions deployment flow for the Status List Server Helm chart on AWS EKS.
+
+## Deployment Flow
+
+The deploy workflow is `.github/workflows/deploy.yml`. It runs on pushes to `main` and tags matching `v*.*.*`.
+
+Every deploy run first executes the reusable CI workflow, builds and pushes a multi-architecture image to GHCR, then deploys the Helm chart with the image tag selected for the target environment.
+
+### Staging
+
+Pushes to `main` deploy to:
+
+- GitHub environment: `staging`
+- Kubernetes namespace: `statuslist-staging`
+- Helm release: `statuslist`
+- Image tag: `sha-<short_sha>`
+
+The staging deploy command is equivalent to:
+
+```bash
+helm upgrade --install statuslist helm/chart \
+  --namespace statuslist-staging \
+  --create-namespace \
+  --atomic \
+  --wait \
+  --timeout 10m \
+  --set-string statuslist.image.repository=ghcr.io/adorsys/status-list-server \
+  --set-string statuslist.image.tag=sha-<short_sha>
+```
+
+### Production
+
+Release tags matching `v*.*.*` deploy to:
+
+- GitHub environment: `production`
+- Kubernetes namespace: `statuslist-production`
+- Helm release: `statuslist`
+- Image tag: semantic version without the leading `v`
+
+For example, tag `v0.5.0` deploys image tag `0.5.0`.
+
+The production deploy command is equivalent to:
+
+```bash
+helm upgrade --install statuslist helm/chart \
+  --namespace statuslist-production \
+  --create-namespace \
+  --atomic \
+  --wait \
+  --timeout 10m \
+  --set-string statuslist.image.repository=ghcr.io/adorsys/status-list-server \
+  --set-string statuslist.image.tag=0.5.0
+```
+
+Configure the GitHub `production` environment with required reviewers so production deploys pause for approval before AWS credentials are requested.
+
+## Required GitHub and AWS Setup
+
+Create GitHub environments named `staging` and `production`. Each environment must expose:
+
+- `AWS_DEPLOY_ROLE_ARN`: IAM role ARN assumed by the deploy job through GitHub OIDC.
+
+Configure environment protection rules:
+
+- `staging`: allow deployments from the `main` branch.
+- `production`: allow deployments from protected release tags matching `v*.*.*` and require reviewers.
+
+The deploy job requires:
+
+- GitHub Actions permission `id-token: write`
+- IAM trust for `token.actions.githubusercontent.com`
+- AWS permission to describe the EKS cluster and perform the Kubernetes operations needed by Helm
+
+Recommended OIDC trust subjects:
+
+- Staging: `repo:adorsys/status-list-server:environment:staging`
+- Production: `repo:adorsys/status-list-server:environment:production`
+
+When a GitHub Actions job uses an environment, GitHub's default OIDC `sub` claim references the environment name. Keep branch and tag scoping in the GitHub environment protection rules. For repositories using immutable OIDC subject claims, adjust the `repo:` prefix to the immutable owner and repository ID format shown by GitHub.
+
+## Verification
+
+After a deploy, verify the Helm release and Kubernetes rollout:
+
+```bash
+helm status statuslist -n statuslist-staging
+helm history statuslist -n statuslist-staging
+kubectl rollout status deployment/statuslist-status-list-server-deployment -n statuslist-staging
+kubectl logs -l app.kubernetes.io/name=status-list-server -n statuslist-staging --tail=100
+```
+
+For production, replace `statuslist-staging` with `statuslist-production`.
+
+Smoke-check the running service:
+
+```bash
+kubectl get pods -n statuslist-production
+kubectl describe pod -l app.kubernetes.io/name=status-list-server -n statuslist-production
+kubectl exec deploy/statuslist-status-list-server-deployment -n statuslist-production -- test -r /home/nobody/.aws/credentials
+```
+
+If certificate provisioning or AWS-backed storage is enabled, also confirm the app can reach AWS services by checking application logs for successful S3, Secrets Manager, or certificate renewal operations.
+
+## Rollback
+
+There are two rollback paths:
+
+- Failed upgrade rollback is automatic. The deploy workflow uses `--atomic --wait --timeout 10m`, so Helm rolls back during the pipeline when an upgrade fails readiness or times out.
+- Successful-but-bad deploy rollback is manual. If a release passes the pipeline but later proves unhealthy or incorrect, an operator must choose a previous Helm revision and run `helm rollback`.
+
+List available revisions:
+
+```bash
+helm history statuslist -n statuslist-production
+```
+
+Rollback to a known-good revision:
+
+```bash
+helm rollback statuslist <revision> -n statuslist-production --wait --timeout 10m
+kubectl rollout status deployment/statuslist-status-list-server-deployment -n statuslist-production
+```
+
+Use the same commands with `-n statuslist-staging` for staging.
+
+## Failure Triage
+
+### OIDC Denied
+
+Symptoms:
+
+- `configure-aws-credentials` fails before `aws eks update-kubeconfig`.
+- AWS STS reports that the role cannot be assumed.
+
+Check:
+
+- The GitHub environment name matches the IAM trust subject.
+- `AWS_DEPLOY_ROLE_ARN` exists in the selected environment.
+- The role trust references this repository and the correct branch or tag pattern.
+- The IAM OIDC provider for GitHub Actions and the trust policy for this repository are configured.
+
+### Helm Timeout
+
+Symptoms:
+
+- `helm upgrade --install` fails after `--timeout 10m`.
+- Helm reports the release rolled back because `--atomic` is enabled.
+
+Check:
+
+```bash
+helm history statuslist -n <namespace>
+kubectl get pods -n <namespace>
+kubectl describe pod -l app.kubernetes.io/name=status-list-server -n <namespace>
+kubectl logs -l app.kubernetes.io/name=status-list-server -n <namespace> --tail=200
+```
+
+### Image Pull Failure
+
+Symptoms:
+
+- Pods show `ImagePullBackOff` or `ErrImagePull`.
+
+Check:
+
+- The workflow pushed the expected GHCR tag.
+- Staging uses `sha-<short_sha>`.
+- Production uses the semver tag without the leading `v`.
+- The cluster can pull from GHCR.
+
+### Readiness Failure
+
+Symptoms:
+
+- Helm waits until timeout.
+- Pods are running but not ready.
+
+Check:
+
+- `/health/ready` responses in pod logs.
+- PostgreSQL and optional Redis readiness.
+- ExternalSecret and SecretStore status.
+- Application configuration injected through Helm values.
+
+### AWS Credential or Certificate Access Failure
+
+Symptoms:
+
+- The app starts but fails S3, Secrets Manager, Route53, or certificate operations.
+- Logs mention missing AWS credentials or permission denied.
+
+Check:
+
+> **Note:** The preferred authentication path for pods is IRSA (IAM Role for Service Accounts), which eliminates the need for credential files. The credential mount check below applies only when IRSA is not yet in place.
+
+- The chart mounts credentials at `/home/nobody/.aws` (unless IRSA is already configured).
+- The pod runs as the configured non-root user.
+- The mounted secret contains the expected files.
+- The IAM permissions behind the credentials cover the configured AWS operations.
+
+## Helm Chart Requirements
+
+Before deploying to a production namespace, the chart must include production-ready probes, resource requests and limits, a network policy, a non-root security context, and a compatible AWS credentials configuration (IRSA is preferred; credential files via secret mount are supported as a fallback).
+
+If these are missing, deployments may fail readiness, fail security scans, or start pods that cannot access AWS services.
+
+## Release Tagging
+
+Production deploys only trigger for tags matching `v*.*.*`. The workflow strips the leading `v` and uses the remaining version string as the image tag. Ensure release tags are created correctly — if tags are not pushed after merging the release PR, the production deploy workflow will not run.

--- a/helm/README.md
+++ b/helm/README.md
@@ -54,6 +54,8 @@ To enable Redis, use an application image built with `redis,aws,acme` features, 
 
 ## Production Deployment Instructions
 
+For GitHub Actions deployments to staging and production, see the [Deployment Runbook](../docs/deployment-runbook.md). CI/CD owns production image tag injection with `statuslist.image.repository` and `statuslist.image.tag`; operators should avoid patching live images imperatively because Helm will reconcile the chart state on the next deploy. Failed upgrades roll back automatically through Helm `--atomic`; rollbacks after a successful but bad deploy are manual Helm operations.
+
 1. **Create a namespace:**
 
    ```bash


### PR DESCRIPTION
## Summary

Replace the imperative EKS deploy step with Helm-based staging and production deployments. The workflow deploys `main` to `staging` using SHA image tags and release tags to `production` using semver image tags. AWS credentials come from GitHub OIDC through `AWS_DEPLOY_ROLE_ARN`.

## Changes

* **deploy.yml**: Replaced `kubectl set image` with `helm dependency build` and `helm upgrade --install` with `--atomic --wait --timeout 10m`
* **deploy.yml**: Replaced static AWS credentials with OIDC `role-to-assume`
* **deploy.yml**: Deploy `main` to `statuslist-staging` namespace, `v*.*.*` tags to `statuslist-production` namespace
* **deploy.yml**: Added CI prerequisite job via reusable workflow
* **docs/deployment-runbook.md**: New file documenting deployment flow, OIDC prerequisites, rollback, and verification
* **helm/README.md**: Updated with GitOps deployment reference

Closes #248