### PR TITLE
chore: populate baseline changelog and configure lint ignores

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,13 @@
+{
+  "config": {
+    "MD013": false,
+    "MD022": false,
+    "MD024": false,
+    "MD032": false,
+    "MD060": { "style": "aligned" }
+  },
+  "ignores": [
+    "CHANGELOG.md",
+    "**/target"
+  ]
+}

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,7 +1,0 @@
-{
-  "MD013": false,
-  "MD022": false,
-  "MD024": false,
-  "MD032": false,
-  "MD060": { "style": "aligned" }
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 <!-- markdownlint-disable line-length no-bare-urls ul-style emphasis-style -->
+
+
+## [1.0.1] - 2026-08-20
+
+### Features
+
+- feat: created the first version of the status list server
+
+### New Contributors
+* @Hermann-Core made their first contribution
+* @Blindspot22 made their first contribution in [#339](https://github.com/adorsys/status-list-server/pull/339)
+* @martcpp made their first contribution in [#334](https://github.com/adorsys/status-list-server/pull/334)
+* @Ngha-Boris made their first contribution
+* @ndefokou made their first contribution in [#295](https://github.com/adorsys/status-list-server/pull/295)
+* @Ogenbertrand made their first contribution in [#296](https://github.com/adorsys/status-list-server/pull/296)
+* @Christiantyemele made their first contribution in [#261](https://github.com/adorsys/status-list-server/pull/261)
+* @dependabot[bot] made their first contribution
+* @Awambeng made their first contribution in [#134](https://github.com/adorsys/status-list-server/pull/134)
+* @forkimenjeckayang made their first contribution in [#129](https://github.com/adorsys/status-list-server/pull/129)
+* @IngridPuppet made their first contribution

--- a/typos.toml
+++ b/typos.toml
@@ -14,4 +14,5 @@ extend-exclude = [
   "supply-chain",
   "test_data/",
   "src/test_resources",
+  "CHANGELOG.md",
 ]


### PR DESCRIPTION
## Summary

- Populates baseline release notes for `v1.0.1` in `CHANGELOG.md` so that `release-plz` can parse previous release notes and generate changelog entries for upcoming releases (`v1.1.0`).
- Configures `.markdownlint-cli2.jsonc` with ignores for `CHANGELOG.md` and `**/target`.
- Adds `CHANGELOG.md` to `extend-exclude` in `typos.toml`.

cc @Christiantyemele @Blindspot22 @martcpp