### PR TITLE
feat: Helm-based production deploys via EKS (issue #248)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,19 +7,25 @@ on:
       - v*.*.*
 env:
   IMAGE_NAME: status-list-server
-  NAMESPACE: statuslist
   CLUSTER_NAME: datev-wallet-cluster
   AWS_REGION: eu-central-1
   REGISTRY: ghcr.io
+  HELM_RELEASE_NAME: statuslist
+  HELM_NAMESPACE: statuslist-production
 jobs:
+  ci:
+    name: CI
+    uses: ./.github/workflows/CI.yml
+
   build-and-push:
     name: Build and Push Docker Image to GHCR
     runs-on: ubuntu-latest
+    needs: ci
     permissions:
       contents: read
       packages: write
     outputs:
-      image_tag: ${{ steps.vars.outputs.SHORT_SHA }}
+      deploy_tag: ${{ steps.vars.outputs.DEPLOY_TAG }}
     steps:
       - name: Checkout source code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -33,16 +39,24 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Get short commit SHA
         id: vars
-        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+        run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+          echo "SHORT_SHA=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            echo "DEPLOY_TAG=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "DEPLOY_TAG=sha-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          fi
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+            type=sha,format=short,prefix=sha-
           tags: |
             type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-            type=sha,format=short
+            type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=sha,format=short,prefix=sha-,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
       - name: Build and push Docker image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
@@ -51,26 +65,43 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
-  deploy-to-eks:
-    name: Deploy to EKS
+
+  deploy:
+    name: Deploy to Production
     runs-on: ubuntu-latest
     needs: build-and-push
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    environment: production
     permissions:
       contents: read
       id-token: write
     steps:
+      - name: Checkout source code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install kubectl
-        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5
+        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.0.1
+      - name: Install Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          role-session-name: status-list-server-deploy
           aws-region: ${{ env.AWS_REGION }}
       - name: Update kubeconfig for EKS
         run: aws eks update-kubeconfig --name ${{ env.CLUSTER_NAME }} --region ${{ env.AWS_REGION }}
-      - name: Deploy updated image to Kubernetes
+      - name: Build Helm dependencies
         run: |
-          kubectl set image deployment/statuslist-status-list-server-deployment \
-            status-list-server=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:sha-${{ needs.build-and-push.outputs.image_tag }} \
-            -n ${{ env.NAMESPACE }}
+          helm repo add dandydeveloper https://dandydeveloper.github.io/charts
+          helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+          helm dependency build helm/chart
+      - name: Deploy chart
+        run: |
+          helm upgrade --install ${{ env.HELM_RELEASE_NAME }} helm/chart \
+            --namespace ${{ env.HELM_NAMESPACE }} \
+            --create-namespace \
+            --atomic \
+            --wait \
+            --timeout 10m \
+            --set-string statuslist.image.repository=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }} \
+            --set-string statuslist.image.tag=${{ needs.build-and-push.outputs.deploy_tag }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-            type=sha,format=short,prefix=sha-,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=sha,format=short,prefix=sha-
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
       - name: Build and push Docker image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
-            type=sha,format=short,prefix=sha-
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,7 +1928,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2312,9 +2312,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4177,7 +4177,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4645,7 +4645,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4704,7 +4704,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6714,7 +6714,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/docs/deployment-runbook.md
+++ b/docs/deployment-runbook.md
@@ -15,9 +15,9 @@ Every workflow run first executes the reusable CI workflow, builds and pushes a 
 
 ### Image Tags
 
-| Trigger | Image Tags |
-|---------|------------|
-| Push to `main` | `sha-<short_sha>` |
+| Trigger              | Image Tags                                                  |
+|----------------------|-------------------------------------------------------------|
+| Push to `main`       | `sha-<short_sha>`                                           |
 | Release tag `v*.*.*` | `<major>.<minor>`, `<version>`, `sha-<short_sha>`, `latest` |
 
 The `latest` tag is only applied to official release tags, not to intermediate commits from `main`. This follows standard OCI/Docker distribution conventions where `latest` represents the latest stable release.
@@ -64,7 +64,7 @@ The deploy job requires:
 
 Recommended OIDC trust subject for production:
 
-```
+```text
 repo:adorsys/status-list-server:environment:production
 ```
 

--- a/docs/deployment-runbook.md
+++ b/docs/deployment-runbook.md
@@ -1,0 +1,173 @@
+# Deployment Runbook
+
+This runbook describes the GitHub Actions deployment flow for the Status List Server Helm chart on AWS EKS.
+
+## Deployment Flow
+
+The deploy workflow is `.github/workflows/deploy.yml`. It runs on pushes to `main` and release tags matching `v*.*.*`.
+
+- Pushes to `main` run CI checks and build and push the Docker image to GHCR.
+- Release tags matching `v*.*.*` deploy to the production cluster.
+
+## How It Works
+
+Every workflow run first executes the reusable CI workflow, builds and pushes a multi-architecture image to GHCR. Release tag runs then deploy the Helm chart with the semver image tag to production.
+
+### Image Tags
+
+| Trigger | Image Tags |
+|---------|------------|
+| Push to `main` | `sha-<short_sha>` |
+| Release tag `v*.*.*` | `<major>.<minor>`, `<version>`, `sha-<short_sha>`, `latest` |
+
+The `latest` tag is only applied to official release tags, not to intermediate commits from `main`. This follows standard OCI/Docker distribution conventions where `latest` represents the latest stable release.
+
+### Production Deploy
+
+Release tags matching `v*.*.*` deploy to:
+
+- GitHub environment: `production`
+- Kubernetes namespace: `statuslist-production`
+- Helm release: `statuslist`
+- Image tag: semantic version without the leading `v`
+
+For example, tag `v0.5.0` deploys image tag `0.5.0`.
+
+The production deploy command is equivalent to:
+
+```bash
+helm upgrade --install statuslist helm/chart \
+  --namespace statuslist-production \
+  --create-namespace \
+  --atomic \
+  --wait \
+  --timeout 10m \
+  --set-string statuslist.image.repository=ghcr.io/adorsys/status-list-server \
+  --set-string statuslist.image.tag=0.5.0
+```
+
+Configure the GitHub `production` environment with required reviewers so production deploys pause for approval before AWS credentials are requested.
+
+## Required GitHub and AWS Setup
+
+Create the GitHub `production` environment with:
+
+- `AWS_DEPLOY_ROLE_ARN`: IAM role ARN assumed by the deploy job through GitHub OIDC.
+- Required reviewers: configure at least one approver.
+- Deployment branches/tags: restrict to release tags matching `v*.*.*`.
+
+The deploy job requires:
+
+- GitHub Actions permission `id-token: write`
+- IAM trust for `token.actions.githubusercontent.com`
+- AWS permission to describe the EKS cluster and perform the Kubernetes operations needed by Helm
+
+Recommended OIDC trust subject for production:
+
+```
+repo:adorsys/status-list-server:environment:production
+```
+
+When a GitHub Actions job uses an environment, GitHub's default OIDC `sub` claim references the environment name. For repositories using immutable OIDC subject claims, adjust the `repo:` prefix to the immutable owner and repository ID format shown by GitHub.
+
+## Verification
+
+After a deploy, verify the Helm release and Kubernetes rollout:
+
+```bash
+helm status statuslist -n statuslist-production
+helm history statuslist -n statuslist-production
+kubectl rollout status deployment/statuslist-status-list-server-deployment -n statuslist-production
+kubectl logs -l app.kubernetes.io/name=status-list-server -n statuslist-production --tail=100
+```
+
+Smoke-check the running service:
+
+```bash
+kubectl get pods -n statuslist-production
+kubectl describe pod -l app.kubernetes.io/name=status-list-server -n statuslist-production
+```
+
+If certificate provisioning or AWS-backed storage is enabled, also confirm the app can reach AWS services by checking application logs for successful S3, Secrets Manager, or certificate renewal operations.
+
+## Rollback
+
+There are two rollback paths:
+
+- Failed upgrade rollback is automatic. The deploy workflow uses `--atomic --wait --timeout 10m`, so Helm rolls back during the pipeline when an upgrade fails readiness or times out.
+- Successful-but-bad deploy rollback is manual. If a release passes the pipeline but later proves unhealthy or incorrect, an operator must choose a previous Helm revision and run `helm rollback`.
+
+List available revisions:
+
+```bash
+helm history statuslist -n statuslist-production
+```
+
+Rollback to a known-good revision:
+
+```bash
+helm rollback statuslist <revision> -n statuslist-production --wait --timeout 10m
+kubectl rollout status deployment/statuslist-status-list-server-deployment -n statuslist-production
+```
+
+## Failure Triage
+
+### OIDC Denied
+
+Symptoms:
+
+- `configure-aws-credentials` fails before `aws eks update-kubeconfig`.
+- AWS STS reports that the role cannot be assumed.
+
+Check:
+
+- The GitHub environment name matches the IAM trust subject.
+- `AWS_DEPLOY_ROLE_ARN` exists in the selected environment.
+- The role trust references this repository and the correct branch or environment.
+- OIDC IAM role has been created and applied (see issue #236).
+
+### Helm Timeout
+
+Symptoms:
+
+- `helm upgrade --install` fails after `--timeout 10m`.
+- Helm reports the release rolled back because `--atomic` is enabled.
+
+Check:
+
+```bash
+helm history statuslist -n statuslist-production
+kubectl get pods -n statuslist-production
+kubectl describe pod -l app.kubernetes.io/name=status-list-server -n statuslist-production
+kubectl logs -l app.kubernetes.io/name=status-list-server -n statuslist-production --tail=200
+```
+
+### Image Pull Failure
+
+Symptoms:
+
+- Pods show `ImagePullBackOff` or `ErrImagePull`.
+
+Check:
+
+- The workflow pushed the expected GHCR tag with the semver format.
+- The cluster can pull from GHCR.
+
+### Readiness Failure
+
+Symptoms:
+
+- Helm waits until timeout.
+- Pods are running but not ready.
+
+Check:
+
+- `/health/ready` responses in pod logs.
+- PostgreSQL and optional Redis readiness.
+- ExternalSecret and SecretStore status.
+- Application configuration injected through Helm values.
+
+## External Dependencies
+
+- **Issue #236**: OIDC IAM role and GitHub environment setup must be completed before first deploy.
+- **Issue #239**: Chart hardening (IRSA migration of cert-manager/Route53 credentials) is pending.

--- a/helm/README.md
+++ b/helm/README.md
@@ -54,6 +54,8 @@ To enable Redis, use an application image built with `redis,aws,acme` features, 
 
 ## Production Deployment Instructions
 
+For GitHub Actions deployments to production, see the [Deployment Runbook](../docs/deployment-runbook.md). CI/CD owns production image tag injection with `statuslist.image.repository` and `statuslist.image.tag`; operators should avoid patching live images imperatively because Helm will reconcile the chart state on the next deploy. Failed upgrades roll back automatically through Helm `--atomic`; rollbacks after a successful but bad deploy are manual Helm operations.
+
 1. **Create a namespace:**
 
    ```bash


### PR DESCRIPTION
## Summary

Replaces the imperative EKS deploy step with Helm-based production deployments. Only release tags (`v*.*.*`) trigger production deployments. AWS credentials come from GitHub OIDC through `AWS_DEPLOY_ROLE_ARN`.

Squashed from PR #379 into a single conventional commit.

## Key Design Decisions

1. **Deploy only on release tags** — Push to `main` runs CI and builds images but does not deploy. Production deployment is gated on release tags (`v*.*.*`).
2. **`latest` tag only on releases** — Applied only to official release tags, not intermediate commits from `main`.
3. **DRY deploy job** — Single parameterized deploy job.

## Changes

- `.github/workflows/deploy.yml`: Add reusable CI prerequisite, single parameterized deploy job with Helm upgrade, OIDC role assumption, release-tag gating.
- `docs/deployment-runbook.md`: New runbook documenting the deploy flow, image tags, OIDC prerequisites, rollback, and failure triage.
- `helm/README.md`: Link to the deployment runbook.

## References

- Issue #248
- Depends on issue #236 (OIDC IAM role and GitHub environment setup)
