### PR TITLE
ci: use GitHub App token for release-plz, restrict deploy to tags, and fix changelog format

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,9 @@
 name: Build and Deploy to EKS
 on:
   push:
-    branches:
-      - main
     tags:
       - v*.*.*
+  workflow_dispatch:
 env:
   IMAGE_NAME: status-list-server
   CLUSTER_NAME: datev-wallet-cluster

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -19,12 +19,19 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'adorsys' }}
+    if: ${{ github.repository == 'adorsys/status-list-server' }}
     steps:
+      - name: Generate GitHub App Token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
           persist-credentials: false
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
@@ -35,10 +42,7 @@ jobs:
         with:
           command: release
         env:
-          # A PAT/GitHub App token is required here — GITHUB_TOKEN-created tag
-          # events do not trigger other workflow runs (e.g. deploy.yml on v*.*.*)
-          # See: https://release-plz.dev/docs/github/output#workflow-not-triggered
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
   # Create a PR with the new versions and changelog, preparing the next release.
   release-plz-pr:
@@ -47,15 +51,22 @@ jobs:
       pull-requests: write
       contents: write
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'adorsys' }}
+    if: ${{ github.repository == 'adorsys/status-list-server' }}
     concurrency:
       group: release-plz-pr-${{ github.ref }}
       cancel-in-progress: false
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
           persist-credentials: false
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
@@ -66,4 +77,4 @@ jobs:
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+<!-- markdownlint-disable line-length no-bare-urls ul-style emphasis-style -->

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM builder-${TARGETARCH} AS builder
 ARG APP_NAME
 ARG TARGETPLATFORM
 ARG TARGETARCH
-ARG FEATURES="postgres,aws,acme"
+ARG FEATURES="postgres,aws-secrets,acme"
 WORKDIR /app
 
 # Set the Rust target and build the application

--- a/cliff.toml
+++ b/cliff.toml
@@ -18,7 +18,7 @@ body = """
 {%- if not version %}
 ## [unreleased]
 {% else -%}
-## [{{ version }}]({{ self::remote_url() }}/releases/tag/{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+## [{{ version }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% endif -%}
 
 {% macro commit(commit) -%}


### PR DESCRIPTION
## Summary

This PR addresses the release workflow permissions error and ensures the intended release-to-deploy lifecycle works smoothly:

1. **Deploy Workflow Trigger ([deploy.yml](file:///.github/workflows/deploy.yml))**:
   - Removed `push: branches: [main]` trigger so that pushing/merging into `main` will **not** trigger build and deployment to EKS.
   - Deployments will only trigger upon version tag creation (`v*.*.*`) and manual `workflow_dispatch`.

2. **Release-plz Authentication ([release-plz.yml](file:///.github/workflows/release-plz.yml))**:
   - Switched both `release-plz-release` and `release-plz-pr` jobs to authenticate via a GitHub App token (`actions/create-github-app-token`).
   - This resolves the organization-level restriction preventing `GITHUB_TOKEN` from opening PRs and allows tag push events to trigger downstream release workflows (`deploy.yml`).

3. **Changelog Formatting ([cliff.toml](file:///cliff.toml) & [CHANGELOG.md](file:///CHANGELOG.md))**:
   - Updated the git-cliff version header format to `## [{{ version }}] - {{ timestamp }}` (without inline URL in the heading), complying with Keep a Changelog syntax and resolving the `parse-changelog` warning (`no release note was found`).
   - Initialized `CHANGELOG.md` with standard header.

## Setup Requirements

Repository settings required for the GitHub App:
- **Repository Variable**: `RELEASE_BOT_CLIENT_ID`
- **Repository Secret**: `RELEASE_BOT_PRIVATE_KEY`

cc @Christiantyemele @Blindspot22 @martcpp