### PR TITLE
docs: Workload Identity deployment patterns, secrets backends, and deployment architecture (issue #385)

### DIFF
--- a/docs/deployment-architecture.md
+++ b/docs/deployment-architecture.md
@@ -1,0 +1,572 @@
+# Status List Server — Deployment Architecture
+
+## Overview
+
+The Status List Server is a Rust-based microservice deployed on AWS EKS. This document describes the complete deployment architecture from source code to running service.
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                           DEPLOYMENT ARCHITECTURE                           │
+└─────────────────────────────────────────────────────────────────────────────┘
+
+   ┌──────────┐      ┌──────────────┐      ┌─────────────────┐
+   │   GitHub  │ ───► │  GitHub      │ ───► │   AWS EKS        │
+   │  (main)   │      │  Actions     │      │   Kubernetes    │
+   └──────────┘      │  CI/CD       │      │   Cluster       │
+                      └──────────────┘      └────────┬────────┘
+                              │                        │
+                              ▼                        ▼
+                     ┌──────────────┐         ┌──────────────┐
+                     │   GHCR       │         │  Helm Chart  │
+                     │  Container   │         │  Deployment  │
+                     │  Registry    │         └──────────────┘
+                     └──────────────┘
+```
+
+## Table of Contents
+
+1. [Technology Stack](#1-technology-stack)
+2. [Build & Packaging](#2-build--packaging)
+3. [Container Architecture](#3-container-architecture)
+4. [CI/CD Pipeline](#4-cicd-pipeline)
+5. [Kubernetes Deployment](#5-kubernetes-deployment)
+6. [Helm Chart Structure](#6-helm-chart-structure)
+7. [Runtime Configuration](#7-runtime-configuration)
+8. [Observability Stack](#8-observability-stack)
+9. [Dependency Management](#9-dependency-management)
+10. [Security Hardening](#10-security-hardening)
+11. [Deployment Checklist](#11-deployment-checklist)
+
+---
+
+## 1. Technology Stack
+
+| Component          | Technology                      | Purpose                                    |
+| -------------------|--------------------------------| ------------------------------------------ |
+| Language           | Rust (Edition 2024)            | High-performance, memory-safe backend      |
+| Web Framework      | Axum 0.8                       | Async HTTP server                          |
+| Database           | PostgreSQL 18 / MySQL 9        | Persistent storage via SeaORM              |
+| Container          | Docker / BuildKit              | Multi-platform builds (amd64, arm64)       |
+| Orchestration      | Kubernetes (AWS EKS)           | Container orchestration                    |
+| Package Manager    | Helm 3                         | Kubernetes resource management             |
+| Observability      | OpenTelemetry + Prometheus     | Tracing, metrics, log aggregation          |
+| Secrets            | External Secrets Operator      | AWS Secrets Manager integration           |
+| DNS                | External-DNS + cert-manager    | Automated DNS + TLS certificates          |
+| CDN/Load Balancing | AWS NLB                        | Load balancing and global distribution    |
+
+---
+
+## 2. Build & Packaging
+
+### 2.1 Multi-Platform Docker Build
+
+The project uses Docker BuildKit with cross-compilation for `amd64` and `arm64`:
+
+```dockerfile
+# Multi-stage build targeting musl-based Alpine for minimal image
+FROM blackdex/rust-musl:${TARGETARCH} AS builder
+ARG FEATURES="postgres,aws,acme"
+cargo build --release --target=${RUST_TARGET} --features "${FEATURES}"
+
+# Minimal scratch-based runtime image
+FROM scratch AS runtime
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder --chown=65534:65534 /app/${APP_NAME} /app/${APP_NAME}
+USER 65534
+```
+
+### 2.2 Feature Flags
+
+Cargo features gate production backend drivers:
+
+| Feature       | Description                                                              | Default       |
+| ------------- | ------------------------------------------------------------------------ | ------------- |
+| `memory`      | In-memory storage + Moka cache                                           | ✅ Active     |
+| `postgres`    | PostgreSQL via SeaORM                                                     | Opt-in        |
+| `mysql`       | MySQL via SeaORM                                                          | Opt-in        |
+| `sqlite`      | SQLite via SeaORM                                                         | Opt-in        |
+| `redis`       | Redis certificate cache driver                                           | Opt-in        |
+| `aws-secrets` | Route53 DNS-01 + AWS Secrets Manager (single crypto-material backend)   | Opt-in        |
+| `vault`       | Vault/OpenBao KV v2 crypto-material backend                              | Opt-in        |
+| `acme`        | ACME DNS-01 certificate provisioning                                      | Opt-in        |
+
+Production builds include: `FEATURES="postgres,aws-secrets,acme"` (or `postgres,vault,acme` to store crypto material in Vault/OpenBao).
+
+---
+
+## 3. Container Architecture
+
+### 3.1 Image Structure
+
+```
+┌─────────────────────────────────────────────────────────┐
+│              status-list-server:latest                  │
+├─────────────────────────────────────────────────────────┤
+│  Layer 1: Scratch base image                            │
+│  Layer 2: CA certificates (TLS verification)            │
+│  Layer 3: /etc/passwd (non-root user)                   │
+│  Layer 4: Application binary (UID 65534)                │
+├─────────────────────────────────────────────────────────┤
+│  User: 65534 (nobody)                                   │
+│  Entrypoint: /app/status-list-server                    │
+│  Port: 8000                                             │
+└─────────────────────────────────────────────────────────┘
+```
+
+### 3.2 Container Security
+
+- **Non-root execution**: Runs as UID 65534
+- **Minimal base**: `scratch` image contains only required artifacts
+- **Read-only filesystem**: Root filesystem is read-only
+- **No shell access**: Attack surface minimized
+
+---
+
+## 4. CI/CD Pipeline
+
+### 4.1 Pipeline Overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    GitHub Actions CI/CD                          │
+└─────────────────────────────────────────────────────────────────┘
+
+  ┌─────────┐    ┌──────────┐    ┌────────────┐    ┌──────────┐
+  │  Push   │───►│   Zizmor  │───►│   Build    │───►│ Clippy   │
+  │  PR     │    │ Security  │    │   Check    │    │ Lints    │
+  └─────────┘    └──────────┘    └────────────┘    └──────────┘
+       │                                              │
+       │                                              ▼
+       │                                    ┌────────────────┐
+       │                                    │   Nextest      │
+       │                                    │   Tests        │
+       │                                    └────────────────┘
+       │                                              │
+       ▼                                              ▼
+  ┌──────────┐    ┌─────────────┐    ┌───────┐    ┌──────────┐
+  │ Markdown │    │ Trivy Config │    │ Kube  │    │ Coverage │
+  │ Lint     │    │ Scan         │    │ Linter│    │ Report   │
+  └──────────┘    └─────────────┘    └───────┘    └──────────┘
+
+  ┌─────────────────────────────────────────────────────────────────┐
+  │                     CD Pipeline (on push to main/tag)          │
+  └─────────────────────────────────────────────────────────────────┘
+
+  ┌─────────┐    ┌──────────────┐    ┌─────────┐    ┌──────────┐
+  │  Push   │───►│    CI        │───►│ Build & │───►│  Deploy  │
+  │  main   │    │   Passes     │    │  Push   │    │  to EKS  │
+  │  Tag    │    │              │    │  GHCR   │    │          │
+  └─────────┘    └──────────────┘    └─────────┘    └──────────┘
+```
+
+### 4.2 CI Jobs
+
+| Job                  | Purpose                                           |
+| -------------------- | ------------------------------------------------- |
+| `zizmor-security`    | Workflow security scanning                        |
+| `cargo-fmt`          | Rust formatting check                             |
+| `cargo-build`        | Full workspace compilation                        |
+| `cargo-clippy`       | Linting with clippy                               |
+| `cargo-nextest`      | Parallel test execution                           |
+| `cargo-doc`          | Documentation generation                          |
+| `cargo-machete`       | Unused dependency detection                       |
+| `cargo-vet`           | Dependency vulnerability auditing                 |
+| `cargo-deny`          | License and security policy checks                |
+| `trivy-config`        | Helm chart vulnerability scanning                  |
+| `kube-linter`         | Kubernetes manifests linting                      |
+| `cargo-coverage`      | LLVM code coverage report                         |
+
+### 4.3 CD Pipeline
+
+```yaml
+# Triggered on push to main or tag (v*.*.*)
+on:
+  push:
+    branches: [main]
+    tags: [v*.*.*]
+
+# Image tagging strategy
+tags: |
+  type=semver,pattern={{version}}          # v1.2.3 → 1.2.3
+  type=raw,value=latest                     # main branch → latest
+  type=sha,format=short                     # commit SHA → sha-abc1234
+```
+
+---
+
+## 5. Kubernetes Deployment
+
+### 5.1 Architecture on EKS
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                           AWS EKS Cluster                              │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  ┌─────────────────────────────────────────────────────────────────┐   │
+│  │                    statuslist Namespace                         │   │
+│  │  ┌─────────────────────────────────────────────────────────┐   │   │
+│  │  │                 NGINX Ingress Controller                  │   │   │
+│  │  │                      (External LB)                       │   │   │
+│  │  └─────────────────────────────────────────────────────────┘   │   │
+│  │                            │                                   │   │
+│  │  ┌────────────────────────▼───────────────────────────────┐   │   │
+│  │  │              statuslist Service (ClusterIP)             │   │   │
+│  │  │                       Port: 8081                        │   │   │
+│  │  └─────────────────────────────────────────────────────────┘   │   │
+│  │                            │                                   │   │
+│  │  ┌────────────────────────▼───────────────────────────────┐   │   │
+│  │  │           statuslist Deployment (1 replica)            │   │   │
+│  │  │  ┌───────────────────┐  ┌───────────────────────────┐  │   │   │
+│  │  │  │  statuslist-server │  │  otel-collector (sidecar)│  │   │   │
+│  │  │  │   Port: 8000       │  │   Port: 4317 (gRPC)     │  │   │   │
+│  │  │  └───────────────────┘  └───────────────────────────┘  │   │   │
+│  │  └─────────────────────────────────────────────────────────┘   │   │
+│  │                            │                                   │   │
+│  │  ┌─────────────────────────┼───────────────────────────────┐  │   │
+│  │  │                         │                               │  │   │
+│  │  ▼                         ▼                               ▼  │   │
+│  │ ┌─────────────┐    ┌─────────────┐    ┌─────────────────┐      │   │
+│  │ │ PostgreSQL  │    │   Redis HA  │    │ OTEL Collector   │      │   │
+│  │ │  (Pods)     │    │  (Pods)     │    │  (Standalone)    │      │   │
+│  │ └─────────────┘    └─────────────┘    └─────────────────┘      │   │
+│  └─────────────────────────────────────────────────────────────────┘   │
+│                                                                         │
+│  ┌─────────────────────────────────────────────────────────────────┐   │
+│  │                      Infrastructure Layer                        │   │
+│  │  ┌───────────────────────┐  ┌───────────────────────────────┐   │   │
+│  │  │  Crypto-Material Store │  │      cert-manager / ACME      │   │   │
+│  │  │  (Vault or AWS SM)     │  │  (TLS certs via Route53 DNS)  │   │   │
+│  │  └───────────────────────┘  └───────────────────────────────┘   │   │
+│  └─────────────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### 5.2 Resource Allocation
+
+| Component                | CPU Request | Memory Request | CPU Limit | Memory Limit |
+| ------------------------ | ----------- | -------------- | --------- | ------------ |
+| status-list-server       | 250m        | 256Mi          | 500m      | 512Mi        |
+| PostgreSQL                | 250m        | 256Mi          | 500m      | 512Mi        |
+| Redis HA                 | 100m        | 200Mi          | 500m      | 700Mi        |
+| HAProxy (Redis)          | 100m        | 128Mi          | 200m      | 256Mi        |
+| OTEL Collector (sidecar) | 50m         | 64Mi           | 100m      | 128Mi        |
+
+---
+
+## 6. Helm Chart Structure
+
+```
+helm/chart/
+├── Chart.yaml              # Chart metadata and dependencies
+├── values.yaml             # Production default values
+├── values-local.yaml       # Local development values
+├── templates/
+│   ├── deployment.yaml     # Application deployment
+│   ├── service.yaml        # ClusterIP service
+│   ├── serviceaccount.yaml # Workload Identity / IRSA service account
+│   ├── ingress.yaml        # NGINX ingress with TLS
+│   ├── network-policy.yaml # Kubernetes network policies
+│   ├── external-secrets.yaml   # ESO ExternalSecret integration
+│   ├── secret-store.yaml       # Provider-neutral SecretStore configuration
+│   ├── secret.yaml             # Fallback Kubernetes Secret (non-ESO clusters)
+│   ├── redis-ha-cert-sync.yaml # Redis TLS certificate sync
+│   └── otel-collector-*.yaml   # OpenTelemetry collector configs
+└── README.md               # Deployment documentation
+```
+
+### 6.1 Chart Dependencies
+
+| Dependency       | Version | Repository                        | Purpose                        |
+| ---------------- | ------- | --------------------------------- | ------------------------------ |
+| PostgreSQL       | 0.8.2   | `oci://registry-1.docker.io/cloudpirates` | Database storage   |
+| Redis HA         | 4.35.0  | `https://dandydeveloper.github.io/charts` | Certificate cache (optional) |
+
+### 6.2 Key Values
+
+```yaml
+# Image configuration
+statuslist:
+  image:
+    repository: ghcr.io/adorsys/status-list-server
+    tag: "latest"  # Overridden by CD pipeline
+    pullPolicy: Always
+
+# Service configuration
+  service:
+    type: ClusterIP
+    port: 8081
+    targetPort: 8000
+
+# Ingress with TLS
+  ingress:
+    enabled: true
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+      nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    tls:
+      hosts:
+        - "*.eudi-adorsys.com"
+      secretName: statuslist-tls
+    externalDnsHostname: statuslist.eudi-adorsys.com
+```
+
+---
+
+## 7. Runtime Configuration
+
+### 7.1 Environment Variables
+
+| Variable                           | Default         | Description                                 |
+| ---------------------------------- | --------------- | ------------------------------------------ |
+| `APP_ENV`                          | `development`   | Runtime environment                        |
+| `APP_SERVER__PORT`                 | `8000`          | Server port                                |
+| `APP_DATABASE__BACKEND`            | `postgres`      | Database driver                            |
+| `APP_STATUS_LIST__TOKEN_EXP_SECS`  | `900`           | Status list expiration (15 min)            |
+| `APP_STATUS_LIST__TOKEN_TTL_SECS`  | `300`           | Status list TTL (5 min)                    |
+| `APP_CACHE__TTL`                   | `300`           | Status list cache TTL                      |
+| `APP_RATE_LIMIT__*`                | Various         | Rate limiting configuration                |
+| `APP_LIMITS__MAX_BODY_SIZE_BYTES`  | `2097152`       | Max request body (2 MiB)                   |
+| `APP_SERVER__CERT__ACME_*`          | —               | ACME certificate provisioning              |
+| `APP_TELEMETRY__ENABLED`           | `true`          | OpenTelemetry export                       |
+| `APP_TELEMETRY__OTLP_ENDPOINT`     | `localhost:4317` | OTLP gRPC endpoint                         |
+
+### 7.2 DNS Providers for ACME
+
+| Provider   | Environment Variable Prefix                      |
+| ---------- | ------------------------------------------------ |
+| AWS Route53 | `APP_SERVER__CERT__DNS__ROUTE53__*`             |
+| Cloudflare | `APP_SERVER__CERT__DNS__CLOUDFLARE__*`          |
+| Google Cloud DNS | `APP_SERVER__CERT__DNS__GCLOUD__*`           |
+| Azure DNS   | `APP_SERVER__CERT__DNS__AZURE__*`               |
+| ACME-DNS    | `APP_SERVER__CERT__DNS__ACMEDNS__*`             |
+
+---
+
+## 8. Observability Stack
+
+### 8.1 Data Flow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                      Observability Architecture                  │
+└─────────────────────────────────────────────────────────────────┘
+
+   ┌──────────────────┐         ┌──────────────────┐
+   │ statuslist-server│         │   Application    │
+   │                  │         │    Logs          │
+   └────────┬─────────┘         └────────┬─────────┘
+            │                          │
+            ▼                          ▼
+   ┌──────────────────┐         ┌──────────────────┐
+   │   Prometheus     │         │  Structured      │
+   │   Metrics        │         │  JSON Logs       │
+   │   (:8000/metrics)│         │  (stdout)        │
+   └────────┬─────────┘         └────────┬─────────┘
+            │                          │
+            ▼                          │
+   ┌──────────────────┐                │
+   │ OTEL Collector   │◄────────────────┘
+   │ (sidecar/        │
+   │  standalone)     │
+   └────────┬─────────┘
+            │
+    ┌───────┼───────┐
+    ▼       ▼       ▼
+┌───────┐ ┌──────┐ ┌────────┐
+│Traces │ │Metrics│ │ Logs   │
+│(OTLP) │ │(OTLP)│ │(OTLP)  │
+└───┬───┘ └──┬───┘ └───┬────┘
+    ▼       ▼         ▼
+┌────────────────────────────────┐
+│      Backend                   │
+│  ┌────────┐ ┌────────┐         │
+│  │ Jaeger │ │Tempo/  │         │
+│  │        │ │Loki    │         │
+│  └────────┘ └────────┘         │
+└────────────────────────────────┘
+```
+
+### 8.2 Local Observability Setup
+
+When running with Docker Compose:
+
+| Service              | URL                       |
+| -------------------- | ------------------------- |
+| Status List Server   | `http://localhost:8000`    |
+| Prometheus UI        | `http://localhost:9090`   |
+| Jaeger UI            | `http://localhost:16686`  |
+| Metrics endpoint     | `http://localhost:8000/metrics` |
+
+---
+
+## 9. Dependency Management
+
+### 9.1 Secrets Management
+
+Secrets are delivered to the application through **External Secrets Operator (ESO)**. The chart renders:
+
+- A `SecretStore` (`secret-store.yaml`) that is **provider-neutral** — `secretStore.provider` selects between `aws` (Secrets Manager / Parameter Store), `vault` (Vault / OpenBao), `gcp` (Secret Manager), `azure` (Key Vault), or `raw` (full provider passthrough for unsupported ESO providers).
+- An `ExternalSecret` (`external-secrets.yaml`, gated on `externalSecret.enabled`) that syncs the `postgres-password` and `redis-password` keys into the `statuslist-secret` Kubernetes Secret.
+- A **fallback Kubernetes `Secret`** (`secret.yaml`) for clusters that do not run ESO, rendered only when `externalSecret.enabled=false` and `statuslist.fallbackSecret.enabled=true`.
+
+**Workload Identity / IRSA:** the application pod uses a dedicated `ServiceAccount` (`serviceAccount.create=true`). AWS/GCP/Azure ambient credentials are attached via `serviceAccount.annotations` (e.g. `eks.amazonaws.com/role-arn` for EKS IRSA). The chart defaults to Workload Identity mode — no static AWS credentials are mounted into the pod (`statuslist.aws.mountCredentials=false`). Legacy deployments that still use a mounted `aws-credentials-secret` must set `statuslist.aws.mountCredentials=true` until Workload Identity is configured.
+
+### 9.2 Redis HA Integration (Optional)
+
+Redis is **optional** for production deployments.
+
+| Deployment Type | Redis Required | Purpose                        |
+| --------------- | -------------- | ------------------------------ |
+| Single replica  | ❌ No          | Moka in-process cache sufficient |
+| Multi-replica   | ⚠️ Optional    | Shared certificate cache        |
+| AWS S3 cert path | ⚠️ Optional    | Distributed cert cache entry sharing |
+
+### 9.3 Database Selection
+
+| Use Case                     | Recommended Backend |
+| ---------------------------- | ------------------- |
+| Production HA                | PostgreSQL          |
+| MySQL-compatible infra       | MySQL               |
+| Single-node / Development    | SQLite              |
+| Distributed production        | PostgreSQL / MySQL   |
+
+---
+
+## 10. Security Hardening
+
+### 10.1 Kubernetes Security Context
+
+```yaml
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 65534
+  runAsGroup: 65534
+  fsGroup: 65534
+  seccompProfile:
+    type: RuntimeDefault
+
+# Container-level
+readOnlyRootFilesystem: true
+allowPrivilegeEscalation: false
+capabilities:
+  drop: ["ALL"]
+```
+
+### 10.2 Network Policies
+
+```yaml
+# Ingress: Allow anywhere (no IP restrictions)
+ingress: []
+
+# Egress: PostgreSQL (5432), Redis (6379/6380), DNS (53), HTTPS (443), OTLP (4317/4318)
+egress:
+  - ports: [5432, 6379, 6380, 443, 53, 4317, 4318]
+```
+
+### 10.3 Rate Limiting
+
+| Tier       | Burst | Period | Routes                           |
+| ---------- | ----- | ------ | -------------------------------- |
+| Strict     | 10    | 60s    | `POST /api/v1/credentials`       |
+| Writes     | 10    | 60s    | `PUT/PATCH /status-lists/*`      |
+| Permissive | 100   | 60s    | `GET /status-lists/*`, aggregation |
+
+### 10.4 Request Bounds
+
+| Bound                     | Value      | Response Code     |
+| ------------------------- | ---------- | ----------------- |
+| `max_body_size_bytes`     | 2 MiB      | `413`             |
+| `max_status_index`        | 100,000    | `400`             |
+| `max_statuses_per_request`| 5,000      | `400`             |
+| `max_serialized_list_size`| 1 MiB      | `422`             |
+
+---
+
+## 11. Deployment Checklist
+
+### Pre-Deployment
+
+- [ ] Configure AWS credentials in GitHub Secrets
+- [ ] Verify Helm dependencies are up to date
+- [ ] Validate `values.yaml` for production environment
+- [ ] Confirm database credentials in AWS Secrets Manager
+- [ ] Verify DNS provider credentials for ACME
+
+### Infrastructure Setup
+
+- [ ] Create `statuslist` namespace
+- [ ] Configure `high-performance` StorageClass (or adjust)
+- [ ] Set up cert-manager ClusterIssuer for Let's Encrypt
+- [ ] Configure External-DNS with DNS provider
+- [ ] Create TLS secrets for Redis HAProxy (if using Redis)
+
+### Application Deployment
+
+- [ ] Deploy PostgreSQL: `helm install statuslist-postgres ./chart`
+- [ ] Deploy Redis HA (optional): `redis-ha.enabled=true`
+- [ ] Deploy application: `helm install statuslist ./chart -f chart/values.yaml`
+- [ ] Verify pods are running: `kubectl get pods -n statuslist`
+- [ ] Check application logs: `kubectl logs -l app.kubernetes.io/name=status-list-server -n statuslist`
+
+### Post-Deployment Verification
+
+- [ ] Access application at configured domain
+- [ ] Verify TLS certificate provisioning
+- [ ] Check OpenTelemetry traces in Jaeger
+- [ ] Verify Prometheus metrics endpoint
+- [ ] Test API endpoints (health, credentials, status lists)
+- [ ] Validate network policies are enforced
+
+### Monitoring Setup
+
+- [ ] Configure Grafana dashboards (if applicable)
+- [ ] Set up alerting rules for:
+  - [ ] Pod restarts
+  - [ ] High error rates
+  - [ ] Certificate expiration
+  - [ ] Database connectivity
+- [ ] Verify log aggregation
+
+---
+
+## Appendix: API Endpoints
+
+| Method | Endpoint                              | Auth | Description                         |
+| ------ | ------------------------------------- | ---- | ----------------------------------- |
+| GET    | `/api/v1/status-lists/{id}`           | No   | Retrieve status list (JWT/CWT)       |
+| GET    | `/api/v1/aggregation`                 | No   | List all status list URIs            |
+| POST   | `/api/v1/credentials`                 | No   | Register issuer credentials          |
+| PUT    | `/api/v1/status-lists/{id}/statuses`   | JWT  | Publish full status list             |
+| PATCH  | `/api/v1/status-lists/{id}/statuses`   | JWT  | Partial status update               |
+| GET    | `/health`                             | No   | Health check endpoint               |
+| GET    | `/metrics`                            | No   | Prometheus metrics                  |
+
+---
+
+## Appendix: Error Codes
+
+| Code | Meaning                                      |
+| ---- | -------------------------------------------- |
+| 400  | Invalid request / bound exceeded             |
+| 401  | Missing or invalid Bearer token              |
+| 403  | Issuer does not own the list                 |
+| 404  | Status list not found                        |
+| 406  | Unsupported Accept header                   |
+| 409  | Resource already exists / concurrent update |
+| 413  | Request body too large                      |
+| 422  | Serialized list too large / unparsable JWK  |
+| 429  | Rate limit quota exhausted                   |
+| 500  | Internal server error                        |
+| 503  | Service unavailable                          |
+
+---
+
+## Further Reading
+
+- [Hexagonal Architecture Documentation](docs/hexagonal-architecture.md)
+- [Database Backend Guidance](docs/database-backends.md)
+- [Observability Guide](docs/observability.md)
+- [DNS Provider Setup](docs/dns-providers.md)
+- [Redis TLS Setup](docs/REDIS_TLS_SETUP.md)
+- [Helm Deployment Guide](helm/README.md)

--- a/docs/secrets-backends.md
+++ b/docs/secrets-backends.md
@@ -14,9 +14,14 @@ Backend selection is controlled by enabled Cargo features. Builds with `vault` u
 
 Both HashiCorp Vault and OpenBao share the KV v2 REST API interface and are supported natively when the `vault` feature flag is enabled.
 
-Authentication is strictly performed via **AppRole**, which is the industry standard machine-to-machine authentication mechanism for production deployments.
+The server supports two authentication methods:
 
-### Configuration Variables
+- **AppRole**: Industry-standard machine-to-machine auth using `role_id`/`secret_id` credentials.
+- **Kubernetes ServiceAccount**: No static credentials required — uses the projected ServiceAccount token.
+
+### AppRole Authentication
+
+#### Configuration Variables
 
 | Variable                       | Type              | Default                             | Description                                                              |
 | ------------------------------ | ----------------- | ----------------------------------- | ------------------------------------------------------------------------ |
@@ -28,7 +33,7 @@ Authentication is strictly performed via **AppRole**, which is the industry stan
 | `APP_VAULT__MOUNT`             | String            | `"secret"`                          | KV v2 secrets engine mount point                                         |
 | `APP_VAULT__PATH_PREFIX`       | String            | `""`                                | Optional prefix prepended to all secret keys (e.g. `status-list-server`) |
 | `APP_VAULT__NAMESPACE`         | String            | `None`                              | Optional Enterprise/OpenBao namespace header (`X-Vault-Namespace`)       |
-| `APP_VAULT__SECRETS_CACHE_TTL` | Integer (seconds) | `300` (5 minutes)                   | In-memory cache TTL in seconds. Set to `0` to disable caching.           |
+| `APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL` | Integer (seconds) | `0`                | In-memory cache TTL (seconds) for private signing-key reads. Set to `0` to disable caching. |
 | `APP_VAULT__TIMEOUT_SECS`      | Integer (seconds) | `30`                                | HTTP request timeout duration in seconds                                 |
 
 ### Least-Privilege Vault / OpenBao Policy
@@ -128,19 +133,85 @@ APP_VAULT__MOUNT=secret
 APP_VAULT__PATH_PREFIX=dev/status-list
 ```
 
-### Example 2: Production Deployment with OpenBao / Vault
+### Example 2: Production Deployment with OpenBao / Vault (AppRole)
 
-In Kubernetes or ECS, inject the `role_id` and `secret_id` via Kubernetes Secrets or IAM-bound orchestration:
+In Kubernetes, deliver the `role_id` and `secret_id` via Kubernetes Secrets or the ESO Vault provider:
 
 ```env
 APP_VAULT__ADDR=http://openbao-service.openbao.svc.cluster.local:8200
 APP_VAULT__AUTH_MOUNT=approle
 APP_VAULT__ROLE_ID=ba0a1234-5678-90ab-cdef-1234567890ab
-APP_VAULT__SECRET_ID=fe987654-3210-fedc-ba09-876543210fed
+APP_VAULT__SECRET_ID_PATH=/var/run/secrets/vault/secret_id
 APP_VAULT__MOUNT=secret
 APP_VAULT__PATH_PREFIX=production/status-list
 APP_VAULT__NAMESPACE=my-org-namespace
 ```
+
+### Vault Kubernetes Auth (No Static Credentials)
+
+Use Kubernetes ServiceAccount token projection to authenticate with Vault without AppRole `role_id`/`secret_id` secrets. The service account must be bound to a Vault Kubernetes auth role.
+
+**Key difference from AppRole:** No `APP_VAULT__ROLE_ID` or `APP_VAULT__SECRET_ID` required. The app uses the projected Kubernetes ServiceAccount token automatically mounted at `TOKEN_PATH`.
+
+#### Configuration Variables
+
+| Variable                    | Type   | Default                                  | Description                                              |
+|-----------------------------|--------|------------------------------------------|----------------------------------------------------------|
+| `APP_VAULT__ADDR`           | String | `http://127.0.0.1:8200`                 | Vault server URL                                          |
+| `APP_VAULT__AUTH_MOUNT`     | String | `"kubernetes"`                          | Mount path for Kubernetes auth                            |
+| `APP_VAULT__TOKEN_PATH`     | Path   | `/var/run/secrets/tokens/vaulttoken`    | Path to projected ServiceAccount token                   |
+| `APP_VAULT__MOUNT`          | String | `"secret"`                              | KV v2 mount                                              |
+| `APP_VAULT__PATH_PREFIX`    | String | `""`                                    | Optional prefix for secret paths                         |
+| `APP_VAULT__NAMESPACE`      | String | `None`                                  | Optional Vault namespace header                          |
+| `APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL` | Integer | `0`                    | In-memory cache TTL (seconds) for private signing-key reads. Set to `0` to disable caching. |
+
+#### Server-Side Vault Setup
+
+1. **Enable Kubernetes auth:**
+
+   ```bash
+   vault auth enable kubernetes
+   ```
+
+2. **Configure the Kubernetes auth method:**
+
+   ```bash
+   vault write auth/kubernetes/config \
+     token_reViewer_jwt="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+     kubernetes_host="https://$KUBERNETES_PORT_443_TCP_ADDR:443" \
+     kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+   ```
+
+3. **Create the Vault policy** (see [Least-Privilege Vault / OpenBao Policy](#least-privilege-vault--openbao-policy)).
+
+4. **Create the Kubernetes auth role:**
+
+   ```bash
+   vault write auth/kubernetes/role/statuslist-role \
+     bound_service_account_names=statuslist-sa \
+     bound_service_account_namespaces=statuslist \
+     policies=statuslist-policy \
+     token_ttl=1h \
+     token_max_ttl=4h
+   ```
+
+   Replace `statuslist-sa` and `statuslist` with your actual ServiceAccount name and namespace.
+
+5. **Create the ServiceAccount** in Kubernetes with your platform's Workload Identity annotations (see [docs/workload-identity.md](workload-identity.md)).
+
+#### Example: Vault K8s Auth Environment Variables
+
+```env
+APP_VAULT__ADDR=http://vault.openbao.svc.cluster.local:8200
+APP_VAULT__AUTH_MOUNT=kubernetes
+APP_VAULT__TOKEN_PATH=/var/run/secrets/tokens/vaulttoken
+APP_VAULT__MOUNT=secret
+APP_VAULT__PATH_PREFIX=production/status-list
+# Private signing-key cache TTL (seconds); 0 disables caching
+APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL=0
+```
+
+See [docs/workload-identity.md](workload-identity.md#vault-kubernetes-auth) for the full Helm deployment guide using `values-vault-k8s.yaml`.
 
 ### Automated Token Lifecycle & Resilience
 
@@ -148,7 +219,7 @@ The server features an enterprise-grade automated token manager:
 
 - **Initial Login**: Exchanged via `POST /v1/auth/{auth_mount}/login` at application startup.
 - **Proactive Renewal**: Tokens are automatically renewed via `POST /v1/auth/token/renew-self` when 80% of their lease TTL has elapsed.
-- **Re-authentication Fallback**: If renewal fails (e.g. token expired or revoked), the client seamlessly re-authenticates using the AppRole credentials.
+- **Re-authentication Fallback**: If renewal fails (e.g. token expired or revoked), the client seamlessly re-authenticates using the configured credentials (AppRole or K8s token).
 
 ### Observability & Metrics
 
@@ -160,9 +231,77 @@ Vault authentication and token operations emit OpenTelemetry counters for succes
 - Signing-key material reads are controlled consistently across backends by `APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL`.
 - To require every private-key read to query the selected material backend, keep `APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL=0`.
 
+## Authentication & Secrets Delivery Decision Tree
+
+Choose the combination of **application authentication** and **secrets delivery** that matches your infrastructure:
+
+```
+Start: What is your secrets backend?
+│
+├─► AWS Secrets Manager
+│   │
+│   └─► What is your Kubernetes platform?
+│       ├─► AWS EKS
+│       │   └─► Use: AWS IRSA
+│       │         (Workload Identity: no static creds)
+│       │         Chart: values-aws-irsa.yaml
+│       │         Doc: docs/workload-identity.md
+│       │
+│       └─► Other EKS-compat (Fargate, etc.)
+│           └─► Use: AWS IRSA with Fargate profile
+│
+├─► HashiCorp Vault / OpenBao
+│   │
+│   └─► What authentication method?
+│       ├─► Kubernetes ServiceAccount (IRSA/GKE WI/Azure WIF available)
+│       │   └─► Use: Vault Kubernetes Auth
+│       │         (No role_id/secret_id needed)
+│       │         Chart: values-vault-k8s.yaml
+│       │         Doc: docs/workload-identity.md
+│       │
+│       └─► AppRole credentials exist in K8s Secrets
+│           └─► Use: Vault AppRole + K8s volume mount
+│                 (Delivered via ESO or static secret)
+│                 Doc: This doc (AppRole section above)
+│
+├─► GCP Secret Manager
+│   └─► Use: GKE Workload Identity
+│         Chart: values-gke-wi.yaml
+│         Doc: docs/workload-identity.md
+│
+└─► Azure Key Vault
+    └─► Use: AKS Workload Identity Federation
+          Chart: values-aks-wif.yaml
+          Doc: docs/workload-identity.md
+```
+
+### Decision Matrix
+
+| Secrets Backend             | Cloud/Platform      | Auth Method               | ESO Provider | Static Creds? |
+|-----------------------------|---------------------|---------------------------|--------------|--------------|
+| AWS Secrets Manager         | AWS EKS             | IRSA                      | `aws`        | No           |
+| AWS Secrets Manager         | Any K8s             | ESO + mounted credentials  | `aws`        | Yes (legacy) |
+| Vault / OpenBao KV          | Any                 | AppRole (file/Vault Agent) | `vault`      | Yes (legacy) |
+| Vault / OpenBao KV          | EKS / GKE / AKS     | Vault K8s Auth            | `vault`      | No           |
+| GCP Secret Manager          | GKE                 | GKE Workload Identity     | `gcp`        | No           |
+| Azure Key Vault             | AKS                 | AKS Workload Identity Fed. | `azure`     | No           |
+
+**Key terminology:**
+
+- **Application Vault auth**: How the *application binary* authenticates to Vault to read/write secrets. Two modes: `approle` (uses `role_id`/`secret_id`) or `kubernetes` (uses projected ServiceAccount token, no static secrets).
+- **ESO SecretStore provider**: How the *External Secrets Operator* synchronizes secrets from the external backend into Kubernetes Secrets. Independent of how the app authenticates to Vault.
+
+These are independent concerns:
+
+- You can use Vault K8s auth for the app + ESO `vault` provider for secret sync.
+- You can use AWS IRSA for the app + ESO `aws` provider for secret sync.
+- The app never needs to know which ESO provider in use.
+
+For the complete Workload Identity setup guide covering AWS IRSA, GKE WI, AKS WIF, and Vault K8s auth, see [docs/workload-identity.md](workload-identity.md).
+
 ## AWS Secrets Manager
 
-When compiled with the `aws-secrets` feature flag:
+When compiled with the `aws-secrets` feature flag and deployed without Workload Identity:
 
 ```env
 AWS_ACCESS_KEY_ID=test
@@ -170,3 +309,5 @@ AWS_SECRET_ACCESS_KEY=test
 APP_AWS__REGION=us-east-1
 APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL=0
 ```
+
+For Workload Identity deployments (recommended), see [docs/workload-identity.md](workload-identity.md#aws-eks--iam-roles-for-service-accounts-irsa) — no static credentials needed.

--- a/docs/workload-identity.md
+++ b/docs/workload-identity.md
@@ -1,0 +1,360 @@
+# Workload Identity Deployment Guide
+
+This guide covers deploying the Status List Server using cloud-provider Workload Identity and Kubernetes-native authentication patterns — eliminating static long-lived credentials.
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [AWS EKS — IAM Roles for Service Accounts (IRSA)](#aws-eks--iam-roles-for-service-accounts-irsa)
+3. [GKE — Workload Identity](#gke--workload-identity)
+4. [AKS — Workload Identity Federation](#aks--workload-identity-federation)
+5. [Vault Kubernetes Auth](#vault-kubernetes-auth)
+6. [Checking Active Credentials](#checking-active-credentials)
+
+---
+
+## Overview
+
+Workload Identity allows Kubernetes ServiceAccounts to authenticate as cloud IAM identities (AWS IAM roles, GCP service accounts, Azure managed identities) without static access keys.
+
+| Static Credentials           | Workload Identity                         |
+|------------------------------|------------------------------------------|
+| Long-lived secrets that can leak | Short-lived tokens rotated automatically |
+| Manual rotation required     | No rotation needed                        |
+| Stored in GitHub Secrets     | No secrets to manage                      |
+| Works from any context       | Only from the assigned pod                 |
+
+The Helm chart supports Workload Identity via `serviceAccount.create` and `serviceAccount.annotations`:
+
+```yaml
+serviceAccount:
+  create: true           # Render a ServiceAccount
+  annotations: {}        # Cloud-provider role annotations
+```
+
+---
+
+## AWS EKS — IAM Roles for Service Accounts (IRSA)
+
+### Prerequisites
+
+- EKS cluster with OIDC provider configured
+- `aws` CLI with appropriate IAM permissions
+
+### 1. Verify EKS OIDC Provider
+
+```bash
+# Get the OIDC issuer URL
+aws eks describe-cluster --name my-cluster --query cluster.oidc.issuerUrl
+
+# List OIDC providers
+aws iam list-open-id-connect-providers
+```
+
+### 2. Create the IAM Role for IRSA
+
+```bash
+# Replace ACCOUNT_ID, CLUSTER_NAME, OIDC_PROVIDER, and NAMESPACE accordingly
+aws iam create-role \
+  --role-name statuslist-irsa \
+  --assume-role-policy-document file://<(cat <<'EOF'
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::ACCOUNT_ID:oidc-provider/OPENID_PROVIDER"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "OPENID_PROVIDER:sub": "system:serviceaccount:NAMESPACE:statuslist-sa"
+        }
+      }
+    }
+  ]
+}
+EOF
+)
+```
+
+### 3. Attach Required Policies
+
+The server now stores all cryptographic material (certificate chain, signing key, ACME account material) in a single backend. When compiled with `aws-secrets` (and without `vault`), that backend is AWS Secrets Manager, so the IRSA role needs Route53 (ACME DNS-01) and full Secrets Manager CRUD — S3 is no longer used at runtime:
+
+```bash
+# Inline policy for Route53 ACME DNS-01 + Secrets Manager (single crypto-material backend)
+cat > /tmp/irsa-policy.json <<'EOF'
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["route53:ChangeResourceRecordSets", "route53:ListResourceRecordSets"],
+      "Resource": "arn:aws:route53:::hostedzone/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "route53:GetChange",
+      "Resource": "arn:aws:route53:::change/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:DescribeSecret",
+        "secretsmanager:CreateSecret",
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:PutSecretValue",
+        "secretsmanager:DeleteSecret"
+      ],
+      "Resource": "arn:aws:secretsmanager:REGION:ACCOUNT_ID:secret:statuslist/*"
+    }
+  ]
+}
+EOF
+
+aws iam put-role-policy \
+  --role-name statuslist-irsa \
+  --policy-name statuslist-route53 \
+  --policy-document file:///tmp/irsa-policy.json
+```
+
+> **Note:** If the server is compiled with the `vault` feature, cryptographic material is stored in Vault/OpenBao instead, and the pod may not need Secrets Manager permissions at all (Route53 for ACME remains unless you mount a static DNS credential).
+
+### 4. Deploy with Helm
+
+```bash
+helm install statuslist ./chart \
+  --namespace statuslist \
+  -f chart/values.yaml \
+  -f chart/values-aws-irsa.yaml
+```
+
+**Expected service account annotation:**
+
+```yaml
+serviceAccount:
+  create: true
+  name: statuslist-sa
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/statuslist-irsa
+```
+
+---
+
+## GKE — Workload Identity
+
+### Prerequisites
+
+- GKE cluster with Workload Identity enabled
+- `gcloud` CLI configured
+
+### 1. Create the GCP Service Account
+
+```bash
+gcloud iam service-accounts create statuslist-sa \
+  --display-name="Status List Server" \
+  --project=PROJECT_ID
+
+SA_EMAIL=statuslist-sa@PROJECT_ID.iam.gserviceaccount.com
+
+# Grant permissions for Secret Manager + Cloud DNS
+gcloud projects add-iam-policy-binding PROJECT_ID \
+  --member="serviceAccount:$SA_EMAIL" \
+  --role="roles/secretmanager.secretAccessor"
+
+gcloud projects add-iam-policy-binding PROJECT_ID \
+  --member="serviceAccount:$SA_EMAIL" \
+  --role="roles/dns.admin"
+```
+
+### 2. Bind the Kubernetes ServiceAccount to the GCP ServiceAccount
+
+```bash
+gcloud iam service-accounts add-iam-policy-binding $SA_EMAIL \
+  --member="serviceAccount:PROJECT.svc.id.goog[statuslist/statuslist-sa]" \
+  --role="roles/iam.workloadIdentityUser"
+```
+
+### 3. Deploy with Helm
+
+```bash
+helm install statuslist ./chart \
+  --namespace statuslist \
+  -f chart/values.yaml \
+  -f chart/values-gke-wi.yaml
+```
+
+**Expected service account annotation:**
+
+```yaml
+serviceAccount:
+  create: true
+  name: statuslist-sa
+  annotations:
+    iam.gke.io/gcp-service-account: statuslist-sa@PROJECT_ID.iam.gserviceaccount.com
+```
+
+---
+
+## AKS — Workload Identity Federation
+
+### Prerequisites
+
+- AKS cluster with Azure AD Workload Identity enabled
+- `az` CLI configured
+
+### 1. Create Azure Managed Identity
+
+```bash
+az identity create \
+  --name statuslist-mi \
+  --resource-group RESOURCE_GROUP \
+  --location northeurope
+
+MI_CLIENT_ID=$(az identity show \
+  --name statuslist-mi \
+  --resource-group RESOURCE_GROUP \
+  --query clientId -o tsv)
+
+MI_OBJ_ID=$(az identity show \
+  --name statuslist-mi \
+  --resource-group RESOURCE_GROUP \
+  --query principalId -o tsv)
+
+# Grant Key Vault access
+az keyvault set-policy \
+  --name KEY_VAULT_NAME \
+  --spn $MI_CLIENT_ID \
+  --secret-permissions get list
+```
+
+### 2. Create Federated Identity Credential
+
+```bash
+# Get the OIDC issuer URL from AKS
+OIDC_ISSUER=$(az aks show \
+  --name AKS_CLUSTER_NAME \
+  --resource-group RESOURCE_GROUP \
+  --query oidcIssuerProfile.issuerUrl -o tsv)
+
+az identity federated-credential create \
+  --name statuslist-federated \
+  --identity-name statuslist-mi \
+  --resource-group RESOURCE_GROUP \
+  --issuer $OIDC_ISSUER \
+  --subject "system:serviceaccount:statuslist:statuslist-sa"
+```
+
+### 3. Deploy with Helm
+
+```bash
+helm install statuslist ./chart \
+  --namespace statuslist \
+  -f chart/values.yaml \
+  -f chart/values-aks-wif.yaml
+```
+
+**Expected service account annotations:**
+
+```yaml
+serviceAccount:
+  create: true
+  name: statuslist-sa
+  annotations:
+    azure.workload.identity/client-id: <managed-identity-client-id>
+    azure.workload.identity/tenant-id: <azure-tenant-id>
+```
+
+---
+
+## Vault Kubernetes Auth
+
+The server can authenticate to Vault using the Kubernetes ServiceAccount token projected into each pod by the Kubernetes API server — no `role_id`/`secret_id` secrets required.
+
+### The TOKEN_PATH Pattern
+
+```
+/var/run/secrets/kubernetes.io/serviceaccount/token  ← K8s projected SA token
+```
+
+Set `APP_VAULT__AUTH_MOUNT=kubernetes` and `APP_VAULT__TOKEN_PATH=/var/run/secrets/tokens/vaulttoken` (adjust the path to match your CSI driver or Vault Agent projection location).
+
+### Server-Side Setup
+
+1. **Enable and configure Kubernetes auth** — see [docs/secrets-backends.md](secrets-backends.md#vault-kubernetes-auth-no-static-credentials).
+
+2. **Deploy with Helm** using `values-vault-k8s.yaml`:
+
+```bash
+helm install statuslist ./chart \
+  --namespace statuslist \
+  -f chart/values.yaml \
+  -f chart/values-vault-k8s.yaml
+```
+
+For a hybrid deployment that uses IRSA for Route53 ACME DNS challenges and Vault K8s auth for certificate storage:
+
+```bash
+helm install statuslist ./chart \
+  --namespace statuslist \
+  -f chart/values.yaml \
+  -f chart/values-aws-irsa.yaml \
+  -f chart/values-vault-k8s.yaml
+```
+
+---
+
+## Checking Active Credentials
+
+Verify Workload Identity is working before deploying the full application:
+
+### AWS IRSA
+
+```bash
+kubectl run creds-check --rm -it --image=amazon/aws-cli -- \
+  aws sts get-caller-identity
+```
+
+Expected output shows the IRSA role ARN, not a user ARN.
+
+### GCP WI
+
+```bash
+kubectl run creds-check --rm -it --image=gcr.io/google.com/cloudsdktool/cloud-sdk:slim -- \
+  sh -c "gcloud auth application-default login"
+```
+
+### Verify ServiceAccount Annotations
+
+```bash
+# Check the pod uses the correct ServiceAccount
+kubectl get pod -l app.kubernetes.io/name=status-list-server \
+  -o jsonpath='{.items[*].spec.serviceAccountName}'
+
+# Verify IRSA annotation
+kubectl get sa statuslist-sa \
+  -o jsonpath='{.metadata.annotations.eks\.amazonaws\.com/role-arn}'
+```
+
+If the SA annotation matches the IAM role ARN, the cloud SDK in the container automatically uses the Workload Identity credentials — no code or configuration changes needed in the application.
+
+### Vault K8s Auth
+
+```bash
+# Check the mounted token exists
+kubectl exec deploy/statuslist-server -- cat /var/run/secrets/tokens/vaulttoken | head -c 100
+
+# Verify the app can reach Vault
+kubectl exec deploy/statuslist-server -- \
+  wget -qO- http://vault.openbao.svc.cluster.local:8200/v1/sys/health 2>/dev/null || echo "Vault unreachable"
+```
+
+---
+
+## Further Reading
+
+- [Secrets Backends Guide](secrets-backends.md) — AppRole vs K8s auth, decision matrix
+- [Helm Deployment Guide](helm/README.md) — Quick-start by platform, rendering all variants
+- [Deployment Architecture](deployment-architecture.md) — Full topology overview


### PR DESCRIPTION
## Summary

Documentation changes for **issue #385** covering Workload Identity deployment patterns, Vault/OpenBao secrets backends, and the overall deployment architecture.

## Files changed

| File | Change |
|------|--------|
| `docs/workload-identity.md` | **New** — Workload Identity deployment guide (AWS IRSA, GKE WI, AKS WIF, Vault Kubernetes auth) |
| `docs/deployment-architecture.md` | **New** — full deployment architecture (build, CI/CD, Helm chart, observability, security) |
| `docs/secrets-backends.md` | Extended with the authentication & secrets-delivery decision tree/matrix; corrected `APP_VAULT__SECRETS_CACHE_TTL` → `APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL` |

## Notes

- Docs-only PR. No source or workflow changes.
- The blog posts (`.md`/`.html`) are intentionally not included in this PR.
- Branch is a clean, docs-only branch created from the latest `develop`.