### PR TITLE
fix(deploy): remove --create-namespace from helm deploy step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,8 +98,8 @@ jobs:
         run: |
           helm upgrade --install ${{ env.HELM_RELEASE_NAME }} helm/chart \
             --namespace ${{ env.HELM_NAMESPACE }} \
-            --atomic \
             --wait \
+            --rollback-on-failure \
             --timeout 10m \
             --set-string statuslist.image.repository=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }} \
             --set-string statuslist.image.tag=${{ needs.build-and-push.outputs.deploy_tag }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,7 +99,7 @@ jobs:
           helm upgrade --install ${{ env.HELM_RELEASE_NAME }} helm/chart \
             --namespace ${{ env.HELM_NAMESPACE }} \
             --wait \
-            --rollback-on-failure \
+            --atomic \
             --timeout 10m \
             --set-string statuslist.image.repository=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }} \
             --set-string statuslist.image.tag=${{ needs.build-and-push.outputs.deploy_tag }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,7 +98,6 @@ jobs:
         run: |
           helm upgrade --install ${{ env.HELM_RELEASE_NAME }} helm/chart \
             --namespace ${{ env.HELM_NAMESPACE }} \
-            --create-namespace \
             --atomic \
             --wait \
             --timeout 10m \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,6 +81,8 @@ jobs:
         uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.0.1
       - name: Install Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: v4.2.4
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
         with:
@@ -99,7 +101,7 @@ jobs:
           helm upgrade --install ${{ env.HELM_RELEASE_NAME }} helm/chart \
             --namespace ${{ env.HELM_NAMESPACE }} \
             --wait \
-            --atomic \
+            --rollback-on-failure \
             --timeout 10m \
             --set-string statuslist.image.repository=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }} \
             --set-string statuslist.image.tag=${{ needs.build-and-push.outputs.deploy_tag }}


### PR DESCRIPTION
Closes #443

## Summary

Fix the deploy workflow so the OIDC deploy to `statuslist-production` succeeds, addressing two issues in the `helm upgrade --install` command in `.github/workflows/deploy.yml`.

## 1. Remove `--create-namespace`

The deploy fails with `Forbidden` when Helm tries to server-side apply/patch the `statuslist-production` Namespace:

```
Error: server-side apply failed for object /statuslist-production /v1, Kind=Namespace: namespaces "statuslist-production" is forbidden: User "...github-actions-production-deploy..." cannot patch resource "namespaces" ...
```

A Namespace is a cluster-scoped resource, but the deploy role uses the namespace-scoped `AmazonEKSAdminPolicy`, which does not grant `patch` on `namespaces`. The namespace is created and owned by Terraform and already exists (`Active`), so `--create-namespace` is unnecessary.

## 2. Use `--rollback-on-failure` and pin Helm 4

Helm 4 deprecates `--atomic` in favor of `--rollback-on-failure`. Because `--rollback-on-failure` is a Helm 4-only flag, the `azure/setup-helm` step now pins `version: v4.2.4` explicitly (previously it resolved `latest` and could fall back to Helm 3.18.4, where `--rollback-on-failure` is not a valid flag). This makes the Helm version deterministic and lets us use the non-deprecated flag. Rollback-on-failure behavior is preserved via `--rollback-on-failure --wait`.

## Change

Deploy step now:

```yaml
- name: Install Helm
  uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
  with:
    version: v4.2.4
...
helm upgrade --install ${{ env.HELM_RELEASE_NAME }} helm/chart \
  --namespace ${{ env.HELM_NAMESPACE }} \
  --wait \
  --rollback-on-failure \
  --timeout 10m \
  --set-string statuslist.image.repository=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }} \
  --set-string statuslist.image.tag=${{ needs.build-and-push.outputs.deploy_tag }}
```

## Validation

- [ ] Deploy to `statuslist-production` succeeds via OIDC role without `Forbidden` on the Namespace.
