### PR TITLE
docs: generalize deployment runbook and document ESO vs Workload Identity trade-offs

### DIFF
--- a/docs/deployment-architecture.md
+++ b/docs/deployment-architecture.md
@@ -4,7 +4,7 @@
 
 The Status List Server is a Rust-based microservice deployed on AWS EKS. This document describes the complete deployment architecture from source code to running service.
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │                           DEPLOYMENT ARCHITECTURE                           │
 └─────────────────────────────────────────────────────────────────────────────┘
@@ -41,18 +41,18 @@ The Status List Server is a Rust-based microservice deployed on AWS EKS. This do
 
 ## 1. Technology Stack
 
-| Component          | Technology                      | Purpose                                    |
-| -------------------|--------------------------------| ------------------------------------------ |
-| Language           | Rust (Edition 2024)            | High-performance, memory-safe backend      |
-| Web Framework      | Axum 0.8                       | Async HTTP server                          |
-| Database           | PostgreSQL 18 / MySQL 9        | Persistent storage via SeaORM              |
-| Container          | Docker / BuildKit              | Multi-platform builds (amd64, arm64)       |
-| Orchestration      | Kubernetes (AWS EKS)           | Container orchestration                    |
-| Package Manager    | Helm 3                         | Kubernetes resource management             |
-| Observability      | OpenTelemetry + Prometheus     | Tracing, metrics, log aggregation          |
-| Secrets            | External Secrets Operator      | AWS Secrets Manager integration           |
-| DNS                | External-DNS + cert-manager    | Automated DNS + TLS certificates          |
-| CDN/Load Balancing | AWS NLB                        | Load balancing and global distribution    |
+| Component          | Technology                  | Purpose                                |
+| ------------------ | --------------------------- | -------------------------------------- |
+| Language           | Rust (Edition 2024)         | High-performance, memory-safe backend  |
+| Web Framework      | Axum 0.8                    | Async HTTP server                      |
+| Database           | PostgreSQL 18 / MySQL 9     | Persistent storage via SeaORM          |
+| Container          | Docker / BuildKit           | Multi-platform builds (amd64, arm64)   |
+| Orchestration      | Kubernetes (AWS EKS)        | Container orchestration                |
+| Package Manager    | Helm 3                      | Kubernetes resource management         |
+| Observability      | OpenTelemetry + Prometheus  | Tracing, metrics, log aggregation      |
+| Secrets            | External Secrets Operator   | AWS Secrets Manager integration        |
+| DNS                | External-DNS + cert-manager | Automated DNS + TLS certificates       |
+| CDN/Load Balancing | AWS NLB                     | Load balancing and global distribution |
 
 ---
 
@@ -79,16 +79,16 @@ USER 65534
 
 Cargo features gate production backend drivers:
 
-| Feature       | Description                                                              | Default       |
-| ------------- | ------------------------------------------------------------------------ | ------------- |
-| `memory`      | In-memory storage + Moka cache                                           | ✅ Active     |
-| `postgres`    | PostgreSQL via SeaORM                                                     | Opt-in        |
-| `mysql`       | MySQL via SeaORM                                                          | Opt-in        |
-| `sqlite`      | SQLite via SeaORM                                                         | Opt-in        |
-| `redis`       | Redis certificate cache driver                                           | Opt-in        |
-| `aws-secrets` | Route53 DNS-01 + AWS Secrets Manager (single crypto-material backend)   | Opt-in        |
-| `vault`       | Vault/OpenBao KV v2 crypto-material backend                              | Opt-in        |
-| `acme`        | ACME DNS-01 certificate provisioning                                      | Opt-in        |
+| Feature       | Description                                                           | Default   |
+| ------------- | --------------------------------------------------------------------- | --------- |
+| `memory`      | In-memory storage + Moka cache                                        | ✅ Active |
+| `postgres`    | PostgreSQL via SeaORM                                                 | Opt-in    |
+| `mysql`       | MySQL via SeaORM                                                      | Opt-in    |
+| `sqlite`      | SQLite via SeaORM                                                     | Opt-in    |
+| `redis`       | Redis certificate cache driver                                        | Opt-in    |
+| `aws-secrets` | Route53 DNS-01 + AWS Secrets Manager (single crypto-material backend) | Opt-in    |
+| `vault`       | Vault/OpenBao KV v2 crypto-material backend                           | Opt-in    |
+| `acme`        | ACME DNS-01 certificate provisioning                                  | Opt-in    |
 
 Production builds include: `FEATURES="postgres,aws-secrets,acme"` (or `postgres,vault,acme` to store crypto material in Vault/OpenBao).
 
@@ -98,7 +98,7 @@ Production builds include: `FEATURES="postgres,aws-secrets,acme"` (or `postgres,
 
 ### 3.1 Image Structure
 
-```
+```text
 ┌─────────────────────────────────────────────────────────┐
 │              status-list-server:latest                  │
 ├─────────────────────────────────────────────────────────┤
@@ -126,7 +126,7 @@ Production builds include: `FEATURES="postgres,aws-secrets,acme"` (or `postgres,
 
 ### 4.1 Pipeline Overview
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────┐
 │                    GitHub Actions CI/CD                          │
 └─────────────────────────────────────────────────────────────────┘
@@ -161,20 +161,20 @@ Production builds include: `FEATURES="postgres,aws-secrets,acme"` (or `postgres,
 
 ### 4.2 CI Jobs
 
-| Job                  | Purpose                                           |
-| -------------------- | ------------------------------------------------- |
-| `zizmor-security`    | Workflow security scanning                        |
-| `cargo-fmt`          | Rust formatting check                             |
-| `cargo-build`        | Full workspace compilation                        |
-| `cargo-clippy`       | Linting with clippy                               |
-| `cargo-nextest`      | Parallel test execution                           |
-| `cargo-doc`          | Documentation generation                          |
-| `cargo-machete`       | Unused dependency detection                       |
-| `cargo-vet`           | Dependency vulnerability auditing                 |
-| `cargo-deny`          | License and security policy checks                |
-| `trivy-config`        | Helm chart vulnerability scanning                  |
-| `kube-linter`         | Kubernetes manifests linting                      |
-| `cargo-coverage`      | LLVM code coverage report                         |
+| Job               | Purpose                            |
+| ----------------- | ---------------------------------- |
+| `zizmor-security` | Workflow security scanning         |
+| `cargo-fmt`       | Rust formatting check              |
+| `cargo-build`     | Full workspace compilation         |
+| `cargo-clippy`    | Linting with clippy                |
+| `cargo-nextest`   | Parallel test execution            |
+| `cargo-doc`       | Documentation generation           |
+| `cargo-machete`   | Unused dependency detection        |
+| `cargo-vet`       | Dependency vulnerability auditing  |
+| `cargo-deny`      | License and security policy checks |
+| `trivy-config`    | Helm chart vulnerability scanning  |
+| `kube-linter`     | Kubernetes manifests linting       |
+| `cargo-coverage`  | LLVM code coverage report          |
 
 ### 4.3 CD Pipeline
 
@@ -198,7 +198,7 @@ tags: |
 
 ### 5.1 Architecture on EKS
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────────────┐
 │                           AWS EKS Cluster                              │
 ├─────────────────────────────────────────────────────────────────────────┤
@@ -247,7 +247,7 @@ tags: |
 | Component                | CPU Request | Memory Request | CPU Limit | Memory Limit |
 | ------------------------ | ----------- | -------------- | --------- | ------------ |
 | status-list-server       | 250m        | 256Mi          | 500m      | 512Mi        |
-| PostgreSQL                | 250m        | 256Mi          | 500m      | 512Mi        |
+| PostgreSQL               | 250m        | 256Mi          | 500m      | 512Mi        |
 | OTEL Collector           | 100m        | 128Mi          | 200m      | 256Mi        |
 | OTEL Collector (sidecar) | 50m         | 64Mi           | 100m      | 128Mi        |
 
@@ -255,7 +255,7 @@ tags: |
 
 ## 6. Helm Chart Structure
 
-```
+```text
 helm/chart/
 ├── Chart.yaml              # Chart metadata and dependencies
 ├── values.yaml             # Production default values
@@ -278,9 +278,9 @@ helm/chart/
 
 ### 6.1 Chart Dependencies
 
-| Dependency       | Version | Repository                        | Purpose                        |
-| ---------------- | ------- | --------------------------------- | ------------------------------ |
-| PostgreSQL       | 0.8.2   | `oci://registry-1.docker.io/cloudpirates` | Database storage   |
+| Dependency              | Version | Repository                                                   | Purpose               |
+| ----------------------- | ------- | ------------------------------------------------------------ | --------------------- |
+| PostgreSQL              | 0.8.2   | `oci://registry-1.docker.io/cloudpirates`                    | Database storage      |
 | OpenTelemetry Collector | 0.169.0 | `https://open-telemetry.github.io/opentelemetry-helm-charts` | Metrics, traces, logs |
 
 ### 6.2 Key Values
@@ -290,16 +290,16 @@ helm/chart/
 statuslist:
   image:
     repository: ghcr.io/adorsys/status-list-server
-    tag: "latest"  # Overridden by CD pipeline
+    tag: "latest" # Overridden by CD pipeline
     pullPolicy: Always
 
-# Service configuration
+  # Service configuration
   service:
     type: ClusterIP
     port: 8081
     targetPort: 8000
 
-# Ingress with TLS
+  # Ingress with TLS
   ingress:
     enabled: true
     annotations:
@@ -318,29 +318,29 @@ statuslist:
 
 ### 7.1 Environment Variables
 
-| Variable                           | Default         | Description                                 |
-| ---------------------------------- | --------------- | ------------------------------------------ |
-| `APP_ENV`                          | `development`   | Runtime environment                        |
-| `APP_SERVER__PORT`                 | `8000`          | Server port                                |
-| `APP_DATABASE__BACKEND`            | `postgres`      | Database driver                            |
-| `APP_STATUS_LIST__TOKEN_EXP_SECS`  | `900`           | Status list expiration (15 min)            |
-| `APP_STATUS_LIST__TOKEN_TTL_SECS`  | `300`           | Status list TTL (5 min)                    |
-| `APP_CACHE__TTL`                   | `300`           | Status list cache TTL                      |
-| `APP_RATE_LIMIT__*`                | Various         | Rate limiting configuration                |
-| `APP_LIMITS__MAX_BODY_SIZE_BYTES`  | `2097152`       | Max request body (2 MiB)                   |
-| `APP_SERVER__CERT__ACME_*`          | —               | ACME certificate provisioning              |
-| `APP_TELEMETRY__ENABLED`           | `true`          | OpenTelemetry export                       |
-| `APP_TELEMETRY__OTLP_ENDPOINT`     | `localhost:4317` | OTLP gRPC endpoint                         |
+| Variable                          | Default          | Description                     |
+| --------------------------------- | ---------------- | ------------------------------- |
+| `APP_ENV`                         | `development`    | Runtime environment             |
+| `APP_SERVER__PORT`                | `8000`           | Server port                     |
+| `APP_DATABASE__BACKEND`           | `postgres`       | Database driver                 |
+| `APP_STATUS_LIST__TOKEN_EXP_SECS` | `900`            | Status list expiration (15 min) |
+| `APP_STATUS_LIST__TOKEN_TTL_SECS` | `300`            | Status list TTL (5 min)         |
+| `APP_CACHE__TTL`                  | `300`            | Status list cache TTL           |
+| `APP_RATE_LIMIT__*`               | Various          | Rate limiting configuration     |
+| `APP_LIMITS__MAX_BODY_SIZE_BYTES` | `2097152`        | Max request body (2 MiB)        |
+| `APP_SERVER__CERT__ACME_*`        | —                | ACME certificate provisioning   |
+| `APP_TELEMETRY__ENABLED`          | `true`           | OpenTelemetry export            |
+| `APP_TELEMETRY__OTLP_ENDPOINT`    | `localhost:4317` | OTLP gRPC endpoint              |
 
 ### 7.2 DNS Providers for ACME
 
-| Provider   | Environment Variable Prefix                      |
-| ---------- | ------------------------------------------------ |
-| AWS Route53 | `APP_SERVER__CERT__DNS__ROUTE53__*`             |
-| Cloudflare | `APP_SERVER__CERT__DNS__CLOUDFLARE__*`          |
-| Google Cloud DNS | `APP_SERVER__CERT__DNS__GCLOUD__*`           |
-| Azure DNS   | `APP_SERVER__CERT__DNS__AZURE__*`               |
-| ACME-DNS    | `APP_SERVER__CERT__DNS__ACMEDNS__*`             |
+| Provider         | Environment Variable Prefix            |
+| ---------------- | -------------------------------------- |
+| AWS Route53      | `APP_SERVER__CERT__DNS__ROUTE53__*`    |
+| Cloudflare       | `APP_SERVER__CERT__DNS__CLOUDFLARE__*` |
+| Google Cloud DNS | `APP_SERVER__CERT__DNS__GCLOUD__*`     |
+| Azure DNS        | `APP_SERVER__CERT__DNS__AZURE__*`      |
+| ACME-DNS         | `APP_SERVER__CERT__DNS__ACMEDNS__*`    |
 
 ---
 
@@ -348,7 +348,7 @@ statuslist:
 
 ### 8.1 Data Flow
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────┐
 │                      Observability Architecture                  │
 └─────────────────────────────────────────────────────────────────┘
@@ -392,12 +392,12 @@ statuslist:
 
 When running with Docker Compose:
 
-| Service              | URL                       |
-| -------------------- | ------------------------- |
-| Status List Server   | `http://localhost:8000`    |
-| Prometheus UI        | `http://localhost:9090`   |
-| Jaeger UI            | `http://localhost:16686`  |
-| Metrics endpoint     | `http://localhost:8000/metrics` |
+| Service            | URL                             |
+| ------------------ | ------------------------------- |
+| Status List Server | `http://localhost:8000`         |
+| Prometheus UI      | `http://localhost:9090`         |
+| Jaeger UI          | `http://localhost:16686`        |
+| Metrics endpoint   | `http://localhost:8000/metrics` |
 
 ---
 
@@ -422,12 +422,12 @@ The Helm chart no longer deploys the Redis HA subchart. Status-list reads and wr
 
 ### 9.3 Database Selection
 
-| Use Case                     | Recommended Backend |
-| ---------------------------- | ------------------- |
-| Production HA                | PostgreSQL          |
-| MySQL-compatible infra       | MySQL               |
-| Single-node / Development    | SQLite              |
-| Distributed production        | PostgreSQL / MySQL   |
+| Use Case                  | Recommended Backend |
+| ------------------------- | ------------------- |
+| Production HA             | PostgreSQL          |
+| MySQL-compatible infra    | MySQL               |
+| Single-node / Development | SQLite              |
+| Distributed production    | PostgreSQL / MySQL  |
 
 ---
 
@@ -464,20 +464,20 @@ egress:
 
 ### 10.3 Rate Limiting
 
-| Tier       | Burst | Period | Routes                           |
-| ---------- | ----- | ------ | -------------------------------- |
-| Strict     | 10    | 60s    | `POST /api/v1/credentials`       |
-| Writes     | 10    | 60s    | `PUT/PATCH /status-lists/*`      |
+| Tier       | Burst | Period | Routes                             |
+| ---------- | ----- | ------ | ---------------------------------- |
+| Strict     | 10    | 60s    | `POST /api/v1/credentials`         |
+| Writes     | 10    | 60s    | `PUT/PATCH /status-lists/*`        |
 | Permissive | 100   | 60s    | `GET /status-lists/*`, aggregation |
 
 ### 10.4 Request Bounds
 
-| Bound                     | Value      | Response Code     |
-| ------------------------- | ---------- | ----------------- |
-| `max_body_size_bytes`     | 2 MiB      | `413`             |
-| `max_status_index`        | 100,000    | `400`             |
-| `max_statuses_per_request`| 5,000      | `400`             |
-| `max_serialized_list_size`| 1 MiB      | `422`             |
+| Bound                      | Value   | Response Code |
+| -------------------------- | ------- | ------------- |
+| `max_body_size_bytes`      | 2 MiB   | `413`         |
+| `max_status_index`         | 100,000 | `400`         |
+| `max_statuses_per_request` | 5,000   | `400`         |
+| `max_serialized_list_size` | 1 MiB   | `422`         |
 
 ---
 
@@ -530,33 +530,33 @@ egress:
 
 ## Appendix: API Endpoints
 
-| Method | Endpoint                              | Auth | Description                         |
-| ------ | ------------------------------------- | ---- | ----------------------------------- |
-| GET    | `/api/v1/status-lists/{id}`           | No   | Retrieve status list (JWT/CWT)       |
-| GET    | `/api/v1/aggregation`                 | No   | List all status list URIs            |
-| POST   | `/api/v1/credentials`                 | No   | Register issuer credentials          |
-| PUT    | `/api/v1/status-lists/{id}/statuses`   | JWT  | Publish full status list             |
-| PATCH  | `/api/v1/status-lists/{id}/statuses`   | JWT  | Partial status update               |
-| GET    | `/health`                             | No   | Health check endpoint               |
-| GET    | `/metrics`                            | No   | Prometheus metrics                  |
+| Method | Endpoint                             | Auth | Description                    |
+| ------ | ------------------------------------ | ---- | ------------------------------ |
+| GET    | `/api/v1/status-lists/{id}`          | No   | Retrieve status list (JWT/CWT) |
+| GET    | `/api/v1/aggregation`                | No   | List all status list URIs      |
+| POST   | `/api/v1/credentials`                | No   | Register issuer credentials    |
+| PUT    | `/api/v1/status-lists/{id}/statuses` | JWT  | Publish full status list       |
+| PATCH  | `/api/v1/status-lists/{id}/statuses` | JWT  | Partial status update          |
+| GET    | `/health`                            | No   | Health check endpoint          |
+| GET    | `/metrics`                           | No   | Prometheus metrics             |
 
 ---
 
 ## Appendix: Error Codes
 
-| Code | Meaning                                      |
-| ---- | -------------------------------------------- |
-| 400  | Invalid request / bound exceeded             |
-| 401  | Missing or invalid Bearer token              |
-| 403  | Issuer does not own the list                 |
-| 404  | Status list not found                        |
+| Code | Meaning                                     |
+| ---- | ------------------------------------------- |
+| 400  | Invalid request / bound exceeded            |
+| 401  | Missing or invalid Bearer token             |
+| 403  | Issuer does not own the list                |
+| 404  | Status list not found                       |
 | 406  | Unsupported Accept header                   |
 | 409  | Resource already exists / concurrent update |
 | 413  | Request body too large                      |
 | 422  | Serialized list too large / unparsable JWK  |
-| 429  | Rate limit quota exhausted                   |
-| 500  | Internal server error                        |
-| 503  | Service unavailable                          |
+| 429  | Rate limit quota exhausted                  |
+| 500  | Internal server error                       |
+| 503  | Service unavailable                         |
 
 ---
 

--- a/docs/deployment-architecture.md
+++ b/docs/deployment-architecture.md
@@ -1,0 +1,571 @@
+# Status List Server — Deployment Architecture
+
+## Overview
+
+The Status List Server is a Rust-based microservice deployed on AWS EKS. This document describes the complete deployment architecture from source code to running service.
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                           DEPLOYMENT ARCHITECTURE                           │
+└─────────────────────────────────────────────────────────────────────────────┘
+
+   ┌──────────┐      ┌──────────────┐      ┌─────────────────┐
+   │   GitHub  │ ───► │  GitHub      │ ───► │   AWS EKS        │
+   │  (main)   │      │  Actions     │      │   Kubernetes    │
+   └──────────┘      │  CI/CD       │      │   Cluster       │
+                      └──────────────┘      └────────┬────────┘
+                              │                        │
+                              ▼                        ▼
+                     ┌──────────────┐         ┌──────────────┐
+                     │   GHCR       │         │  Helm Chart  │
+                     │  Container   │         │  Deployment  │
+                     │  Registry    │         └──────────────┘
+                     └──────────────┘
+```
+
+## Table of Contents
+
+1. [Technology Stack](#1-technology-stack)
+2. [Build & Packaging](#2-build--packaging)
+3. [Container Architecture](#3-container-architecture)
+4. [CI/CD Pipeline](#4-cicd-pipeline)
+5. [Kubernetes Deployment](#5-kubernetes-deployment)
+6. [Helm Chart Structure](#6-helm-chart-structure)
+7. [Runtime Configuration](#7-runtime-configuration)
+8. [Observability Stack](#8-observability-stack)
+9. [Dependency Management](#9-dependency-management)
+10. [Security Hardening](#10-security-hardening)
+11. [Deployment Checklist](#11-deployment-checklist)
+
+---
+
+## 1. Technology Stack
+
+| Component          | Technology                      | Purpose                                    |
+| -------------------|--------------------------------| ------------------------------------------ |
+| Language           | Rust (Edition 2024)            | High-performance, memory-safe backend      |
+| Web Framework      | Axum 0.8                       | Async HTTP server                          |
+| Database           | PostgreSQL 18 / MySQL 9        | Persistent storage via SeaORM              |
+| Container          | Docker / BuildKit              | Multi-platform builds (amd64, arm64)       |
+| Orchestration      | Kubernetes (AWS EKS)           | Container orchestration                    |
+| Package Manager    | Helm 3                         | Kubernetes resource management             |
+| Observability      | OpenTelemetry + Prometheus     | Tracing, metrics, log aggregation          |
+| Secrets            | External Secrets Operator      | AWS Secrets Manager integration           |
+| DNS                | External-DNS + cert-manager    | Automated DNS + TLS certificates          |
+| CDN/Load Balancing | AWS NLB                        | Load balancing and global distribution    |
+
+---
+
+## 2. Build & Packaging
+
+### 2.1 Multi-Platform Docker Build
+
+The project uses Docker BuildKit with cross-compilation for `amd64` and `arm64`:
+
+```dockerfile
+# Multi-stage build targeting musl-based Alpine for minimal image
+FROM blackdex/rust-musl:${TARGETARCH} AS builder
+ARG FEATURES="postgres,aws,acme"
+cargo build --release --target=${RUST_TARGET} --features "${FEATURES}"
+
+# Minimal scratch-based runtime image
+FROM scratch AS runtime
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder --chown=65534:65534 /app/${APP_NAME} /app/${APP_NAME}
+USER 65534
+```
+
+### 2.2 Feature Flags
+
+Cargo features gate production backend drivers:
+
+| Feature       | Description                                                              | Default       |
+| ------------- | ------------------------------------------------------------------------ | ------------- |
+| `memory`      | In-memory storage + Moka cache                                           | ✅ Active     |
+| `postgres`    | PostgreSQL via SeaORM                                                     | Opt-in        |
+| `mysql`       | MySQL via SeaORM                                                          | Opt-in        |
+| `sqlite`      | SQLite via SeaORM                                                         | Opt-in        |
+| `redis`       | Redis certificate cache driver                                           | Opt-in        |
+| `aws-secrets` | Route53 DNS-01 + AWS Secrets Manager (single crypto-material backend)   | Opt-in        |
+| `vault`       | Vault/OpenBao KV v2 crypto-material backend                              | Opt-in        |
+| `acme`        | ACME DNS-01 certificate provisioning                                      | Opt-in        |
+
+Production builds include: `FEATURES="postgres,aws-secrets,acme"` (or `postgres,vault,acme` to store crypto material in Vault/OpenBao).
+
+---
+
+## 3. Container Architecture
+
+### 3.1 Image Structure
+
+```
+┌─────────────────────────────────────────────────────────┐
+│              status-list-server:latest                  │
+├─────────────────────────────────────────────────────────┤
+│  Layer 1: Scratch base image                            │
+│  Layer 2: CA certificates (TLS verification)            │
+│  Layer 3: /etc/passwd (non-root user)                   │
+│  Layer 4: Application binary (UID 65534)                │
+├─────────────────────────────────────────────────────────┤
+│  User: 65534 (nobody)                                   │
+│  Entrypoint: /app/status-list-server                    │
+│  Port: 8000                                             │
+└─────────────────────────────────────────────────────────┘
+```
+
+### 3.2 Container Security
+
+- **Non-root execution**: Runs as UID 65534
+- **Minimal base**: `scratch` image contains only required artifacts
+- **Read-only filesystem**: Root filesystem is read-only
+- **No shell access**: Attack surface minimized
+
+---
+
+## 4. CI/CD Pipeline
+
+### 4.1 Pipeline Overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    GitHub Actions CI/CD                          │
+└─────────────────────────────────────────────────────────────────┘
+
+  ┌─────────┐    ┌──────────┐    ┌────────────┐    ┌──────────┐
+  │  Push   │───►│   Zizmor  │───►│   Build    │───►│ Clippy   │
+  │  PR     │    │ Security  │    │   Check    │    │ Lints    │
+  └─────────┘    └──────────┘    └────────────┘    └──────────┘
+       │                                              │
+       │                                              ▼
+       │                                    ┌────────────────┐
+       │                                    │   Nextest      │
+       │                                    │   Tests        │
+       │                                    └────────────────┘
+       │                                              │
+       ▼                                              ▼
+  ┌──────────┐    ┌─────────────┐    ┌───────┐    ┌──────────┐
+  │ Markdown │    │ Trivy Config │    │ Kube  │    │ Coverage │
+  │ Lint     │    │ Scan         │    │ Linter│    │ Report   │
+  └──────────┘    └─────────────┘    └───────┘    └──────────┘
+
+  ┌─────────────────────────────────────────────────────────────────┐
+  │                     CD Pipeline (on push to main/tag)          │
+  └─────────────────────────────────────────────────────────────────┘
+
+  ┌─────────┐    ┌──────────────┐    ┌─────────┐    ┌──────────┐
+  │  Push   │───►│    CI        │───►│ Build & │───►│  Deploy  │
+  │  main   │    │   Passes     │    │  Push   │    │  to EKS  │
+  │  Tag    │    │              │    │  GHCR   │    │          │
+  └─────────┘    └──────────────┘    └─────────┘    └──────────┘
+```
+
+### 4.2 CI Jobs
+
+| Job                  | Purpose                                           |
+| -------------------- | ------------------------------------------------- |
+| `zizmor-security`    | Workflow security scanning                        |
+| `cargo-fmt`          | Rust formatting check                             |
+| `cargo-build`        | Full workspace compilation                        |
+| `cargo-clippy`       | Linting with clippy                               |
+| `cargo-nextest`      | Parallel test execution                           |
+| `cargo-doc`          | Documentation generation                          |
+| `cargo-machete`       | Unused dependency detection                       |
+| `cargo-vet`           | Dependency vulnerability auditing                 |
+| `cargo-deny`          | License and security policy checks                |
+| `trivy-config`        | Helm chart vulnerability scanning                  |
+| `kube-linter`         | Kubernetes manifests linting                      |
+| `cargo-coverage`      | LLVM code coverage report                         |
+
+### 4.3 CD Pipeline
+
+```yaml
+# Triggered on push to main or tag (v*.*.*)
+on:
+  push:
+    branches: [main]
+    tags: [v*.*.*]
+
+# Image tagging strategy
+tags: |
+  type=semver,pattern={{version}}          # v1.2.3 → 1.2.3
+  type=raw,value=latest                     # main branch → latest
+  type=sha,format=short                     # commit SHA → sha-abc1234
+```
+
+---
+
+## 5. Kubernetes Deployment
+
+### 5.1 Architecture on EKS
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                           AWS EKS Cluster                              │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  ┌─────────────────────────────────────────────────────────────────┐   │
+│  │                    statuslist Namespace                         │   │
+│  │  ┌─────────────────────────────────────────────────────────┐   │   │
+│  │  │                 NGINX Ingress Controller                  │   │   │
+│  │  │                      (External LB)                       │   │   │
+│  │  └─────────────────────────────────────────────────────────┘   │   │
+│  │                            │                                   │   │
+│  │  ┌────────────────────────▼───────────────────────────────┐   │   │
+│  │  │              statuslist Service (ClusterIP)             │   │   │
+│  │  │                       Port: 8081                        │   │   │
+│  │  └─────────────────────────────────────────────────────────┘   │   │
+│  │                            │                                   │   │
+│  │  ┌────────────────────────▼───────────────────────────────┐   │   │
+│  │  │           statuslist Deployment (1 replica)            │   │   │
+│  │  │  ┌───────────────────┐  ┌───────────────────────────┐  │   │   │
+│  │  │  │  statuslist-server │  │  otel-collector (sidecar)│  │   │   │
+│  │  │  │   Port: 8000       │  │   Port: 4317 (gRPC)     │  │   │   │
+│  │  │  └───────────────────┘  └───────────────────────────┘  │   │   │
+│  │  └─────────────────────────────────────────────────────────┘   │   │
+│  │                            │                                   │   │
+│  │  ┌─────────────────────────┼───────────────────────────────┐  │   │
+│  │  │                         │                               │  │   │
+│  │  ▼                         ▼                               ▼  │   │
+│  │ ┌─────────────┐    ┌─────────────────┐                      │   │
+│  │ │ PostgreSQL  │    │ OTEL Collector  │                      │   │
+│  │ │  (Pods)     │    │  (Standalone)   │                      │   │
+│  │ └─────────────┘    └─────────────────┘                      │   │
+│  └─────────────────────────────────────────────────────────────────┘   │
+│                                                                         │
+│  ┌─────────────────────────────────────────────────────────────────┐   │
+│  │                      Infrastructure Layer                        │   │
+│  │  ┌───────────────────────┐  ┌───────────────────────────────┐   │   │
+│  │  │  Crypto-Material Store │  │      cert-manager / ACME      │   │   │
+│  │  │  (Vault or AWS SM)     │  │  (TLS certs via Route53 DNS)  │   │   │
+│  │  └───────────────────────┘  └───────────────────────────────┘   │   │
+│  └─────────────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### 5.2 Resource Allocation
+
+| Component                | CPU Request | Memory Request | CPU Limit | Memory Limit |
+| ------------------------ | ----------- | -------------- | --------- | ------------ |
+| status-list-server       | 250m        | 256Mi          | 500m      | 512Mi        |
+| PostgreSQL                | 250m        | 256Mi          | 500m      | 512Mi        |
+| OTEL Collector           | 100m        | 128Mi          | 200m      | 256Mi        |
+| OTEL Collector (sidecar) | 50m         | 64Mi           | 100m      | 128Mi        |
+
+---
+
+## 6. Helm Chart Structure
+
+```
+helm/chart/
+├── Chart.yaml              # Chart metadata and dependencies
+├── values.yaml             # Production default values
+├── values-local.yaml       # Local development values
+├── values-production.yaml  # Production values applied by the deploy workflow
+├── templates/
+│   ├── deployment.yaml     # Application deployment
+│   ├── service.yaml        # ClusterIP service
+│   ├── serviceaccount.yaml # ServiceAccount (Workload Identity / IRSA annotations)
+│   ├── ingress.yaml        # NGINX ingress with TLS
+│   ├── network-policy.yaml # Kubernetes network policies
+│   ├── secret-store.yaml   # Provider-neutral SecretStore configuration
+│   ├── external-secrets.yaml   # ESO ExternalSecret integration
+│   ├── secret.yaml         # Fallback Kubernetes Secret (non-ESO clusters)
+│   ├── hpa.yaml            # Horizontal Pod Autoscaler (opt-in)
+│   ├── pdb.yaml            # Pod Disruption Budget (opt-in)
+│   └── tests/              # Helm chart smoke tests
+└── README.md               # Deployment documentation
+```
+
+### 6.1 Chart Dependencies
+
+| Dependency       | Version | Repository                        | Purpose                        |
+| ---------------- | ------- | --------------------------------- | ------------------------------ |
+| PostgreSQL       | 0.8.2   | `oci://registry-1.docker.io/cloudpirates` | Database storage   |
+| OpenTelemetry Collector | 0.169.0 | `https://open-telemetry.github.io/opentelemetry-helm-charts` | Metrics, traces, logs |
+
+### 6.2 Key Values
+
+```yaml
+# Image configuration
+statuslist:
+  image:
+    repository: ghcr.io/adorsys/status-list-server
+    tag: "latest"  # Overridden by CD pipeline
+    pullPolicy: Always
+
+# Service configuration
+  service:
+    type: ClusterIP
+    port: 8081
+    targetPort: 8000
+
+# Ingress with TLS
+  ingress:
+    enabled: true
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+      nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    tls:
+      hosts:
+        - "*.eudi-adorsys.com"
+      secretName: statuslist-tls
+    externalDnsHostname: statuslist.eudi-adorsys.com
+```
+
+---
+
+## 7. Runtime Configuration
+
+### 7.1 Environment Variables
+
+| Variable                           | Default         | Description                                 |
+| ---------------------------------- | --------------- | ------------------------------------------ |
+| `APP_ENV`                          | `development`   | Runtime environment                        |
+| `APP_SERVER__PORT`                 | `8000`          | Server port                                |
+| `APP_DATABASE__BACKEND`            | `postgres`      | Database driver                            |
+| `APP_STATUS_LIST__TOKEN_EXP_SECS`  | `900`           | Status list expiration (15 min)            |
+| `APP_STATUS_LIST__TOKEN_TTL_SECS`  | `300`           | Status list TTL (5 min)                    |
+| `APP_CACHE__TTL`                   | `300`           | Status list cache TTL                      |
+| `APP_RATE_LIMIT__*`                | Various         | Rate limiting configuration                |
+| `APP_LIMITS__MAX_BODY_SIZE_BYTES`  | `2097152`       | Max request body (2 MiB)                   |
+| `APP_SERVER__CERT__ACME_*`          | —               | ACME certificate provisioning              |
+| `APP_TELEMETRY__ENABLED`           | `true`          | OpenTelemetry export                       |
+| `APP_TELEMETRY__OTLP_ENDPOINT`     | `localhost:4317` | OTLP gRPC endpoint                         |
+
+### 7.2 DNS Providers for ACME
+
+| Provider   | Environment Variable Prefix                      |
+| ---------- | ------------------------------------------------ |
+| AWS Route53 | `APP_SERVER__CERT__DNS__ROUTE53__*`             |
+| Cloudflare | `APP_SERVER__CERT__DNS__CLOUDFLARE__*`          |
+| Google Cloud DNS | `APP_SERVER__CERT__DNS__GCLOUD__*`           |
+| Azure DNS   | `APP_SERVER__CERT__DNS__AZURE__*`               |
+| ACME-DNS    | `APP_SERVER__CERT__DNS__ACMEDNS__*`             |
+
+---
+
+## 8. Observability Stack
+
+### 8.1 Data Flow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                      Observability Architecture                  │
+└─────────────────────────────────────────────────────────────────┘
+
+   ┌──────────────────┐         ┌──────────────────┐
+   │ statuslist-server│         │   Application    │
+   │                  │         │    Logs          │
+   └────────┬─────────┘         └────────┬─────────┘
+            │                          │
+            ▼                          ▼
+   ┌──────────────────┐         ┌──────────────────┐
+   │   Prometheus     │         │  Structured      │
+   │   Metrics        │         │  JSON Logs       │
+   │   (:8000/metrics)│         │  (stdout)        │
+   └────────┬─────────┘         └────────┬─────────┘
+            │                          │
+            ▼                          │
+   ┌──────────────────┐                │
+   │ OTEL Collector   │◄────────────────┘
+   │ (sidecar/        │
+   │  standalone)     │
+   └────────┬─────────┘
+            │
+    ┌───────┼───────┐
+    ▼       ▼       ▼
+┌───────┐ ┌──────┐ ┌────────┐
+│Traces │ │Metrics│ │ Logs   │
+│(OTLP) │ │(OTLP)│ │(OTLP)  │
+└───┬───┘ └──┬───┘ └───┬────┘
+    ▼       ▼         ▼
+┌────────────────────────────────┐
+│      Backend                   │
+│  ┌────────┐ ┌────────┐         │
+│  │ Jaeger │ │Tempo/  │         │
+│  │        │ │Loki    │         │
+│  └────────┘ └────────┘         │
+└────────────────────────────────┘
+```
+
+### 8.2 Local Observability Setup
+
+When running with Docker Compose:
+
+| Service              | URL                       |
+| -------------------- | ------------------------- |
+| Status List Server   | `http://localhost:8000`    |
+| Prometheus UI        | `http://localhost:9090`   |
+| Jaeger UI            | `http://localhost:16686`  |
+| Metrics endpoint     | `http://localhost:8000/metrics` |
+
+---
+
+## 9. Dependency Management
+
+### 9.1 Secrets Management
+
+Secrets are delivered to the application through **External Secrets Operator (ESO)**, the default secret-delivery path — not Workload Identity. The chart renders:
+
+- A `SecretStore` (`secret-store.yaml`) that is **provider-neutral** — `secretStore.provider` selects between `aws` (Secrets Manager / Parameter Store), `vault` (Vault / OpenBao), `gcp` (Secret Manager), `azure` (Key Vault), or `raw` (full provider passthrough for unsupported ESO providers).
+- An `ExternalSecret` (`external-secrets.yaml`, gated on `externalSecret.enabled`) that syncs the `postgres-password` key into the `statuslist-secret` Kubernetes Secret.
+- A second `ExternalSecret` that provisions `aws-credentials-secret` so the ESO-mounted credentials path is complete (rendered only when `externalSecret.enabled=true` **and** `statuslist.aws.mountCredentials=true`).
+- A **fallback Kubernetes `Secret`** (`secret.yaml`) for clusters that do not run ESO, rendered only when `externalSecret.enabled=false` and `statuslist.fallbackSecret.enabled=true`.
+
+**ESO-mounted credentials (default):** the chart defaults to `statuslist.aws.mountCredentials=true`, so the application pod mounts the ESO-provisioned `aws-credentials-secret` at `/home/nobody/.aws`. Production (`values-production.yaml`) keeps this default, so no static credential files are managed by hand and no Workload Identity annotation is required.
+
+**Workload Identity / IRSA (opt-in):** the application pod uses a dedicated `ServiceAccount` (`serviceAccount.create=true`). AWS/GCP/Azure ambient credentials are attached via `serviceAccount.annotations` (e.g. `eks.amazonaws.com/role-arn` for EKS IRSA). To opt in, set `statuslist.aws.mountCredentials=false` and attach the cloud role annotation; the application then uses ambient credentials instead of mounted files. See [Secrets Risk: ESO vs Workload Identity](secrets-risk-eso-vs-workload-identity.md) for the trade-offs.
+
+### 9.2 Redis
+
+The Helm chart no longer deploys the Redis HA subchart. Status-list reads and writes use the configured repository backend plus the in-process Moka cache, so Redis is not a runtime dependency of the deployment chart. Redis remains available behind the crate-level `redis` feature for application images that require an explicit adapter-level Redis integration.
+
+### 9.3 Database Selection
+
+| Use Case                     | Recommended Backend |
+| ---------------------------- | ------------------- |
+| Production HA                | PostgreSQL          |
+| MySQL-compatible infra       | MySQL               |
+| Single-node / Development    | SQLite              |
+| Distributed production        | PostgreSQL / MySQL   |
+
+---
+
+## 10. Security Hardening
+
+### 10.1 Kubernetes Security Context
+
+```yaml
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 65534
+  runAsGroup: 65534
+  fsGroup: 65534
+  seccompProfile:
+    type: RuntimeDefault
+
+# Container-level
+readOnlyRootFilesystem: true
+allowPrivilegeEscalation: false
+capabilities:
+  drop: ["ALL"]
+```
+
+### 10.2 Network Policies
+
+```yaml
+# Ingress: Allow anywhere (no IP restrictions)
+ingress: []
+
+# Egress: PostgreSQL (5432), Redis (6379/6380), DNS (53), HTTPS (443), OTLP (4317/4318)
+egress:
+  - ports: [5432, 6379, 6380, 443, 53, 4317, 4318]
+```
+
+### 10.3 Rate Limiting
+
+| Tier       | Burst | Period | Routes                           |
+| ---------- | ----- | ------ | -------------------------------- |
+| Strict     | 10    | 60s    | `POST /api/v1/credentials`       |
+| Writes     | 10    | 60s    | `PUT/PATCH /status-lists/*`      |
+| Permissive | 100   | 60s    | `GET /status-lists/*`, aggregation |
+
+### 10.4 Request Bounds
+
+| Bound                     | Value      | Response Code     |
+| ------------------------- | ---------- | ----------------- |
+| `max_body_size_bytes`     | 2 MiB      | `413`             |
+| `max_status_index`        | 100,000    | `400`             |
+| `max_statuses_per_request`| 5,000      | `400`             |
+| `max_serialized_list_size`| 1 MiB      | `422`             |
+
+---
+
+## 11. Deployment Checklist
+
+### Pre-Deployment
+
+- [ ] Configure AWS credentials in GitHub Secrets
+- [ ] Verify Helm dependencies are up to date
+- [ ] Validate `values.yaml` for production environment
+- [ ] Confirm database credentials in AWS Secrets Manager
+- [ ] Verify DNS provider credentials for ACME
+
+### Infrastructure Setup
+
+- [ ] Create `statuslist` namespace
+- [ ] Configure `high-performance` StorageClass (or adjust)
+- [ ] Set up cert-manager ClusterIssuer for Let's Encrypt
+- [ ] Configure External-DNS with DNS provider
+- [ ] Create TLS secrets for Redis HAProxy (if using Redis)
+
+### Application Deployment
+
+- [ ] Deploy PostgreSQL: `helm install statuslist-postgres ./chart`
+- [ ] Deploy Redis HA (optional): `redis-ha.enabled=true`
+- [ ] Deploy application: `helm install statuslist ./chart -f chart/values.yaml`
+- [ ] Verify pods are running: `kubectl get pods -n statuslist`
+- [ ] Check application logs: `kubectl logs -l app.kubernetes.io/name=status-list-server -n statuslist`
+
+### Post-Deployment Verification
+
+- [ ] Access application at configured domain
+- [ ] Verify TLS certificate provisioning
+- [ ] Check OpenTelemetry traces in Jaeger
+- [ ] Verify Prometheus metrics endpoint
+- [ ] Test API endpoints (health, credentials, status lists)
+- [ ] Validate network policies are enforced
+
+### Monitoring Setup
+
+- [ ] Configure Grafana dashboards (if applicable)
+- [ ] Set up alerting rules for:
+  - [ ] Pod restarts
+  - [ ] High error rates
+  - [ ] Certificate expiration
+  - [ ] Database connectivity
+- [ ] Verify log aggregation
+
+---
+
+## Appendix: API Endpoints
+
+| Method | Endpoint                              | Auth | Description                         |
+| ------ | ------------------------------------- | ---- | ----------------------------------- |
+| GET    | `/api/v1/status-lists/{id}`           | No   | Retrieve status list (JWT/CWT)       |
+| GET    | `/api/v1/aggregation`                 | No   | List all status list URIs            |
+| POST   | `/api/v1/credentials`                 | No   | Register issuer credentials          |
+| PUT    | `/api/v1/status-lists/{id}/statuses`   | JWT  | Publish full status list             |
+| PATCH  | `/api/v1/status-lists/{id}/statuses`   | JWT  | Partial status update               |
+| GET    | `/health`                             | No   | Health check endpoint               |
+| GET    | `/metrics`                            | No   | Prometheus metrics                  |
+
+---
+
+## Appendix: Error Codes
+
+| Code | Meaning                                      |
+| ---- | -------------------------------------------- |
+| 400  | Invalid request / bound exceeded             |
+| 401  | Missing or invalid Bearer token              |
+| 403  | Issuer does not own the list                 |
+| 404  | Status list not found                        |
+| 406  | Unsupported Accept header                   |
+| 409  | Resource already exists / concurrent update |
+| 413  | Request body too large                      |
+| 422  | Serialized list too large / unparsable JWK  |
+| 429  | Rate limit quota exhausted                   |
+| 500  | Internal server error                        |
+| 503  | Service unavailable                          |
+
+---
+
+## Further Reading
+
+- [Secrets Risk: ESO vs Workload Identity](secrets-risk-eso-vs-workload-identity.md)
+- [Database Backend Guidance](docs/database-backends.md)
+- [Observability Guide](docs/observability.md)
+- [DNS Provider Setup](docs/dns-providers.md)
+- [Secrets Backend Guidance](docs/secrets-backends.md)
+- [Helm Deployment Guide](helm/README.md)
+- [Deployment Runbook](docs/deployment-runbook.md)

--- a/docs/deployment-runbook.md
+++ b/docs/deployment-runbook.md
@@ -6,11 +6,11 @@ This runbook is for **you**: you have the Status List Server project and want to
 
 You have three broad ways to run the Status List Server:
 
-| Option | Cluster | Purpose | Chart values |
-| --- | --- | --- | --- |
-| **Local / development** | Minikube, kind, Docker Desktop | Manual testing, iteration | `values-local.yaml` |
-| **Self-managed deploy (recommended)** | Any cluster you own | A real, repeatable deployment | `values.yaml` (+ your own overrides) |
-| **Bundled chart only** | Any cluster | Bring-your-own containers / compose (non-Helm) | n/a (Docker / Kubernetes manifests) |
+| Option                                | Cluster                        | Purpose                                        | Chart values                         |
+| ------------------------------------- | ------------------------------ | ---------------------------------------------- | ------------------------------------ |
+| **Local / development**               | Minikube, kind, Docker Desktop | Manual testing, iteration                      | `values-local.yaml`                  |
+| **Self-managed deploy (recommended)** | Any cluster you own            | A real, repeatable deployment                  | `values.yaml` (+ your own overrides) |
+| **Bundled chart only**                | Any cluster                    | Bring-your-own containers / compose (non-Helm) | n/a (Docker / Kubernetes manifests)  |
 
 The project ships a Helm chart (`helm/chart`) that is the recommended, supported way to deploy. The chart bundles:
 
@@ -129,8 +129,8 @@ For a stable, reproducible deploy, pin the exact image:
 statuslist:
   image:
     repository: <your-registry>/status-list-server
-    tag: "1.0.1"          # used when digest is empty
-    digest: "sha256:<64 hex chars>"   # takes precedence over tag
+    tag: "1.0.1" # used when digest is empty
+    digest: "sha256:<64 hex chars>" # takes precedence over tag
 ```
 
 When `digest` is set it takes precedence over `tag`, and Kubernetes runs `repository@digest`. `pullPolicy` derives automatically (`IfNotPresent` for a digest, `Always` for a mutable tag). A malformed digest (`not sha256:` + 64 hex) is rejected at template time rather than failing at pull time.
@@ -196,7 +196,7 @@ The fallback Secret is always named `statuslist-secret`. Because it uses `string
 For a production-shape deployment enable scaling and disruption budgets together (disabled by default):
 
 ```yaml
-replicaCount: 2   # or enable autoscaling below
+replicaCount: 2 # or enable autoscaling below
 
 autoscaling:
   enabled: true

--- a/docs/deployment-runbook.md
+++ b/docs/deployment-runbook.md
@@ -1,287 +1,287 @@
 # Deployment Runbook
 
-This runbook describes the GitHub Actions deployment flow for the Status List Server Helm chart on AWS EKS.
+This runbook is for **you**: you have the Status List Server project and want to deploy it on **your own** Kubernetes cluster. It lays out the deployment options available and the steps to follow, regardless of where the cluster runs (EKS, GKE, AKS, or a local cluster such as Minikube or kind).
 
-## Deployment Flow
+## Deployment Options at a Glance
 
-The deploy workflow is `.github/workflows/deploy.yml`. It runs on release tags matching `v*.*.*` and on manual dispatch — **not** on pushes to `main`, and not on pull requests. A two-architecture build plus scan costs roughly 40 minutes and publishes to GHCR, so it is spent per release rather than per merge.
+You have three broad ways to run the Status List Server:
 
-- Release tags matching `v*.*.*` run CI, build, push, scan, promote the release tags, and deploy to the production cluster.
-- Manual dispatch exercises the build, scan and assertion path without promoting or deploying anything. It does still push the `sha-<short_sha>` tag to GHCR — a dispatch run publishes an image, it just never advertises or ships one.
+| Option | Cluster | Purpose | Chart values |
+| --- | --- | --- | --- |
+| **Local / development** | Minikube, kind, Docker Desktop | Manual testing, iteration | `values-local.yaml` |
+| **Self-managed deploy (recommended)** | Any cluster you own | A real, repeatable deployment | `values.yaml` (+ your own overrides) |
+| **Bundled chart only** | Any cluster | Bring-your-own containers / compose (non-Helm) | n/a (Docker / Kubernetes manifests) |
 
-`promote-tags` and `deploy` require `github.event_name == 'push'` in addition to a `refs/tags/v*` ref. That matters because `workflow_dispatch` accepts any ref including a tag, through both the ref picker and the REST API, so a ref test on its own would not make dispatch the non-releasing path it is documented to be.
+The project ships a Helm chart (`helm/chart`) that is the recommended, supported way to deploy. The chart bundles:
 
-Because the workflow does not run on pull requests, anything it is the only check for — the builder-stage audit assertion, the image scan itself — first fails during a release. Use manual dispatch to exercise the path before tagging when a change touches the `Dockerfile` or the scan job.
+- the **Status List Server** application Deployment, Service, and (optionally) Ingress;
+- a **PostgreSQL** subchart for the database;
+- an **OpenTelemetry Collector** subchart for traces/metrics/logs (optional).
 
-## How It Works
+Everything below assumes you deploy with Helm. The chart is the source of truth for how the application is configured and run; see `helm/README.md` for the full value reference and `docs/` for supporting topics (secrets, DNS providers, database backends, observability).
 
-Every workflow run first executes the reusable CI workflow, then builds and pushes a multi-architecture image to GHCR under its commit SHA tag, then scans that image by digest. Release tag runs then promote the scanned digest to the release tags and deploy the Helm chart to production.
+## Prerequisites
 
-The scan job blocks both promotion and deployment. A release tag whose image fails an assertion builds and pushes, but the semver and `latest` tags are never applied to it and it never reaches production — so a rejected artifact is reachable only by its commit SHA, never as an advertised release. See [Container Supply Chain](supply-chain.md) for thresholds and triage.
+- A Kubernetes cluster you can talk to (`kubectl` configured with the right context).
+- `kubectl` and Helm 3 (≥ v3.8) installed.
+- Network access from the cluster to pull images, and — if you use the ACME certificate provisioning — to the certificate authority and your DNS provider.
+- A way to get images: either a registry account you control, or a local image load (Minikube/kind).
 
-The vulnerability gate blocks on any HIGH or CRITICAL finding that survives the exception ledger, as do the assertions around it. Each run also proves the gate can still fail, against a fixture, before treating a clean scan as meaningful. See the supply chain guide for thresholds and triage.
+### Decide on your image
 
-### Image Tags
+The chart's default `statuslist.image.repository` points at `ghcr.io/adorsys/status-list-server` for convenience. For your own deployment you will normally:
 
-| Trigger              | Image Tags                               | Applied               |
-| -------------------- | ---------------------------------------- | --------------------- |
-| Manual dispatch      | `sha-<short_sha>`                        | At build              |
-| Release tag `v*.*.*` | `sha-<short_sha>`                        | At build              |
-| Release tag `v*.*.*` | `<major>.<minor>`, `<version>`, `latest` | After the scan passes |
+- **Build and push to your own registry**, then point `statuslist.image.repository` and `statuslist.image.tag` (or `digest`) at it, or
+- **Load a locally built image** into a local cluster (Minikube `minikube image load`, kind `kind load docker-image`) and use `pullPolicy: IfNotPresent`.
 
-The `latest` tag is only applied to official release tags, never to a dispatch run. This follows standard OCI/Docker distribution conventions where `latest` represents the latest stable release. `latest` is also withheld from prereleases: `v*.*.*` matches `v1.2.3-rc1`, so the tag is guarded on the ref name containing no `-`.
+Set `statuslist.image.tag` explicitly. If both `tag` and `digest` are empty, the chart falls back to its `appVersion`. Prefer a `sha256:` `digest` for reproducible production deploys (see [Pinning the image](#pinning-the-image)`).
 
-Release tags are applied by the `promote-tags` job using `docker buildx imagetools create`, which copies manifest descriptors by digest. Nothing is rebuilt, and the promoted tags resolve to exactly the index that was scanned, attestations included — which that job asserts rather than assumes.
+## Option 1 — Local / Development Deployment
 
-### Production Deploy
+The quickest path to a running instance, using `values-local.yaml`. It disables the Ingress, the External Secrets Operator and SecretStore CRs, and the OpenTelemetry Collector, and uses non-persistent PostgreSQL with lighter resources so it runs on a laptop.
 
-Release tags matching `v*.*.*` deploy to:
-
-- GitHub environment: `production`
-- Kubernetes namespace: `statuslist-production`
-- Helm release: `statuslist`
-- Image tag: semantic version without the leading `v`
-
-For example, tag `v0.5.0` deploys image tag `0.5.0`.
-
-The production deploy command is equivalent to:
+### Steps
 
 ```bash
-helm upgrade --install statuslist helm/chart \
-  --namespace statuslist-production \
+# 1. Start a local cluster (example: Minikube)
+minikube start
+kubectl config use-context minikube
+
+# 2. Namespace
+kubectl create namespace local
+
+# 3. Seed the fallback database password Secret (any non-empty value)
+kubectl create secret generic statuslist-secret -n local \
+  --from-literal=postgres-password=postgres
+
+# 4. Pull chart dependencies and install
+helm dependency update ./helm/chart
+helm install statuslist-local ./helm/chart \
+  -n local -f ./helm/chart/values-local.yaml
+
+# 5. Verify
+kubectl get pods -n local
+kubectl port-forward -n local svc/statuslist-local-status-list-server-service 8081:8081
+curl http://localhost:8081/health/live
+curl http://localhost:8081/health/ready
+```
+
+`values-local.yaml` only overrides what differs from the production defaults (disabled Ingress/ESO, NodePort/external reachability, lighter resource requests). If pods fail with `CreateContainerConfigError`, confirm the `statuslist-secret` Secret exists in the namespace. See `docs/LOCAL_DEPLOYMENT.md` for a more detailed local walkthrough.
+
+## Option 2 — Self-Managed Deployment (any cluster)
+
+This is the path to a real deployment on a cluster you own. It uses the production-oriented `values.yaml` defaults, which you override for your environment.
+
+### High-level steps
+
+1. Choose your secret and credential delivery (see [Secrets delivery](#secrets-delivery)).
+2. Configure the application for your runtime (database, certificates, DNS provider, region).
+3. (Optional) Enable an Ingress + TLS and route your domain to the service.
+4. Install the chart with Helm and verify.
+
+### Prepare the database password Secret
+
+The application reads `POSTGRES_PASSWORD` from a Kubernetes Secret named `statuslist-secret` (key `postgres-password`), and the bundled PostgreSQL subchart references the same Secret. How that Secret is created depends on your [secrets mode](#secrets-delivery): via an ExternalSecret (ESO) or a plain fallback Secret you create by hand.
+
+### Configure for your runtime
+
+The chart's `statuslist.env` holds the application configuration. Set the values your deployment needs:
+
+- **Database port**: `APP_DATABASE__PORT` (e.g. `5432`). This is **not** inferred from the PostgreSQL subchart — set it explicitly.
+- **Certificate provisioning / ACME**: `APP_SERVER__CERT__*` values, including the ACME directory URL and the DNS provider for DNS-01 challenges. See [dns-providers.md](dns-providers.md) for what each provider (`route53`, `cloudflare`, `gcloud`, `azure`, `acmedns`) requires. Provider credentials must come from a Secret, not plain env values.
+- **Region**: `statuslist.aws.region` (plain) renders `APP_AWS__REGION`.
+- **Telemetry / limits / rate limiting / cache**: defaults are sensible; over-ride only what your sizing needs.
+
+### Install
+
+```bash
+# Pull and package dependencies once
+helm dependency update ./helm/chart
+
+# Install with your values file (or inline --set overrides)
+helm upgrade --install statuslist ./helm/chart \
+  --namespace statuslist \
   --create-namespace \
   --atomic \
   --wait \
   --timeout 10m \
-  --set-string statuslist.image.repository=ghcr.io/adorsys/status-list-server \
-  --set-string statuslist.image.tag=0.5.0 \
-  --set-string statuslist.image.digest=sha256:<digest>
+  -f ./helm/chart/values.yaml \
+  -f ./my-deployment-values.yaml
 ```
 
-The digest is what actually determines the running image. `statuslist.image.digest` takes precedence over `statuslist.image.tag` in the chart, so production runs the exact artifact CI scanned. The tag is still passed because it is what humans read in `helm history` and release notes. Leaving `digest` empty falls back to tag-based deployment, which is the default for local and manual installs.
+Use `helm upgrade --install` rather than `helm install` so the same command both creates and later updates the release. `--atomic --wait --timeout 10m` makes failed upgrades roll back automatically during the pipeline.
 
-Because of that precedence, do not run `helm upgrade --reuse-values` with only a changed tag. The stored digest still wins, so the upgrade reports success and changes nothing. Pass both values, or clear the digest with `--set statuslist.image.digest=null`.
+### Expose the service (Ingress)
 
-A digest that is not `sha256:` followed by 64 hex characters fails at template time rather than becoming an `ImagePullBackOff` ten minutes into `helm upgrade --atomic --wait`. `deploy` also refuses to run at all without a `sha256:` digest, so a deploy can never silently fall back to the mutable tag.
+`values.yaml` ships with the Ingress enabled and nginx + cert-manager annotations, but they reference adorsys's domain (`*.eudi-adorsys.com`, `statuslist.eudi-adorsys.com`). For your own deployment:
 
-Configure the GitHub `production` environment with required reviewers so production deploys pause for approval before AWS credentials are requested.
+- Set `statuslist.ingress.hosts`, `statuslist.ingress.tls.secretName`, and `statuslist.ingress.externalDnsHostname` to your domain.
+- Ensure your Ingress controller (e.g. ingress-nginx) and certificate issuer (e.g. cert-manager) actually exist in your cluster, and adjust the `cert-manager.io/cluster-issuer` annotation to an issuer you own.
+- Or set `statuslist.ingress.enabled=false` and expose the `ClusterIP` Service another way (NodePort, port-forward, or a LoadBalancer).
 
-## Required GitHub and AWS Setup
+Because a default DNS-01 certificate provider is usually wired in, decide whether you want certificate provisioning at all. If you do not, disable it and terminate TLS at your ingress/load balancer instead (see [dns-providers.md](dns-providers.md) and [deployment-architecture.md](deployment-architecture.md)).
 
-Create the GitHub `production` environment with:
+### Pinning the image
 
-- `AWS_DEPLOY_ROLE_ARN`: IAM role ARN assumed by the deploy job through GitHub OIDC.
-- `APP_DATABASE_PORT`: database service port passed to Helm as `statuslist.env.APP_DATABASE__PORT` (for example `5432` for PostgreSQL).
-- Required reviewers: configure at least one approver.
-- Deployment branches/tags: restrict to release tags matching `v*.*.*`.
+For a stable, reproducible deploy, pin the exact image:
 
-The deploy job requires:
-
-- GitHub Actions permission `id-token: write`
-- IAM trust for `token.actions.githubusercontent.com`
-- AWS permission to describe the EKS cluster and perform the Kubernetes operations needed by Helm
-
-Recommended OIDC trust subject for production:
-
-```text
-repo:adorsys/status-list-server:environment:production
+```yaml
+statuslist:
+  image:
+    repository: <your-registry>/status-list-server
+    tag: "1.0.1"          # used when digest is empty
+    digest: "sha256:<64 hex chars>"   # takes precedence over tag
 ```
 
-When a GitHub Actions job uses an environment, GitHub's default OIDC `sub` claim references the environment name. For repositories using immutable OIDC subject claims, adjust the `repo:` prefix to the immutable owner and repository ID format shown by GitHub.
+When `digest` is set it takes precedence over `tag`, and Kubernetes runs `repository@digest`. `pullPolicy` derives automatically (`IfNotPresent` for a digest, `Always` for a mutable tag). A malformed digest (`not sha256:` + 64 hex) is rejected at template time rather than failing at pull time.
+
+## Secrets Delivery
+
+The chart supports two secret-delivery modes, plus a no-secret-manager fallback. Pick the one that matches your cluster. See [secrets-risk-eso-vs-workload-identity.md](secrets-risk-eso-vs-workload-identity.md) for the trade-offs in depth.
+
+### Mode A — External Secrets Operator (ESO) [default]
+
+The chart defaults to **External Secrets Operator** to synchronize secrets from a provider instead of storing them as plain Kubernetes Secrets.
+
+- `externalSecret.enabled=true` and `secretStore.enabled=true` (both chart defaults) render ESO CRs:
+  - a provider-neutral `SecretStore` (`secretStore.provider` selects `aws`, `vault`, `gcp`, `azure`, or `raw`);
+  - an `ExternalSecret` that syncs `postgres-password` into a Kubernetes Secret named `statuslist-secret`;
+  - (when `statuslist.aws.mountCredentials=true`, the default) a second `ExternalSecret` that provisions `aws-credentials-secret` — the AWS shared `credentials`/`config` files Mounted under `/home/nobody/.aws`.
+
+**To use ESO** you must install External Secrets Operator in your cluster and configure:
+
+- the provider (`secretStore.provider` and the matching provider block — e.g. AWS region + Secrets Manager/Parameter Store service);
+- the remote keys your `ExternalSecret` references (e.g. a key holding the `POSTGRES_PASSWORD` property; the `aws-credentials-secret` keys holding `CREDENTIALS`/`CONFIG`).
+
+Verify after install:
+
+```bash
+kubectl get secretstore,externalsecret -n <namespace>
+kubectl describe secretstore <store> -n <namespace>
+kubectl describe externalsecret <external-secret> -n <namespace>
+```
+
+A ready `ExternalSecret` shows a `SecretSynced` condition. A missing remote key or bad provider credentials appears in the status conditions.
+
+### Mode B — Workload Identity (opt-in)
+
+Instead of ESO-mounted static credentials, the application can use **ambient** cloud credentials via Workload Identity (EKS IRSA, GCP WI, Azure WIF):
+
+- attach the role annotation via `serviceAccount.annotations` (e.g. `eks.amazonaws.com/role-arn` on EKS; see `helm/README.md` for GCP/Azure, and note Azure also needs the pod label `azure.workload.identity/use: "true"`);
+- set `statuslist.aws.mountCredentials=false` so no credential files are mounted.
+
+Attach a least-privilege policy to the role (see the example in `helm/README.md` for Route53 / Secrets Manager / S3).
+
+### Mode C — Fallback plain Secret (no ESO)
+
+If your cluster does **not** run External Secrets Operator, disable ESO and render a plain Kubernetes Secret:
+
+```yaml
+externalSecret:
+  enabled: false
+  secretStore:
+    enabled: false
+
+statuslist:
+  fallbackSecret:
+    enabled: true
+    stringData:
+      postgres-password: "change-me"
+```
+
+The fallback Secret is always named `statuslist-secret`. Because it uses `stringData`, values are base64-encoded by the API server. In this mode the `aws-credentials-secret` is not provisioned automatically — either create it yourself (for `mountCredentials=true`) or switch to Workload Identity.
+
+## Scaling and Resilience (opt-in)
+
+For a production-shape deployment enable scaling and disruption budgets together (disabled by default):
+
+```yaml
+replicaCount: 2   # or enable autoscaling below
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75
+
+podDisruptionBudget:
+  enabled: true
+  maxUnavailable: 1
+```
+
+When `autoscaling.enabled=true` the Deployment omits `replicas` so the HPA controls the count. Keep `podDisruptionBudget.maxUnavailable` below the replica count (the safe default) so node drains do not get blocked.
 
 ## Verification
 
-After a deploy, verify the Helm release and Kubernetes rollout:
-
 ```bash
-helm status statuslist -n statuslist-production
-helm history statuslist -n statuslist-production
-kubectl rollout status deployment/statuslist-status-list-server-deployment -n statuslist-production
-kubectl logs -l app.kubernetes.io/name=status-list-server -n statuslist-production --tail=100
+helm status statuslist -n <namespace>
+helm history statuslist -n <namespace>
+kubectl get pods -n <namespace>
+kubectl rollout status deployment/statuslist-status-list-server-deployment -n <namespace>
+kubectl logs -l app.kubernetes.io/name=status-list-server -n <namespace> --tail=100
 ```
 
-Smoke-check the running service:
+Smoke-check the service:
 
 ```bash
-kubectl get pods -n statuslist-production
-kubectl describe pod -l app.kubernetes.io/name=status-list-server -n statuslist-production
+curl http://<service>/health/live
+curl http://<service>/health/ready
 ```
 
-If certificate provisioning or AWS-backed storage is enabled, also confirm the app can reach AWS services by checking application logs for successful Secrets Manager or certificate renewal operations.
+`/health/ready` reflects backing-store readiness (database, and cloud/secret backends if configured), so it is the best signal that the instance is truly healthy.
 
 ## Rollback
 
-There are two rollback paths:
-
-- Failed upgrade rollback is automatic. The deploy workflow uses `--atomic --wait --timeout 10m`, so Helm rolls back during the pipeline when an upgrade fails readiness or times out.
-- Successful-but-bad deploy rollback is manual. If a release passes the pipeline but later proves unhealthy or incorrect, an operator must choose a previous Helm revision and run `helm rollback`.
-
-List available revisions:
+- **Failed upgrade**: automatic. `--atomic --wait --timeout 10m` rolls the release back during the upgrade when readiness fails or the timeout is hit.
+- **Bad-but-successful deploy**: manual. List revisions and roll back:
 
 ```bash
-helm history statuslist -n statuslist-production
+helm history statuslist -n <namespace>
+helm rollback statuslist <revision> -n <namespace> --wait --timeout 10m
+kubectl rollout status deployment/statuslist-status-list-server-deployment -n <namespace>
 ```
 
-Rollback to a known-good revision:
-
-```bash
-helm rollback statuslist <revision> -n statuslist-production --wait --timeout 10m
-kubectl rollout status deployment/statuslist-status-list-server-deployment -n statuslist-production
-```
+Note: pinning by `digest` keeps rollbacks reproducible, since the stored digest — not a mutable tag — determines the running image. When upgrading, pass both `tag` and `digest` explicitly (or clear the digest with `--set statuslist.image.digest=null`); `helm upgrade --reuse-values` with only a changed tag will not move the image because the stored digest still wins.
 
 ## Failure Triage
 
-### OIDC Denied
+### Image pull failure
 
-Symptoms:
+- Pods show `ImagePullBackOff` / `ErrImagePull`.
+- Check the image `repository`/`tag`/`digest` you configured exists in the registry the cluster can reach, and that the cluster has pull credentials if the registry is private.
 
-- `configure-aws-credentials` fails before `aws eks update-kubeconfig`.
-- AWS STS reports that the role cannot be assumed.
+### Readiness failure
 
-Check:
+- `/health/ready` reports a failing backing store.
+- Check database readiness (PostgreSQL pod/connection), the ExternalSecret/SecretStore status (if ESO), and application env values.
 
-- The GitHub environment name matches the IAM trust subject.
-- `AWS_DEPLOY_ROLE_ARN` exists in the selected environment.
-- The role trust references this repository and the correct branch or environment.
-- OIDC IAM role has been created and applied (see issue #236).
+### Secret not synced (ESO)
 
-### Helm Timeout
+- The pod is up but not ready and reports a missing/empty Secret, or `kubectl get externalsecret` shows a condition other than `SecretSynced`.
+- Common causes: the provider lacks permission to `GetSecretValue` on the referenced key; the `SecretStore` region/settings do not match where the key lives; the remote key or property name does not match what `externalSecret.spec.data` / `statuslist.aws.credentialsSecret` expect.
 
-Symptoms:
+### Certificate / ACME issues
 
-- `helm upgrade --install` fails after `--timeout 10m`.
-- Helm reports the release rolled back because `--atomic` is enabled.
-
-Check:
-
-```bash
-helm history statuslist -n statuslist-production
-kubectl get pods -n statuslist-production
-kubectl describe pod -l app.kubernetes.io/name=status-list-server -n statuslist-production
-kubectl logs -l app.kubernetes.io/name=status-list-server -n statuslist-production --tail=200
-```
-
-### Image Pull Failure
-
-Symptoms:
-
-- Pods show `ImagePullBackOff` or `ErrImagePull`.
-
-Check:
-
-- The workflow pushed the expected GHCR tag with the semver format.
-- The cluster can pull from GHCR.
-
-### Readiness Failure
-
-Symptoms:
-
-- Helm waits until timeout.
-- Pods are running but not ready.
-
-Check:
-
-- `/health/ready` responses in pod logs.
-- PostgreSQL readiness.
-- ExternalSecret and SecretStore status.
-- Application configuration injected through Helm values.
-
-### Image Assertion Failure
-
-Symptoms:
-
-- `Scan Image for Vulnerabilities` fails at `Assert published SBOMs list Rust crates`, or at `Resolve the architecture manifest to scan`.
-- The image exists in GHCR under its `sha-<short_sha>` tag, but the release tags were never applied and `Deploy to Production` is skipped.
-
-Check:
-
-- The run artifacts and the job summary. Reports and SBOMs are uploaded before the assertion runs, so a failure here still leaves the full report attached to the run. They arrive as two artifacts: `container-scan-reports` and `container-sboms`.
-- For an SBOM failure, whether the builder-stage audit assertion also changed behaviour recently. An empty published SBOM with a passing build assertion points at BuildKit's cataloguer, not at the binary.
-- For a resolution failure, the message names how many `linux/amd64` manifests were found in the index. Zero means the build stopped producing that platform; more than one means the index is not shaped the way this pipeline assumes. Neither is a scanner problem.
-
-### Vulnerability Gate Findings
-
-Symptoms:
-
-- `Vulnerability gate` fails, the summary lists the blocking advisories, and the release tags are never applied.
-
-Check:
-
-- `trivy-gate-findings-<arch>.json` in the `container-scan-reports` artifact is the exact blocking set for that architecture. The gate's table is rendered from those same files, so the summary count and the table cannot disagree.
-- The summary reports distinct advisories and package occurrences separately. One CVE affecting three crates is three rows in the table and one thing to triage.
-- Whether the advisory is already argued in `deny.toml`. The two ledgers are not connected, so a release can block on something `cargo-deny` has been ignoring deliberately.
-
-Triage steps and the exception format are in [Container Supply Chain](supply-chain.md). Fix it at the lockfile if a fix exists; add a dated ledger entry only if one does not.
-
-### Gate Self-Test Failure
-
-Symptoms:
-
-- `Prove the gate can fail` fails with "the vulnerability gate cannot fail and is not protecting this release".
-
-Check:
-
-- This is not a finding about the image. It means `scripts/vuln-gate.sh` returned success against a fixture that contains a CRITICAL, so the gate would have passed the real scan no matter what was in it.
-- Likely causes: `--exit-code` was changed or dropped in `scripts/vuln-gate.sh`, or a Trivy upgrade changed `convert`'s exit-code behaviour.
-- Do not work around it by skipping the step. A release cut while this is failing has an unverified gate.
-
-### Tag Promotion Failure
-
-Symptoms:
-
-- `Promote Scanned Digest to Release Tags` fails, and the release exists in GHCR only as `sha-<short_sha>`.
-- `Deploy to Production` is skipped because it depends on promotion.
-
-Check:
-
-- Whether `Verify attestations survived promotion` is the failing step. That means the retag succeeded but the SBOM or provenance manifests did not carry through, which would publish a release whose metadata silently vanished.
-- Re-running the job is safe: `imagetools create` is idempotent for a given digest and tag set. **Re-run `promote-tags` alone** — `deploy` depends on it, so a successful re-run unblocks production without cutting a new release. A promotion failure is not a reason to re-tag the repository.
-
-### Builder Audit Assertion Failure
-
-Symptoms:
-
-- The image build fails in the builder stage at the `rust-audit-info` assertion, or at the `cargo install` layer above it, on a commit that changed nothing relevant.
-
-Check:
-
-- This means the binary no longer carries readable `.dep-v0` audit data, usually because the floating stable toolchain drifted away from the pinned `cargo-auditable` version. Bump `CARGO_AUDITABLE_VERSION` and `RUST_AUDIT_INFO_VERSION` in the `Dockerfile`.
-- The assertion is deliberate. Without it the build would succeed and publish an empty SBOM.
+- Certificates fail to provision or renew.
+- Check `APP_SERVER__CERT__ACME_DIRECTORY_URL` (staging vs production), the DNS provider settings and credentials in [dns-providers.md](dns-providers.md), and that the DNS-01 challenge can reach your DNS provider (network + IAM/cloud role).
 
 ## External Dependencies
 
-- **Issue #236**: OIDC IAM role and GitHub environment setup must be completed before first deploy.
-- **Issue #239**: Chart hardening (IRSA migration of cert-manager/Route53 credentials) is pending.
+- **External Secrets Operator** — needed for the default ESO secret path; install it in your cluster (or use Mode B / Mode C to avoid it).
+- **Ingress controller + cert-manager** — needed only if you enable the Ingress / TLS path.
+- **Your cloud provider** — for Workload Identity roles and any AWS/GCP/Azure backends the application uses.
 
-## Redis Removal Cleanup (breaking change)
+## Next Steps
 
-This chart no longer deploys the Redis HA subchart (`redis-ha`), its application
-env vars, its NetworkPolicy rules, or its TLS-sync CronJob. If a previous release
-was deployed with `redis-ha.enabled=true`, the removal of the subchart **orphans**
-Kubernetes resources that Helm does not delete. Clean these up as an ops action
-item before/after the first deploy that carries this chart:
-
-1. **`statuslist-haproxy-tls` secret** — this secret holds the TLS key (`redis.pem`)
-   for the Redis HAProxy load balancer, including the **production wildcard private
-   key**. Because it may contain the production private key, treat it as sensitive
-   and verify it is no longer referenced by any live HAProxy before deleting. Delete
-   it only after confirming no running Redis HAProxy service depends on it:
-
-   ```bash
-   kubectl delete secret statuslist-haproxy-tls -n statuslist-production
-   ```
-
-2. **Redis HA persistent volume claims** — the Redis HA subchart provisions PVCs
-   (e.g. `status-list-server-redis-ha-pvc-*` / release-scoped claims). These retain
-   any persisted Redis data and storage. Delete the claims (and, if you no longer
-   need the data, the underlying PVs / storage volumes):
-
-   ```bash
-   kubectl get pvc -n statuslist-production | grep redis
-   kubectl delete pvc -l release=statuslist,app=redis-ha -n statuslist-production
-   ```
-
-   Confirm the backing volumes are released before removing them to avoid data loss.
-
-There is no code change required for this cleanup; it is purely an operational step
-that must be performed once when adopting this chart version.
+- [helm/README.md](../helm/README.md) — full chart value reference and configuration guide.
+- [LOCAL_DEPLOYMENT.md](LOCAL_DEPLOYMENT.md) — detailed local quickstart.
+- [dns-providers.md](dns-providers.md) — ACME DNS-01 provider setup per provider.
+- [secrets-backends.md](secrets-backends.md), [secrets-risk-eso-vs-workload-identity.md](secrets-risk-eso-vs-workload-identity.md) — choosing a secrets delivery model.
+- [database-backends.md](database-backends.md) — supported database backends.
+- [observability.md](observability.md) — OpenTelemetry / metrics / logs.

--- a/docs/secrets-risk-eso-vs-workload-identity.md
+++ b/docs/secrets-risk-eso-vs-workload-identity.md
@@ -1,0 +1,117 @@
+# Secrets Risk: ESO-mounted Credentials vs Workload Identity
+
+The Status List Server chart defaults to delivering credentials through **External Secrets Operator (ESO)** with mounted static credential files (`statuslist.aws.mountCredentials=true`). **Workload Identity** (EKS IRSA / GCP WI / AKS WIF) is the opt-in alternative. This document is a risk-oriented comparison of the two choices so operators can decide which trade-offs to accept for a given environment.
+
+It does not argue that one is universally "better" — it lays out the threats, blast radius, and operational properties of each so the choice is explicit and informed.
+
+## Scope: two different secrets layers
+
+Do not confuse the two layers that both deal with "secrets":
+
+- **ESO SecretStore / ExternalSecret** (the delivery mechanism): how a provider (AWS Secrets Manager, Vault, GCP, Azure, …) is turned into a Kubernetes `Secret` that the pod mounts. Selecting **ESO** or **Workload Identity** only changes *how the pod obtains the remote material*, not which material backend the application reads at runtime.
+- **The application's crypto-material backend** (`APP_*__*`, e.g. AWS Secrets Manager, Vault/OpenBao, GCP Secret Manager, Azure Key Vault): where the application stores ACME account keys, signing keys, and certificate chains. This is selected by Cargo features and is independent of the delivery mechanism. See [Secrets Backend Guidance](secrets-backends.md).
+
+The comparison below is about the **delivery** layer.
+
+## What each option looks like in the chart
+
+### ESO with mounted credentials (default)
+
+```yaml
+externalSecret:
+  enabled: true
+secretStore:
+  enabled: true
+  provider: aws
+statuslist:
+  aws:
+    mountCredentials: true     # default; chart renders aws-credentials-secret
+```
+
+The ESO controller assumes a provider credential (for `aws` a Secrets Manager role/policy) and synchronizes remote values into Kubernetes `Secret` objects:
+
+- `statuslist-external-secret` → `statuslist-secret` (holds `postgres-password`)
+- `statuslist-external-secret-aws-credentials` → `aws-credentials-secret` (holds the application's AWS shared `credentials` + `config` files, mounted at `/home/nobody/.aws`)
+
+### Workload Identity (opt-in)
+
+```yaml
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/status-list-server
+statuslist:
+  aws:
+    mountCredentials: false    # no mounted credential files
+```
+
+The pod receives a short-lived, projected OIDC token bound to a cloud role (IRSA / GCP WI / AKS WIF). The application authenticates with ambient credentials; no static files are mounted.
+
+## Threat comparison
+
+| Threat property           | ESO mounted credentials (default)  | Workload Identity (opt-in)     |
+| ------------------------- | ---------------------------------- | ------------------------------ |
+| Secret at rest            | Static file + K8s Secret in etcd   | None; short-lived OIDC token   |
+| Credential lifetime       | Until rotated / ESO re-sync        | Minutes-to-hours, auto per pod |
+| Blast radius of one leak  | May span all synced secrets        | Scoped to the pod's own role   |
+| Where the token lives     | On disk + in the Secret (etcd)     | Injected; not written to etcd  |
+| Rotation model            | Operator rotates source + re-sync  | Automatic; no operator action  |
+| Extra privileged identity | ESO controller holds provider cred | None for delivery              |
+| Portability               | Any cluster / provider-neutral     | Requires platform WI plumbing  |
+
+## Primary risks of choosing ESO
+
+### 1. A second, privileged, long-lived credential
+
+ESO's whole point is that a controller with provider access writes Kubernetes `Secrets`. That means a cluster without ESO now carries a credential (for `aws`, the role the controller assumes) that can read the referenced Secrets Manager/Parameter Store keys for every release it manages. Compromise of the ESO controller (or its credentials) is a single pivot point to all synced secrets.
+
+Risk: **high**. It concentrates many secrets behind one identity.
+
+### 2. Static, mounted credentials are longer-lived secrets at rest
+
+With `mountCredentials=true` the application's AWS shared credential file is a real long-lived secret materialized on the pod filesystem and stored in a Kubernetes `Secret` (etcd). The blast radius of leaking `aws-credentials-secret` includes the live certificate infrastructure: Route 53 (ACME DNS-01), S3 (certificate storage). A leaked Workload Identity token expires on its own in roughly an hour; a mounted key does not.
+
+Risk: **high** if the mounted key is broad; mitigated when the mounted key is scoped narrowly and rotated.
+
+### 3. Health is only as good as the sync
+
+The pod depends on ESO having successfully synced the Secret before (or independent of) pod start. If the `SecretStore` is misconfigured (wrong region, missing remote key) or the controller cannot assume its role, the pod stays unready. The application cannot self-heal a missing mount the way Workload Identity resolves credentials on demand at API-call time.
+
+Risk: **medium** availability; an operator intervention (fix provider access / values, trigger a re-sync) is required.
+
+### 4. Reconciliation and drift
+
+ESO re-syncs on `refreshInterval` (default `30m`). Between rotations of the remote key and the next sync the pod runs a stale credential; the failure surfaces as a hard deployment/readiness problem at rotation boundaries unless the operator aligns the rotation with the sync schedule.
+
+Risk: **medium**.
+
+### 5. Secrets visible to cluster operators
+
+Mounted credentials are ordinary Kubernetes `Secret`s. Anyone with `get` on Secrets (or etcd access) can read them. This broadens the set of people and processes who can retrieve the live credential material. Workload Identity keeps the material out of the `Secret` objects entirely.
+
+Risk: **medium**; depends on your RBAC hygiene around Secrets.
+
+## Risks of choosing Workload Identity
+
+For balance, Workload Identity is not free of risk:
+
+- **Platform coupling**: it only works on the cloud platform that provides the identity webhook (EKS/GKE/AKS/on-prem equivalents). Moving to a different platform or running on-prem requires reworking the credential model, whereas ESO-mounted files are platform-neutral.
+- **IAM/Permissions sprawl**: you must maintain a role per workload (or per environment) and keep trust policies correct. A too-broad role recreates the same blast radius problem, just with shorter-lived credentials.
+- **Token handling in-process**: the application's SDK must support the OIDC token path; a misconfigured `automountServiceAccountToken` or cloud admission webhook silently degrades authentication.
+- **Harder static analysis / fewer "it's just a file" guarantees**: some operators prefer the explicit, inspectable mounted-file model.
+
+## Recommendations
+
+1. **Default is acceptable for low-risk/initial deployments**: ESO with mounted credentials is the chart default and is fine when the mounted key is **narrowly scoped** (least-privilege, e.g. only the specific Secrets Manager keys and S3/Route53 resources the server uses) and **rotated regularly**, with ESO's `refreshInterval` aligned to rotation.
+2. **Prefer Workload Identity where you already use it or run cloud-native EKS/GKE/AKS**: the shorter-lived token and reduced secrets-at-rest surface meaningfully lower blast radius for the live certificate infrastructure.
+3. **Regardless of choice**:
+   - Scope the ESO provider role and the application role with least privilege (see the IAM examples in `helm/README.md`).
+   - Restrict Kubernetes RBAC so only trusted operators can read `Secret`s and inspect pods.
+   - Align the ESO `refreshInterval` with your provider-key rotation cadence.
+   - Keep `automountServiceAccountToken=false` (the chart default) unless the pod genuinely needs the Kubernetes API token.
+   - Harden the ESO controller namespace and its credential.
+
+## Related
+
+- [Deployment Runbook](deployment-runbook.md) — ESO-default deploy and verification steps.
+- [Helm Deployment Guide](../helm/README.md) — chart values, opt-in Workload Identity migration.
+- [Secrets Backend Guidance](secrets-backends.md) — the application's crypto-material backends.


### PR DESCRIPTION
## Summary
closes #385 

Docs-only changes, re-based onto `develop` (branch `docs/generalize-deployment-runbook`):

- **`docs/deployment-runbook.md`** — rewritten from the adorsys-specific GitHub Actions → AWS EKS runbook into a self-service guide for deploying the chart on your own cluster: deployment options (local/dev, self-managed, non-Helm), steps, secrets delivery (ESO, Workload Identity, fallback plain Secret), scaling, verification, rollback, and triage.
- **`docs/secrets-risk-eso-vs-workload-identity.md`** — new: security trade-offs of ESO-mounted credentials vs Workload Identity across the two secrets layers.
- **`docs/deployment-architecture.md`** — updated to match (reintroduced on `develop`, where this file is not currently present).

## Notes

- Re-based onto current `develop` (previously targeted a divergent docs branch).
- No code/configuration changes included.

## Extra
confluence doc: https://adorsys.atlassian.net/wiki/x/4Adasw