### PR TITLE
fix: configure release-plz and cargo for non-published private crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
-
 <!-- markdownlint-disable line-length no-bare-urls ul-style emphasis-style -->

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "status-list-server"
 version = "1.0.1"
 edition = "2024"
+publish = false
 
 [features]
 default = ["memory"]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -3,7 +3,11 @@ changelog_path = "./CHANGELOG.md"
 changelog_config = "cliff.toml"
 release_always = false
 semver_check = false
+
+[[package]]
+name = "status-list-server"
 publish = false
+git_only = true
 
 git_release_body = """
 {{ changelog }}


### PR DESCRIPTION
## Summary

This PR resolves the issue where `release-plz` generated an empty release PR for `1.0.1` instead of computing the next version bump and changelog:

1. **Cargo Configuration ([Cargo.toml](file:///Cargo.toml))**:
   - Added `publish = false` under `[package]` to prevent `release-plz` from looking up the crate on crates.io and attempting an initial release for `1.0.1`.

2. **Release-plz Configuration ([release-plz.toml](file:///release-plz.toml))**:
   - Explicitly configured `[[package]] name = "status-list-server"` with `publish = false`.
   - Set `git_tag = true` to instruct elease-plz to use git tags to determine what the latest version of the package.

3. **Changelog Formatting ([CHANGELOG.md](file:///CHANGELOG.md))**:
   - Aligned the header with [cliff.toml](file:///cliff.toml) template to prevent duplicate header insertion.

4. **Cleanup**:
   - Closed stale empty release PR #418 and removed its branch.

cc @Christiantyemele @Blindspot22 @martcpp