### PR TITLE
refactor: add in file rationale documentation for disabled semver checks and publish in release plz.toml 

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,6 +2,11 @@
 changelog_path = "./CHANGELOG.md"
 changelog_config = "cliff.toml"
 release_always = false
+
+# semver_check is disabled because this is a standalone binary crate, not a
+# published library crate on crates.io. cargo-semver-checks validates a public
+# API library contract, which a binary-only crate does not expose, so the check
+# has nothing meaningful to verify and would only add noise.
 semver_check = false
 publish = false
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,3 +1,5 @@
+# Note: release-plz's [workspace] table defines default configuration settings
+# for release-plz across packages; it is unrelated to Cargo workspaces (this crate has none).
 [workspace]
 changelog_path = "./CHANGELOG.md"
 changelog_config = "cliff.toml"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -4,6 +4,11 @@
 changelog_path = "./CHANGELOG.md"
 changelog_config = "cliff.toml"
 release_always = false
+
+# semver_check is disabled because this is a standalone binary crate, not a library
+# published on crates.io. Since there is no public library API contract exposed to
+# external callers, cargo-semver-checks has no baseline version on the registry to
+# compare API changes against.
 semver_check = false
 
 [[package]]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -17,6 +17,11 @@ name = "status-list-server"
 # publish is disabled because this crate is distributed via Docker images and
 # GitHub releases, not published to crates.io.
 publish = false
+
+# git_only = true instructs release-plz to look for existing git tags to determine the
+# current version rather than checking the Cargo registry (making it load-bearing for
+# version determination). While git_only also skips registry publishing, pairing it
+# with publish = false is intentional to remain explicit and prevent re-coupling to crates.io.
 git_only = true
 
 git_release_body = """

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -13,6 +13,9 @@ semver_check = false
 
 [[package]]
 name = "status-list-server"
+
+# publish is disabled because this crate is distributed via Docker images and
+# GitHub releases, not published to crates.io.
 publish = false
 git_only = true
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -8,6 +8,11 @@ release_always = false
 # API library contract, which a binary-only crate does not expose, so the check
 # has nothing meaningful to verify and would only add noise.
 semver_check = false
+
+# publish is disabled because this crate is not published to crates.io. It is
+# distributed via Docker images and GitHub releases instead, so release-plz
+# should tag and produce changelog/release artifacts without attempting to
+# publish a crate to the registry.
 publish = false
 
 git_release_body = """


### PR DESCRIPTION
In `release-plz.toml`, `semver_check = false` and `publish = false` are currently set without in-file documentation. While justified (this is a standalone binary crate, not a published library crate on crates.io, so `cargo-semver-checks` has no public API library contract to validate), adding explicit in-file comments ensures future maintainers understand the architectural rationale and tradeoffs.