### PR TITLE
ci: clear rustflags in release-plz workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           toolchain: stable
+          rustflags: ''
       - name: Run release-plz
         uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
         with:
@@ -72,6 +73,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           toolchain: stable
+          rustflags: ''
       - name: Run release-plz
         uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
         with:


### PR DESCRIPTION
## Summary

This PR fixes the `release-plz-pr` job failure in workflow run 32379740428:

- When `git_only = true` is enabled, `release-plz` packages the previous release tag (`v1.0.1`) in a worktree to determine differences.
- `actions-rust-lang/setup-rust-toolchain` defaults to setting `RUSTFLAGS: -D warnings`.
- Under the modern compiler, packaging the historical commit from `v1.0.1` generated warnings (`unused_parens` in `src/model.rs`), which were turned into hard errors by `-D warnings` and caused `release-plz` to fail at `collect_git_only_packages`.
- Adding `rustflags: ''` to both `setup-rust-toolchain` steps resolves this issue.

cc @Christiantyemele @Blindspot22 @martcpp