### PR TITLE
fix(cert): streamline static cert provider, mutual exclusion with acme, and rename cloud features

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -246,13 +246,13 @@ jobs:
       matrix:
         variant:
           - suffix: aws
-            features: "postgres,aws-secrets,acme"
+            features: "postgres,aws"
           - suffix: gcp
-            features: "postgres,gcp-secrets,acme"
+            features: "postgres,gcp"
           - suffix: azure
-            features: "postgres,azure-kv,acme"
+            features: "postgres,azure"
           - suffix: vault
-            features: "postgres,vault,acme"
+            features: "postgres,vault"
           - suffix: fscert
             features: "postgres"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,16 +78,16 @@ jobs:
       matrix:
         variant:
           - suffix: aws
-            features: "postgres,aws-secrets,acme"
+            features: "postgres,aws"
             description: "PostgreSQL database with AWS Secrets Manager and Route53 DNS support"
           - suffix: gcp
-            features: "postgres,gcp-secrets,acme"
+            features: "postgres,gcp"
             description: "PostgreSQL database with GCP Secret Manager and Cloud DNS support"
           - suffix: azure
-            features: "postgres,azure-kv,acme"
+            features: "postgres,azure"
             description: "PostgreSQL database with Azure Key Vault and Azure DNS support"
           - suffix: vault
-            features: "postgres,vault,acme"
+            features: "postgres,vault"
             description: "PostgreSQL database with HashiCorp Vault / OpenBao token material storage"
           - suffix: fscert
             features: "postgres"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ repository rulesets to require the status check named
 unconventional commit subjects out of protected branches, where they would
 otherwise be ignored by `git-cliff` and `release-plz`.
 
-They must also require **`CI Success`**, and require *only* that check from
+They must also require **`CI Success`**, and require _only_ that check from
 `CI.yml`. The jobs in `CI.yml` form several independent chains — the Rust jobs hang
 off `cargo-build`, the linters and scanners stand alone — deliberately, so that a
 network-dependent scanner is not the root of every Rust job. No single job therefore
@@ -93,7 +93,7 @@ rather than reshuffling an existing list:
 1. Merge the PR that introduces `ci-success`.
 2. Add **`CI Success`** to the required status checks on both rulesets.
 3. If individual `CI.yml` job names are ever added to a ruleset, remove them only
-   *after* `CI Success` is required — doing it in the other order leaves a window
+   _after_ `CI Success` is required — doing it in the other order leaves a window
    where a failing job blocks nothing.
 
 `ci-success` fails if any job it needs reported `failure` or `cancelled`. It also
@@ -124,18 +124,18 @@ is not proposed straight away — this is expected, not a broken schedule. Secur
 updates are exempt from cooldown. Because the cooldown decides when a bump is opened
 at all, it also decides when the auto-merge path above ever sees a new version.
 
-**This needs the repository setting *Allow auto-merge* to be on** — Settings →
+**This needs the repository setting _Allow auto-merge_ to be on** — Settings →
 General → Pull Requests. It is currently off by choice, so nothing is ever armed:
 the job warns and passes rather than failing, because a job that is red on every
-dependency bump only teaches people to ignore red. Any *other* failure to arm still
+dependency bump only teaches people to ignore red. Any _other_ failure to arm still
 fails the job. Turning the setting on does not weaken anything: the `Rules` ruleset
 still requires two approving reviews with `require_last_push_approval` before an
 armed pull request can merge.
 
 The workflow previously ran `gh pr review --approve` as well. That never worked —
 every run since it was added failed with `GitHub Actions is not permitted to approve
-pull requests (addPullRequestReview)`, which is the *Allow GitHub Actions to create
-and approve pull requests* setting rather than the workflow's `permissions:` block.
+pull requests (addPullRequestReview)`, which is the _Allow GitHub Actions to create
+and approve pull requests_ setting rather than the workflow's `permissions:` block.
 Because approve failed, the auto-merge step behind it was skipped every time. The
 step was removed rather than unblocked: a bot approval could not satisfy a two-review
 requirement anyway, and having CI approve its own dependency bumps is the thing the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,14 @@ postgres = ["history", "sea-orm?/sqlx-postgres"]
 sqlite = ["history", "sea-orm?/sqlx-sqlite"]
 mysql = ["history", "sea-orm?/sqlx-mysql"]
 vault = ["acme"]
-gcp-secrets = ["acme", "dep:google-cloud-auth", "dep:google-cloud-secretmanager-v1"]
-azure-kv = [
+gcp = ["acme", "dep:google-cloud-auth", "dep:google-cloud-secretmanager-v1"]
+azure = [
   "acme",
   "dep:azure_core",
   "dep:azure_identity",
   "dep:azure_security_keyvault_secrets",
 ]
-aws-secrets = [
+aws = [
   "acme",
   "dep:aws-config",
   "dep:aws-sdk-route53",

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN --mount=type=cache,target=/root/.cargo/registry,id=registry-cache-${TARGETPL
     cargo install --locked --root /usr/local cargo-auditable@${CARGO_AUDITABLE_VERSION}; \
     cargo install --locked --root /usr/local rust-audit-info@${RUST_AUDIT_INFO_VERSION}
 
-ARG FEATURES="postgres,aws-secrets,acme"
+ARG FEATURES="postgres,aws"
 
 # The release profile sets strip, lto and codegen-units = 1, each of which can drop
 # .dep-v0. A missing section yields a passing scan and an empty SBOM, so this must

--- a/README.md
+++ b/README.md
@@ -86,17 +86,17 @@ By default, the server will listen on `http://localhost:8000` using in-memory re
 
 The crate uses modular Cargo feature flags to gate optional production backend drivers:
 
-| Feature    | Description                                                                              | Default    |
-| ---------- | ---------------------------------------------------------------------------------------- | ---------- |
-| `memory`   | In-memory repositories, TTL cache, and static certificate loading.                       | ✅ Default |
-| `postgres` | SeaORM PostgreSQL database driver.                                                       | ❌ Opt-in  |
-| `sqlite`   | SeaORM SQLite database driver.                                                           | ❌ Opt-in  |
-| `mysql`    | SeaORM MySQL database driver.                                                            | ❌ Opt-in  |
-| `aws`      | AWS Secrets Manager and Route53 DNS-01 driver (transitively enables `acme`).              | ❌ Opt-in  |
-| `gcp`      | GCP Secret Manager and Cloud DNS driver (transitively enables `acme`).                   | ❌ Opt-in  |
-| `azure`    | Azure Key Vault and Azure DNS driver (transitively enables `acme`).                      | ❌ Opt-in  |
-| `vault`    | HashiCorp Vault / OpenBao driver (transitively enables `acme`).                          | ❌ Opt-in  |
-| `acme`     | ACME DNS-01 certificate manager driver.                                                  | ❌ Opt-in  |
+| Feature    | Description                                                                  | Default    |
+| ---------- | ---------------------------------------------------------------------------- | ---------- |
+| `memory`   | In-memory repositories, TTL cache, and static certificate loading.           | ✅ Default |
+| `postgres` | SeaORM PostgreSQL database driver.                                           | ❌ Opt-in  |
+| `sqlite`   | SeaORM SQLite database driver.                                               | ❌ Opt-in  |
+| `mysql`    | SeaORM MySQL database driver.                                                | ❌ Opt-in  |
+| `aws`      | AWS Secrets Manager and Route53 DNS-01 driver (transitively enables `acme`). | ❌ Opt-in  |
+| `gcp`      | GCP Secret Manager and Cloud DNS driver (transitively enables `acme`).       | ❌ Opt-in  |
+| `azure`    | Azure Key Vault and Azure DNS driver (transitively enables `acme`).          | ❌ Opt-in  |
+| `vault`    | HashiCorp Vault / OpenBao driver (transitively enables `acme`).              | ❌ Opt-in  |
+| `acme`     | ACME DNS-01 certificate manager driver.                                      | ❌ Opt-in  |
 
 To build with specific backend drivers, pass the matching feature flag(s):
 

--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ The simplest way to run the project is with [docker compose](https://docs.docker
 docker compose up --build
 ```
 
-This command will pull all required images and start the server compiled with default compose features (`postgres,aws-secrets,acme`).
+This command will pull all required images and start the server compiled with default compose features (`postgres,aws`).
 
 To pass custom Cargo feature flags during build, specify the `FEATURES` environment variable:
 
 ```sh
-FEATURES="mysql,aws-secrets,acme" docker compose --profile mysql up --build
+FEATURES="mysql,aws" docker compose --profile mysql up --build
 ```
 
 #### Running Manually
@@ -86,14 +86,17 @@ By default, the server will listen on `http://localhost:8000` using in-memory re
 
 The crate uses modular Cargo feature flags to gate optional production backend drivers:
 
-| Feature       | Description                                                             | Default    |
-| ------------- | ----------------------------------------------------------------------- | ---------- |
-| `memory`      | In-memory repositories, TTL cache, and store-based certificate storage. | ✅ Default |
-| `postgres`    | SeaORM PostgreSQL database driver.                                      | ❌ Opt-in  |
-| `sqlite`      | SeaORM SQLite database driver.                                          | ❌ Opt-in  |
-| `mysql`       | SeaORM MySQL database driver.                                           | ❌ Opt-in  |
-| `aws-secrets` | Route53 DNS-01, and AWS Secrets Manager drivers.                        | ❌ Opt-in  |
-| `acme`        | ACME DNS-01 certificate manager driver.                                 | ❌ Opt-in  |
+| Feature    | Description                                                                              | Default    |
+| ---------- | ---------------------------------------------------------------------------------------- | ---------- |
+| `memory`   | In-memory repositories, TTL cache, and static certificate loading.                       | ✅ Default |
+| `postgres` | SeaORM PostgreSQL database driver.                                                       | ❌ Opt-in  |
+| `sqlite`   | SeaORM SQLite database driver.                                                           | ❌ Opt-in  |
+| `mysql`    | SeaORM MySQL database driver.                                                            | ❌ Opt-in  |
+| `aws`      | AWS Secrets Manager and Route53 DNS-01 driver (transitively enables `acme`).              | ❌ Opt-in  |
+| `gcp`      | GCP Secret Manager and Cloud DNS driver (transitively enables `acme`).                   | ❌ Opt-in  |
+| `azure`    | Azure Key Vault and Azure DNS driver (transitively enables `acme`).                      | ❌ Opt-in  |
+| `vault`    | HashiCorp Vault / OpenBao driver (transitively enables `acme`).                          | ❌ Opt-in  |
+| `acme`     | ACME DNS-01 certificate manager driver.                                                  | ❌ Opt-in  |
 
 To build with specific backend drivers, pass the matching feature flag(s):
 
@@ -101,8 +104,8 @@ To build with specific backend drivers, pass the matching feature flag(s):
 # Run with PostgreSQL support available
 cargo run --features postgres
 
-# Run with AWS and ACME production integrations
-cargo run --features postgres,aws-secrets,acme
+# Run with AWS native integration (automatically enables ACME)
+cargo run --features postgres,aws
 ```
 
 For deployment guidance and backend tradeoffs, see [`docs/database-backends.md`](docs/database-backends.md).
@@ -187,18 +190,15 @@ The Status List Server is provisioned with a cryptographic certificate that is e
 - Certificate issuance and renewal are managed according to the configured renewal strategy.
 - Every day, a cron job checks whether the certificate should be renewed based on this strategy.
 - If the certificate is still considered valid according to the configured strategy, no renewal occurs; renewal is only triggered when necessary.
-- The server signing key and certificate chain are stored in one cryptographic-material backend selected by enabled Cargo features (`vault`, `aws-secrets`, or in-memory fallback).
+- The server signing key and certificate chain are stored in one cryptographic-material backend selected by enabled Cargo features (`vault`, `aws`, `gcp`, `azure`, or in-memory fallback).
 - Certificate material stays cached until provisioning or renewal invalidates it. Signing-key reads can be cached with `APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL`; set it to `0` to force private-key reads to bypass the material cache.
 - Parsed certificate chains stay cached in memory until certificate provisioning or renewal replaces them.
 
 **Provisioning Modes:**
 
-- `server.cert.provisioning_strategy = "acme"` requests and renews certificates through ACME.
-- `server.cert.provisioning_strategy = "store"` loads externally managed certificate material and persists it into the configured cryptographic-material backend.
-- Store provisioning infers filesystem loading when `server.cert.store.certificate_path` and `signing_key_path` are configured.
-- Store provisioning infers storage-backed loading when `server.cert.store.certificate_key` and `signing_key_key` are configured; those keys are read from the feature-selected cryptographic-material backend.
-- Filesystem store inputs may be PEM text or raw DER. Storage-backed store inputs may be PEM text or base64/base64url-encoded DER. Private keys must be PKCS#8 in PEM or DER form.
-- The renewal cron schedule is configured with `server.cert.renewal_cron_schedule`. For store provisioning, each scheduled run reloads the configured source and refreshes persisted material only when it changed.
+- **ACME Provisioning (`acme` feature)**: Requests, validates (via DNS-01 challenge), and automatically renews TLS certificates using Let's Encrypt / ACME directory. Built into cloud-native binary variants.
+- **Static Loading (`fscert` binary)**: Loads pre-existing certificate chain and private key directly into memory, without ACME overhead or DNS challenges.
+- If neither or only partial static material is provided, server startup immediately fails with a clear validation error.
 
 **Certificate Manager Builder Defaults:**
 

--- a/README.md
+++ b/README.md
@@ -92,11 +92,10 @@ The crate uses modular Cargo feature flags to gate optional production backend d
 | `postgres` | SeaORM PostgreSQL database driver.                                           | ❌ Opt-in  |
 | `sqlite`   | SeaORM SQLite database driver.                                               | ❌ Opt-in  |
 | `mysql`    | SeaORM MySQL database driver.                                                | ❌ Opt-in  |
-| `aws`      | AWS Secrets Manager and Route53 DNS-01 driver (transitively enables `acme`). | ❌ Opt-in  |
-| `gcp`      | GCP Secret Manager and Cloud DNS driver (transitively enables `acme`).       | ❌ Opt-in  |
-| `azure`    | Azure Key Vault and Azure DNS driver (transitively enables `acme`).          | ❌ Opt-in  |
-| `vault`    | HashiCorp Vault / OpenBao driver (transitively enables `acme`).              | ❌ Opt-in  |
-| `acme`     | ACME DNS-01 certificate manager driver.                                      | ❌ Opt-in  |
+| `aws`      | AWS Secrets Manager and Route53 DNS-01 driver                                | ❌ Opt-in  |
+| `gcp`      | GCP Secret Manager and Cloud DNS driver                                      | ❌ Opt-in  |
+| `azure`    | Azure Key Vault and Azure DNS driver                                         | ❌ Opt-in  |
+| `vault`    | HashiCorp Vault / OpenBao driver                                             | ❌ Opt-in  |
 
 To build with specific backend drivers, pass the matching feature flag(s):
 
@@ -196,8 +195,8 @@ The Status List Server is provisioned with a cryptographic certificate that is e
 
 **Provisioning Modes:**
 
-- **ACME Provisioning (`acme` feature)**: Requests, validates (via DNS-01 challenge), and automatically renews TLS certificates using Let's Encrypt / ACME directory. Built into cloud-native binary variants.
-- **Static Loading (`fscert` binary)**: Loads pre-existing certificate chain and private key directly into memory, without ACME overhead or DNS challenges.
+- **ACME Provisioning**: Requests, validates (via DNS-01 challenge), and automatically renews TLS certificates using Let's Encrypt / ACME directory. Built into cloud-native binary variants.
+- **Static Loading**: Loads pre-existing certificate chain and private key directly into memory, without ACME overhead or DNS challenges.
 - If neither or only partial static material is provided, server startup immediately fails with a clear validation error.
 
 **Certificate Manager Builder Defaults:**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        FEATURES: ${FEATURES:-postgres,aws-secrets,acme}
+        FEATURES: ${FEATURES:-postgres,aws}
     container_name: status-list-server
     env_file:
       - path: .env.template

--- a/docs/database-backends.md
+++ b/docs/database-backends.md
@@ -94,10 +94,10 @@ SET GLOBAL binlog_format = 'ROW';  -- then restart the server
 
 ## Compose Profiles
 
-`docker compose up` starts PostgreSQL by default and builds the container with `postgres,aws-secrets,acme` features enabled. To run the MySQL service instead:
+`docker compose up` starts PostgreSQL by default and builds the container with `postgres,aws` features enabled. To run the MySQL service instead:
 
 ```bash
-FEATURES="mysql,aws-secrets,acme" docker compose --profile mysql up --build
+FEATURES="mysql,aws" docker compose --profile mysql up --build
 ```
 
 There is no separate MariaDB service because MariaDB uses the same MySQL-driver path. Connect to a MariaDB host by setting `APP_DATABASE__BACKEND=mysql`, `APP_DATABASE__HOST`, `APP_DATABASE__PORT`, `APP_DATABASE__USERNAME`, `APP_DATABASE__PASSWORD`, and `APP_DATABASE__NAME`. For local/custom deployments, a `mysql://` `APP_DATABASE__URL` is still supported when no split database fields are set.

--- a/docs/deployment-runbook.md
+++ b/docs/deployment-runbook.md
@@ -25,15 +25,16 @@ The vulnerability gate blocks on any HIGH or CRITICAL finding that survives the 
 
 The release workflow publishes **5 multi-arch image variants** with distinct suffixes for different cloud providers and secret storage models. See the image variant matrix in `values.yaml` for the full description of each variant. The chart's empty-tag default resolves to the published AWS variant, not to an unsuffixed image tag.
 
-| Trigger              | Image Tags                                                                   | Applied                   |
-| -------------------- | ---------------------------------------------------------------------------- | ------------------------- |
-| Manual dispatch      | `sha-<short_sha>-<variant>`                                                  | At build                  |
-| Release tag `v*.*.*` | `sha-<short_sha>-<variant>`                                                  | At build                  |
-| Release tag `v*.*.*` | `<version>-<variant>`, `<major>.<minor>-<variant>`, `latest-<variant>`       | After the scan passes     |
+| Trigger              | Image Tags                                                             | Applied               |
+| -------------------- | ---------------------------------------------------------------------- | --------------------- |
+| Manual dispatch      | `sha-<short_sha>-<variant>`                                            | At build              |
+| Release tag `v*.*.*` | `sha-<short_sha>-<variant>`                                            | At build              |
+| Release tag `v*.*.*` | `<version>-<variant>`, `<major>.<minor>-<variant>`, `latest-<variant>` | After the scan passes |
 
 Where `<variant>` is one of: `aws`, `gcp`, `azure`, `vault`, `fscert`.
 
 Examples for tag `v1.2.0`:
+
 - Version tags: `1.2.0-aws`, `1.2.0-gcp`, `1.2.0-azure`, `1.2.0-vault`, `1.2.0-fscert`
 - Short version tags: `1.2-aws`, `1.2-gcp`, `1.2-azure`, `1.2-vault`, `1.2-fscert`
 - Latest tags: `latest-aws`, `latest-gcp`, `latest-azure`, `latest-vault`, `latest-fscert`
@@ -64,7 +65,7 @@ To select a variant, set the image tag with the appropriate suffix in your Helm 
 # values.yaml override
 statuslist:
   image:
-    tag: "1.2.0-vault"  # Use Vault variant
+    tag: "1.2.0-vault" # Use Vault variant
 ```
 
 ### Production Deploy

--- a/docs/secrets-backends.md
+++ b/docs/secrets-backends.md
@@ -4,13 +4,13 @@ The server stores lifecycle-coupled cryptographic material in one backend by def
 
 The supported backends include:
 
-- **HashiCorp Vault / OpenBao** (KV v2 engine, feature flag: `vault`)
-- **GCP Secret Manager** (feature flag: `gcp-secrets`)
-- **Azure Key Vault** (feature flag: `azure-kv`)
-- **AWS Secrets Manager** (feature flag: `aws-secrets`)
+- **HashiCorp Vault / OpenBao** (KV v2 engine, feature flag: `vault`, transitively enables `acme`)
+- **GCP Secret Manager** (feature flag: `gcp`, transitively enables `acme`)
+- **Azure Key Vault** (feature flag: `azure`, transitively enables `acme`)
+- **AWS Secrets Manager** (feature flag: `aws`, transitively enables `acme`)
 - **In-Memory** (for development and testing)
 
-Backend selection is controlled by enabled Cargo features. Builds with `vault` use Vault/OpenBao. Builds with `aws-secrets` and without `vault` use AWS Secrets Manager. Builds without either backend feature use in-memory storage for local development and tests.
+Backend selection is controlled by enabled Cargo features. Builds with `vault` use Vault/OpenBao. Builds with `aws` and without `vault` use AWS Secrets Manager. Builds without either backend feature use in-memory storage for local development and tests.
 
 ## HashiCorp Vault & OpenBao (KV v2)
 
@@ -226,7 +226,7 @@ To test the Kubernetes authentication workflow against a local Vault dev server:
    APP_VAULT__ADDR=http://127.0.0.1:8200 \
    APP_VAULT__K8S_ROLE=status-list-role \
    APP_VAULT__K8S_TOKEN_PATH=/tmp/k8s-token.jwt \
-   cargo run --features "vault,postgres,acme"
+   cargo run --features "vault,postgres"
    ```
 
 ### Automated Token Lifecycle & Resilience
@@ -249,7 +249,7 @@ Vault authentication and token operations emit OpenTelemetry counters for succes
 
 ## GCP Secret Manager
 
-When compiled with the `gcp-secrets` feature flag, secrets are stored in GCP Secret Manager.
+When compiled with the `gcp` feature flag, secrets are stored in GCP Secret Manager.
 
 ### Configuration Variables
 
@@ -302,7 +302,7 @@ GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json
 
 ## Azure Key Vault
 
-When compiled with the `azure-kv` feature flag, secrets are stored in Azure Key Vault.
+When compiled with the `azure` feature flag, secrets are stored in Azure Key Vault.
 
 ### Configuration Variables
 
@@ -349,7 +349,7 @@ APP_SERVER__CERT__SIGNING_KEY_CACHE_TTL=300
 
 ## AWS Secrets Manager
 
-When compiled with the `aws-secrets` feature flag:
+When compiled with the `aws` feature flag:
 
 ```env
 AWS_ACCESS_KEY_ID=test

--- a/docs/secrets-backends.md
+++ b/docs/secrets-backends.md
@@ -4,10 +4,10 @@ The server stores lifecycle-coupled cryptographic material in one backend by def
 
 The supported backends include:
 
-- **HashiCorp Vault / OpenBao** (KV v2 engine, feature flag: `vault`, transitively enables `acme`)
-- **GCP Secret Manager** (feature flag: `gcp`, transitively enables `acme`)
-- **Azure Key Vault** (feature flag: `azure`, transitively enables `acme`)
-- **AWS Secrets Manager** (feature flag: `aws`, transitively enables `acme`)
+- **HashiCorp Vault / OpenBao** (KV v2 engine, feature flag: `vault`)
+- **GCP Secret Manager** (feature flag: `gcp`)
+- **Azure Key Vault** (feature flag: `azure`)
+- **AWS Secrets Manager** (feature flag: `aws`)
 - **In-Memory** (for development and testing)
 
 Backend selection is controlled by enabled Cargo features. Builds with `vault` use Vault/OpenBao. Builds with `aws` and without `vault` use AWS Secrets Manager. Builds without either backend feature use in-memory storage for local development and tests.

--- a/docs/supply-chain.md
+++ b/docs/supply-chain.md
@@ -211,7 +211,7 @@ cargo install --locked --version 0.5.4 rust-audit-info
 rustup target add x86_64-unknown-linux-musl
 cargo auditable build --locked --release \
   --target x86_64-unknown-linux-musl \
-  --features "postgres,aws-secrets,acme"
+  --features "postgres,aws"
 
 rust-audit-info target/x86_64-unknown-linux-musl/release/status-list-server \
   | jq '.packages | length'
@@ -235,7 +235,7 @@ done
 
 The steps are in the [Operator Guide](#operator-guide). Two things that section leaves out:
 
-Read the full report artifact, not just the gate output — the gate applies a severity floor and the exception ledger, and the artifact does not, so a finding can be real and simply below the threshold. And when judging whether an advisory applies, the relevant build is the image's feature set (`postgres,aws-secrets,acme`, the `ARG FEATURES` default in the `Dockerfile`), which is narrower than what `cargo build --all-features` compiles.
+Read the full report artifact, not just the gate output — the gate applies a severity floor and the exception ledger, and the artifact does not, so a finding can be real and simply below the threshold. And when judging whether an advisory applies, the relevant build is the image's feature set (`postgres,aws`, the `ARG FEATURES` default in the `Dockerfile`), which is narrower than what `cargo build --all-features` compiles.
 
 Do not add an exception for a finding you could simply fix. An exception is for a fix that does not exist yet, cannot be taken yet, or a finding that does not apply — and the `statement` should record which of those three it is.
 
@@ -315,11 +315,11 @@ Findings about crates belong to `cargo-audit` and are fixed at the lockfile. Fin
 
 ### The Release Feature Set
 
-Source-level CI compiles two feature sets: `--all-features`, and `--no-default-features --features memory`. The image is built with neither. Its `ARG FEATURES="postgres,aws-secrets,acme"` names a combination that was reachable from no CI job at all.
+Source-level CI compiles two feature sets: `--all-features`, and `--no-default-features --features memory`. The image is built with neither. Its `ARG FEATURES="postgres,aws"` names a combination that was reachable from no CI job at all.
 
-Nothing validated that string. `ARG FEATURES` is a bare string handed to `cargo build` inside the image build, so a value naming no real feature is caught only when someone cuts a release — and it had one. The value was `postgres,aws,acme`, and `Cargo.toml` defines `aws-secrets`, not `aws`, so `cargo` would have rejected it outright.
+Nothing validated that string. `ARG FEATURES` is a bare string handed to `cargo build` inside the image build, so a value naming no real feature is caught only when someone cuts a release.
 
-`--all-features` does not stand in for the real set either. Cargo unifies features across the dependency graph, so enabling every feature of this crate compiles its shared dependencies with the union of theirs: `--all-features` turns on `postgres`, `sqlite`, and `mysql` together and builds `sea-orm` with all three `sqlx` backends, where the release set builds it with `sqlx-postgres` alone. The secret backends behave the same way — `--all-features` compiles `vault`, `gcp-secrets`, `azure-kv`, and `aws-secrets` at once; the image ships `aws-secrets` by itself.
+`--all-features` does not stand in for the real set either. Cargo unifies features across the dependency graph, so enabling every feature of this crate compiles its shared dependencies with the union of theirs: `--all-features` turns on `postgres`, `sqlite`, and `mysql` together and builds `sea-orm` with all three `sqlx` backends, where the release set builds it with `sqlx-postgres` alone. The secret backends behave the same way — `--all-features` compiles `vault`, `gcp`, `azure`, and `aws` at once; the image ships `aws` by itself.
 
 This is the shape worth remembering: **enabling every feature is not a superset of shipping some of them.** Unification builds the graph differently, and `#[cfg(not(...))]` branches exist only in the absence of a feature — so `--all-features` is its own configuration, not an upper bound on the ones you ship.
 

--- a/docs/supply-chain.md
+++ b/docs/supply-chain.md
@@ -8,12 +8,12 @@ The pipeline is `.github/workflows/deploy.yml`. **If a release is blocked and yo
 
 **Where the evidence is.** On the failed run, in artifacts kept for the repository's retention period (90 days by default):
 
-| You want                             | Artifact                 | File                                       |
-| ------------------------------------ | ------------------------ | ------------------------------------------ |
-| The exact blocking set               | `container-scan-reports` | `trivy-gate-findings-<arch>.json`          |
-| Everything HIGH/CRITICAL, pre-ledger | `container-scan-reports` | `trivy-highcrit-all-<arch>.json`           |
-| The full scan, all severities        | `container-scan-reports` | `trivy-image-report-<arch>.json` / `.txt`  |
-| The published SBOM                   | `container-sboms`        | `sbom-<arch>.json`                         |
+| You want                             | Artifact                 | File                                      |
+| ------------------------------------ | ------------------------ | ----------------------------------------- |
+| The exact blocking set               | `container-scan-reports` | `trivy-gate-findings-<arch>.json`         |
+| Everything HIGH/CRITICAL, pre-ledger | `container-scan-reports` | `trivy-highcrit-all-<arch>.json`          |
+| The full scan, all severities        | `container-scan-reports` | `trivy-image-report-<arch>.json` / `.txt` |
+| The published SBOM                   | `container-sboms`        | `sbom-<arch>.json`                        |
 
 Provenance and SBOM are also attached to the image itself: `docker buildx imagetools inspect <ref> --format '{{ json .Provenance }}'`.
 
@@ -29,7 +29,7 @@ Provenance and SBOM are also attached to the image itself: `docker buildx imaget
 
 A dispatch run exercises the build, the scan and every assertion without releasing: `promote-tags` and `deploy` both require `github.event_name == 'push'`, so a dispatch promotes nothing and deploys nothing even when aimed at a tag ref. It does still push `sha-<short>-<variant>` images to GHCR — it publishes images, it just never advertises or ships them.
 
-The image is pushed before it can be scanned. That is not a tradeoff, it is a constraint: BuildKit attestations can only be produced when pushing directly to a registry, because the local image store cannot hold an image carrying attestations. What the pipeline controls is not whether the artifact exists in GHCR, but what it is *called*. An image that has not passed the scan is reachable only by its commit SHA tag. It never becomes `latest`, never becomes `v1.2.3`, and never reaches production.
+The image is pushed before it can be scanned. That is not a tradeoff, it is a constraint: BuildKit attestations can only be produced when pushing directly to a registry, because the local image store cannot hold an image carrying attestations. What the pipeline controls is not whether the artifact exists in GHCR, but what it is _called_. An image that has not passed the scan is reachable only by its commit SHA tag. It never becomes `latest`, never becomes `v1.2.3`, and never reaches production.
 
 That distinction matters more than it first appears. Blocking only the deploy would still leave `latest` and the semver tags resolving to a rejected artifact, so every consumer that is not this pipeline — anything pulling `latest`, any other chart, any developer running `docker pull` — would receive precisely the image the scan refused. Withholding the tags is what makes the refusal mean anything outside this workflow.
 
@@ -48,7 +48,7 @@ That distinction matters more than it first appears. Blocking only the deploy wo
 
 `Derive reports` produces two HIGH/CRITICAL sets per architecture: `trivy-highcrit-all-<arch>.json` before the exception ledger and `trivy-gate-findings-<arch>.json` after it. The gate reports the difference, so a green result distinguishes "nothing was found" from "everything found was accepted".
 
-Three properties of that ordering are deliberate. The scan runs before the SBOM fetch, because registry metadata is a separate failure domain and a transient `imagetools` error must not cost the reports a responder is being told to go and read. Reports and artifacts publish *before* any assertion runs, both under `if: always()`, so a failing assertion still leaves the full report to triage — as two artifacts rather than one, so a lost SBOM cannot take the scan results down with it.
+Three properties of that ordering are deliberate. The scan runs before the SBOM fetch, because registry metadata is a separate failure domain and a transient `imagetools` error must not cost the reports a responder is being told to go and read. Reports and artifacts publish _before_ any assertion runs, both under `if: always()`, so a failing assertion still leaves the full report to triage — as two artifacts rather than one, so a lost SBOM cannot take the scan results down with it.
 
 And every view is derived from that architecture's single scan by `trivy convert` rather than by re-scanning, so the table a maintainer reads and the set the gate evaluates are provably the same data. The gate renders its table from `trivy-gate-findings-<arch>.json` itself rather than re-applying the same filter to the full report, so the count in the summary, the table in the log, and the exit code cannot disagree about what blocks.
 
@@ -70,7 +70,7 @@ A clean scan is the expected result on every run, and that is the problem: a gat
 
 So `scan-image` runs a self-test immediately before the gate, invoking `scripts/vuln-gate.sh` — the same script, flags and `trivy` binary the real gate uses one step later — against two fixtures in `scripts/testdata/`. A fixture holding one CRITICAL **must** fail the gate; a clean one **must** pass, because a gate that blocks unconditionally is equally broken and would otherwise surface mid-release.
 
-Exit status alone is not sufficient evidence. A missing fixture, a `trivy` not on `PATH` and a malformed report all exit non-zero, so checking only the exit code would let a fixture that was never committed read as a *passing* self-test — the absence-reads-as-success failure the step exists to prevent, occurring inside it. The step therefore also asserts the fixture exists, holds at least one finding, and that the gate's output names the vulnerability ID it was given. Only a gate that really evaluated the report can print that ID back.
+Exit status alone is not sufficient evidence. A missing fixture, a `trivy` not on `PATH` and a malformed report all exit non-zero, so checking only the exit code would let a fixture that was never committed read as a _passing_ self-test — the absence-reads-as-success failure the step exists to prevent, occurring inside it. The step therefore also asserts the fixture exists, holds at least one finding, and that the gate's output names the vulnerability ID it was given. Only a gate that really evaluated the report can print that ID back.
 
 The gate is a script rather than an inline step for the same reason. Inline, the self-test and the gate would be two copies of a flag list that must not drift, and the drift would be undetectable: a self-test passing against different flags than the real gate uses tells you nothing about the real gate.
 
@@ -99,13 +99,13 @@ The scan binds to `...@sha256:<digest>`. `promote-tags` retags that same digest,
 
 This matters because tags are mutable. Binding the scan to a digest and then deploying by tag would leave a window in which a re-run or a manual push could replace the image in between.
 
-Two `concurrency` groups back that up. The workflow-level group is keyed on the ref, so re-runs of the same tag do not overlap. The `deploy` job declares a second one keyed on `deploy-production`, because two tags pushed in quick succession are *different* refs and the workflow-level group would let both drive `helm upgrade --wait --rollback-on-failure` against the same release at once. What guarantees production runs the scanned artifact is the digest binding; what the second group prevents is two deploys racing for the Helm release lock.
+Two `concurrency` groups back that up. The workflow-level group is keyed on the ref, so re-runs of the same tag do not overlap. The `deploy` job declares a second one keyed on `deploy-production`, because two tags pushed in quick succession are _different_ refs and the workflow-level group would let both drive `helm upgrade --wait --rollback-on-failure` against the same release at once. What guarantees production runs the scanned artifact is the digest binding; what the second group prevents is two deploys racing for the Helm release lock.
 
 ### Which Architectures Are Scanned
 
-Every architecture the release publishes. The pushed digest names a multi-platform *index*, not an image, so `scan-image` resolves each child manifest with `docker buildx imagetools inspect --raw` and scans `repo@<manifest-digest>` per architecture. Scanning the index directly would leave the choice of platform to Trivy's default — one architecture, silently.
+Every architecture the release publishes. The pushed digest names a multi-platform _index_, not an image, so `scan-image` resolves each child manifest with `docker buildx imagetools inspect --raw` and scans `repo@<manifest-digest>` per architecture. Scanning the index directly would leave the choice of platform to Trivy's default — one architecture, silently.
 
-Scanning one architecture and inferring the other is not sound, though it looks it. The two images share a lockfile, and the runtime stage is `FROM scratch` with no OS packages, so it is tempting to conclude the package sets must match. They are built by different builder images to different Rust targets, and `cargo auditable` records the graph Cargo *resolved for that target* — a lockfile is the union across targets, not the per-target set. An advisory reaching only `linux/arm64` would have been promoted and deployed without ever crossing the gate.
+Scanning one architecture and inferring the other is not sound, though it looks it. The two images share a lockfile, and the runtime stage is `FROM scratch` with no OS packages, so it is tempting to conclude the package sets must match. They are built by different builder images to different Rust targets, and `cargo auditable` records the graph Cargo _resolved for that target_ — a lockfile is the union across targets, not the per-target set. An advisory reaching only `linux/arm64` would have been promoted and deployed without ever crossing the gate.
 
 The resolution step fails if the index does not contain exactly one manifest per requested architecture, which is a real condition with a real cause: the build stopped producing a platform this pipeline claims to scan.
 
@@ -258,9 +258,9 @@ The validator has its own tests in `scripts/tests/`, which CI runs before the va
 
 It also rejects **unknown keys inside an entry**, which is the check that matters most and the least obvious. Trivy silently ignores keys it does not recognise, so a one-character typo is a scope change rather than an error: `path:` instead of `paths:` leaves the entry with no path filter, and an entry with no path filter applies everywhere. Measured against this chart, that typo takes `KSV-0014` from 8 remaining findings to 0 — an exception written to cover one vendored subchart silently starts suppressing the rule repository-wide, and both the file and the scan still look correct.
 
-The same widening is reachable by simply **omitting** `paths`, so misconfiguration entries are required to carry a non-empty `paths` or `purls` list. Catching the typo but not the omission would leave the easier route open. Vulnerability entries are exempt from that requirement: a `FROM scratch` image holding one binary has no meaningful path to scope a crate advisory to, so an unscoped entry is the intended form there and demanding `paths: ['**']` would be noise. Where either key *is* present, in any section, it must be a non-empty list of non-empty strings — `paths: []` is unscoped just as surely as no `paths` at all.
+The same widening is reachable by simply **omitting** `paths`, so misconfiguration entries are required to carry a non-empty `paths` or `purls` list. Catching the typo but not the omission would leave the easier route open. Vulnerability entries are exempt from that requirement: a `FROM scratch` image holding one binary has no meaningful path to scope a crate advisory to, so an unscoped entry is the intended form there and demanding `paths: ['**']` would be noise. Where either key _is_ present, in any section, it must be a non-empty list of non-empty strings — `paths: []` is unscoped just as surely as no `paths` at all.
 
-Duplicate IDs are deliberately *not* rejected: the same rule legitimately appears more than once when it is scoped to different `paths`.
+Duplicate IDs are deliberately _not_ rejected: the same rule legitimately appears more than once when it is scoped to different `paths`.
 
 ### Two Ledgers
 
@@ -307,7 +307,7 @@ What it adds today is narrower than that overlap suggests:
 - It detects drift if the image was built from a lockfile that source-level CI never audited.
 - It binds a scan result to an image digest, so what was checked and what runs are the same artifact.
 
-There is one further capability often claimed for a setup like this — catching advisories published *after* merge, with no source change — and this pipeline does **not** deliver it. `deploy.yml` triggers only on release tags and on manual dispatch, so the image scan runs **once per release** and never again for that image. A newly published advisory first surfaces whenever someone next cuts a release, which may be weeks later and is not tied to the advisory at all.
+There is one further capability often claimed for a setup like this — catching advisories published _after_ merge, with no source change — and this pipeline does **not** deliver it. `deploy.yml` triggers only on release tags and on manual dispatch, so the image scan runs **once per release** and never again for that image. A newly published advisory first surfaces whenever someone next cuts a release, which may be weeks later and is not tied to the advisory at all.
 
 The source-level checks are what actually run continuously here: `cargo-audit`, `cargo-deny`, and `cargo-vet` query RustSec on every pull request. They cover the dependency tree rather than the artifact, so they will usually see a crate advisory first — but only when something triggers CI. Neither path notices an advisory published against an already-released image while nobody is pushing code. Closing that needs a scheduled re-scan of the deployed digest, tracked in [#410](https://github.com/adorsys/status-list-server/issues/410).
 
@@ -335,4 +335,4 @@ This is the shape worth remembering: **enabling every feature is not a superset 
 - **The Trivy vulnerability database is fetched fresh on every run**, unauthenticated, from a third party, at release time. That makes a network blip or a GHCR rate limit into a failed release, and it surfaces as the security gate failing, which reads as "a vulnerability was found". Tracked in [#405](https://github.com/adorsys/status-list-server/issues/405).
 - **The builder-stage audit assertion runs only on the release path.** `deploy.yml` does not run on pull requests, so a change that breaks the auditable build is green on the PR and fails during a release. Tracked against [#316](https://github.com/adorsys/status-list-server/issues/316).
 - **An expired ignore entry is a warning, not a failure.** `scripts/check-trivyignore.py` enforces the required fields but only warns when a date has passed, because an expired entry has already stopped suppressing anything. Whether a lapsed entry should block CI is a policy question that belongs with the scheduled re-scan ([#410](https://github.com/adorsys/status-list-server/issues/410)), since that is what would give advance warning before a release hits it.
-- **There is no break-glass for the gate.** With `ignore-unfixed` off and any HIGH or CRITICAL blocking, a newly published unfixed advisory in a linked crate makes it impossible to cut *any* release, including a security hotfix for something unrelated. The only path is landing a `.trivyignore.yaml` entry through pull request CI — which is the file this document warns hardest against editing under incident pressure. `workflow_dispatch` deliberately cannot release, so it is not an override. A dispatch input gated on the `production` environment's reviewers, recording the justification in the run summary, would close this; it is a policy decision rather than a mechanical one and has not been made.
+- **There is no break-glass for the gate.** With `ignore-unfixed` off and any HIGH or CRITICAL blocking, a newly published unfixed advisory in a linked crate makes it impossible to cut _any_ release, including a security hotfix for something unrelated. The only path is landing a `.trivyignore.yaml` entry through pull request CI — which is the file this document warns hardest against editing under incident pressure. `workflow_dispatch` deliberately cannot release, so it is not an override. A dispatch input gated on the `production` environment's reviewers, recording the justification in the run summary, would close this; it is a policy decision rather than a mechanical one and has not been made.

--- a/helm/README.md
+++ b/helm/README.md
@@ -71,12 +71,12 @@ The default secret/credential provisioning path is **External Secrets Operator (
 ```yaml
 statuslist:
   aws:
-    mountCredentials: true    # default: mount the ESO-provisioned aws-credentials-secret under /home/nobody/.aws
-    region: ""                # plain, non-secret; renders APP_AWS__REGION
+    mountCredentials: true # default: mount the ESO-provisioned aws-credentials-secret under /home/nobody/.aws
+    region: "" # plain, non-secret; renders APP_AWS__REGION
     credentialsSecret:
-      remoteKey: "statuslist-aws-credentials"   # SecretStore key holding both AWS shared files
-      credentialsProperty: "CREDENTIALS"        # property in remoteKey with the credentials file
-      configProperty: "CONFIG"                  # property in remoteKey with the config file
+      remoteKey: "statuslist-aws-credentials" # SecretStore key holding both AWS shared files
+      credentialsProperty: "CREDENTIALS" # property in remoteKey with the credentials file
+      configProperty: "CONFIG" # property in remoteKey with the config file
 ```
 
 `statuslist.aws.region` is a plain (non-secret) value; `APP_AWS__REGION` is rendered whenever an effective region is set, independent of `secretStore.provider` and `mountCredentials`.
@@ -86,6 +86,7 @@ statuslist:
 **Upgrade compatibility:** The effective `APP_AWS__REGION` resolves as `statuslist.aws.region`, falling back to the legacy `secretStore.aws.region` and then `eu-central-1`. Installations that previously set only `secretStore.aws.region` keep that region for the application across upgrade.
 
 When `statuslist.aws.mountCredentials=true` (the default) **and** `externalSecret.enabled=true` (the default ESO path), the chart itself renders a second `ExternalSecret` that provisions `aws-credentials-secret` — the exact Secret the Deployment's credential volume references. It synchronizes two keys into that Secret:
+
 - `credentials` ← `remoteKey`/`credentialsProperty` (the AWS shared credentials file, INI format, e.g. `[default]\naws_access_key_id=...\naws_secret_access_key=...`)
 - `config` ← `remoteKey`/`configProperty` (the AWS shared config file)
 
@@ -144,8 +145,8 @@ secretStore:
   enabled: true
   provider: aws
   aws:
-    service: SecretsManager   # SecretsManager | ParameterStore
-    region: "eu-central-1"    # applies to the AWS SecretStore; APP_AWS__REGION falls back to statuslist.aws.region
+    service: SecretsManager # SecretsManager | ParameterStore
+    region: "eu-central-1" # applies to the AWS SecretStore; APP_AWS__REGION falls back to statuslist.aws.region
   vault:
     server: ""
     path: "secret"
@@ -156,14 +157,14 @@ secretStore:
   azure:
     tenantId: ""
     vaultUrl: ""
-    authType: ""                  # ServicePrincipal | ManagedIdentity | WorkloadIdentity
-    environmentType: ""           # optional: PublicCloud (default) | USGovernmentCloud | ChinaCloud | GermanCloud
-    identityId: ""                # ManagedIdentity: select one of multiple managed identities
+    authType: "" # ServicePrincipal | ManagedIdentity | WorkloadIdentity
+    environmentType: "" # optional: PublicCloud (default) | USGovernmentCloud | ChinaCloud | GermanCloud
+    identityId: "" # ManagedIdentity: select one of multiple managed identities
     serviceAccountRef:
-      name: ""                    # WorkloadIdentity: ESO's own least-privilege identity
+      name: "" # WorkloadIdentity: ESO's own least-privilege identity
       namespace: ""
-    authSecretRef: {}             # ServicePrincipal: clientId/clientSecret/tenantId secret selectors
-  raw: {}                         # provider body passthrough (rendered directly under spec.provider)
+    authSecretRef: {} # ServicePrincipal: clientId/clientSecret/tenantId secret selectors
+  raw: {} # provider body passthrough (rendered directly under spec.provider)
 ```
 
 - **aws** (`SecretsManager` or `ParameterStore`): `service` and `region`. `region` falls back to the effective app region when empty.

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -30,10 +30,10 @@ statuslist:
     #
     # | Tag Suffix | Cargo Features | Description | Primary Use Case |
     # |------------|----------------|-------------|------------------|
-    # | -aws       | postgres,aws-secrets,acme | PostgreSQL database with AWS Secrets Manager and Route53 DNS support | AWS EKS native deployments |
-    # | -gcp       | postgres,gcp-secrets,acme | PostgreSQL database with GCP Secret Manager and Cloud DNS support | GCP GKE native deployments |
-    # | -azure     | postgres,azure-kv,acme | PostgreSQL database with Azure Key Vault and Azure DNS support | Azure AKS native deployments |
-    # | -vault     | postgres,vault,acme | PostgreSQL database with HashiCorp Vault / OpenBao token material storage | Vault-backed on-prem or multi-cloud deployments |
+    # | -aws       | postgres,aws | PostgreSQL database with AWS Secrets Manager and Route53 DNS support | AWS EKS native deployments |
+    # | -gcp       | postgres,gcp | PostgreSQL database with GCP Secret Manager and Cloud DNS support | GCP GKE native deployments |
+    # | -azure     | postgres,azure | PostgreSQL database with Azure Key Vault and Azure DNS support | Azure AKS native deployments |
+    # | -vault     | postgres,vault | PostgreSQL database with HashiCorp Vault / OpenBao token material storage | Vault-backed on-prem or multi-cloud deployments |
     # | -fscert    | postgres | PostgreSQL database with filesystem-mounted token signing keys and certificates | Constrained / air-gapped environments using external secret injection |
     #
     # Tag format: <version>-<suffix> (e.g., 1.2.0-aws, 1.2.0-gcp)

--- a/observability/LIVE_TESTING.md
+++ b/observability/LIVE_TESTING.md
@@ -158,7 +158,7 @@ cannot resolve the datasource.
 ```yaml
 datasources:
   - name: Prometheus
-    uid: prometheus            # <-- must match the dashboard panels
+    uid: prometheus # <-- must match the dashboard panels
     type: prometheus
     access: proxy
     url: http://prometheus:9090

--- a/observability/README.md
+++ b/observability/README.md
@@ -63,7 +63,7 @@ its Prometheus datasource by UID `prometheus` (see
 `dashboards/provisioning/datasources.yml`). Any environment that loads this
 dashboard — including a production/managed Grafana — **must** register its
 Prometheus datasource with exactly that UID, or the panels will not resolve.
-Do not rely on the datasource *name*; Grafana matches the committed UID.
+Do not rely on the datasource _name_; Grafana matches the committed UID.
 
 ## Retention requirement
 

--- a/observability/runbooks/error-budget.md
+++ b/observability/runbooks/error-budget.md
@@ -8,8 +8,8 @@ Alerts:
 
 The 30d error budget (`sli:error_budget:success:30d`) dropped below 10% remaining.
 This means the trailing 30-day 5xx rate is close to consuming the full 0.5%
-budget. Unlike the fast/slow burn alerts (which fire on a *current* burn rate),
-this fires on the *cumulative* window: the budget has largely been spent, so any
+budget. Unlike the fast/slow burn alerts (which fire on a _current_ burn rate),
+this fires on the _cumulative_ window: the budget has largely been spent, so any
 further degradation risks breaching the SLO for the month.
 
 ## Ranked likely causes

--- a/observability/slo/README.md
+++ b/observability/slo/README.md
@@ -35,22 +35,24 @@ set keeps cardinality in check.
 
 ## Per-SLI table
 
-| SLI                  | Metric source                                                                                                 | Example target                   | Window | Alert windows / burn thresholds                                                      |
-| -------------------- | ------------------------------------------------------------------------------------------------------------- | -------------------------------- | ------ | ----------------------------------------------------------------------------         |
-| Request latency      | `http_server_duration_seconds` histogram                                                                      | p95 < **300 ms**                 | 30d    | fast page: 1h > 300ms **and** 5m > 300ms; slow warn: 6h > 300ms **and** 30m > 300ms  |
-| Error rate           | `sum(rate(http_server_requests_total{status_class="5xx"}[...])) / sum(rate(http_server_requests_total[...]))` | ≥ **99.5%** success (≤ 0.5% 5xx) | 30d    | fast page: ≥14.4x (0.072) on 1h **and** 5m; slow warn: ≥6x (0.030) on 6h **and** 30m |
-| Cache hit ratio      | `status_list_cache_hits_total / (hits_total + misses_total)`                                                  | ≥ **85%**                        | 5m     | warn-only (degradation, not outage)                                                  |
-| DB latency           | `db_query_duration_seconds` histogram                                                                         | p95 < **50 ms**                  | 30d    | fast page: 1h > 50ms **and** 5m > 50ms; slow warn: 6h > 50ms **and** 30m > 50ms      |
-| Cert expiry          | `cert_time_to_expiry_seconds` gauge                                                                           | renew before expiry              | –      | warn: ≤14d to expiry (op risk); page: ≤7d to expiry (imminent)                       |
-| Token-gen failure    | `token_generation_failures_total / token_generation_attempts_total`                                           | < **0.5%**                       | 30d    | fast page: ≥14.4x (0.072) on 1h **and** 5m; slow warn: ≥6x (0.030) on 6h **and** 30m |
+| SLI               | Metric source                                                                                                 | Example target                   | Window | Alert windows / burn thresholds                                                      |
+| ----------------- | ------------------------------------------------------------------------------------------------------------- | -------------------------------- | ------ | ------------------------------------------------------------------------------------ |
+| Request latency   | `http_server_duration_seconds` histogram                                                                      | p95 < **300 ms**                 | 30d    | fast page: 1h > 300ms **and** 5m > 300ms; slow warn: 6h > 300ms **and** 30m > 300ms  |
+| Error rate        | `sum(rate(http_server_requests_total{status_class="5xx"}[...])) / sum(rate(http_server_requests_total[...]))` | ≥ **99.5%** success (≤ 0.5% 5xx) | 30d    | fast page: ≥14.4x (0.072) on 1h **and** 5m; slow warn: ≥6x (0.030) on 6h **and** 30m |
+| Cache hit ratio   | `status_list_cache_hits_total / (hits_total + misses_total)`                                                  | ≥ **85%**                        | 5m     | warn-only (degradation, not outage)                                                  |
+| DB latency        | `db_query_duration_seconds` histogram                                                                         | p95 < **50 ms**                  | 30d    | fast page: 1h > 50ms **and** 5m > 50ms; slow warn: 6h > 50ms **and** 30m > 50ms      |
+| Cert expiry       | `cert_time_to_expiry_seconds` gauge                                                                           | renew before expiry              | –      | warn: ≤14d to expiry (op risk); page: ≤7d to expiry (imminent)                       |
+| Token-gen failure | `token_generation_failures_total / token_generation_attempts_total`                                           | < **0.5%**                       | 30d    | fast page: ≥14.4x (0.072) on 1h **and** 5m; slow warn: ≥6x (0.030) on 6h **and** 30m |
 
 ### Why these windows
+
 - **30d** for latency/error/DB/token/cert: matches the standard Google SRE "monthly
   rolling" objective. The **30d window feeds the long-term health metrics and budget gauges**
   (`sli:error_budget:success:30d`, `sli:token_gen_error_budget:30d`, `sli:cert_renewal_failure_rate:30d`); alerts use fast/slow burn or specific alert windows so a single incident does not consume the whole month at once.
-- **5m** for cache hit ratio: hit ratio is a *health* indicator that can turn over fast (a config change flips hit ratio within hours) and is alertable as degradation rather than burned revenue. A shorter 5m window makes the alert responsive to instant regressions.
+- **5m** for cache hit ratio: hit ratio is a _health_ indicator that can turn over fast (a config change flips hit ratio within hours) and is alertable as degradation rather than burned revenue. A shorter 5m window makes the alert responsive to instant regressions.
 
 ### Why these targets
+
 - **p95 < 300 ms latency**: the SLO from the artillery `load-test.yml` commits to
   p95 < 800 ms under load; production target is set tighter (300 ms) to leave
   headroom so the loaded test does not itself breach the objective.
@@ -92,7 +94,7 @@ rate, DB latency, token-gen). See `observability/prometheus/rules/alerting.rules
   degradation, not a blip. The short window is again 1/12 of the long window.
 - Each pair is an `and` of the long-window burn signal with its short-window
   confirmation. The long window guarantees the burn is significant; the short
-  window guarantees it is *still happening* (good reset time) and, because a
+  window guarantees it is _still happening_ (good reset time) and, because a
   severe incident drives the 1h/5m windows immediately, the **page fires before
   the warn** instead of arriving hours later.
 - **Cache hit ratio** is **warn-only**: it degrades availability but does not
@@ -135,7 +137,7 @@ on sustained degradation, on purpose, to avoid paging on a blip.
 1. Collect 30d of production data.
 2. Compare the `sli:*` recording rule output against these targets in Grafana.
 3. If an SLO is at 99.999% with zero near-misses, consider tightening; if it is
-   breached monthly, loosen the *target* (not the window) and add a runbook step
+   breached monthly, loosen the _target_ (not the window) and add a runbook step
    before widening the alert severity.
 4. Tune targets, then update this table, `alerting.rules.yml`, and re-run
    `promtool test rules`.
@@ -147,7 +149,7 @@ one file. A change to a target must be applied to **all** of them together, or
 dashboards and alerts drift from the documented objective:
 
 | Target               | Files that hard-code it                                                                                                                                      |
-| -----------------    | --------------------------------------------------------------------------------------------------------------------------------                             |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | 300 ms latency       | `alerting.rules.yml` (0.3), `dashboards/src/generate.mjs` (0.3), this doc                                                                                    |
 | 0.5% error budget    | `recording.rules.yml` (`0.005` denominator), `alerting.rules.yml` (0.072/0.030), `dashboards/src/generate.mjs` (0.005), this doc                             |
 | 85% cache hit        | `alerting.rules.yml` (0.85), `dashboards/src/generate.mjs` (0.85), this doc                                                                                  |

--- a/src/config.rs
+++ b/src/config.rs
@@ -183,7 +183,6 @@ pub struct ServerConfig {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct CertConfig {
-    pub provisioning_strategy: String,
     pub email: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub organization: Option<String>,
@@ -203,14 +202,18 @@ pub struct CertConfig {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct CertStoreConfig {
+    /// PEM certificate chain file path.
     #[serde(default)]
     pub certificate_path: Option<String>,
+    /// PKCS#8 PEM private key file path.
     #[serde(default)]
     pub signing_key_path: Option<String>,
+    /// Inline PEM certificate chain.
     #[serde(default)]
-    pub certificate_key: Option<String>,
+    pub certificate: Option<String>,
+    /// Inline PKCS#8 PEM private key.
     #[serde(default)]
-    pub signing_key_key: Option<String>,
+    pub signing_key: Option<String>,
 }
 
 /// DNS provider used to solve ACME DNS-01 challenges
@@ -1040,13 +1043,6 @@ fn base_builder() -> Result<ConfigBuilder<DefaultState>, ConfigError> {
     ))]
     let default_db_backend = "memory";
 
-    #[cfg(feature = "acme")]
-    let (default_provisioning_strategy, default_cert_path, default_key_path) =
-        ("acme", Option::<String>::None, Option::<String>::None);
-    #[cfg(not(feature = "acme"))]
-    let (default_provisioning_strategy, default_cert_path, default_key_path) =
-        ("store", Option::<String>::None, Option::<String>::None);
-
     let telemetry_environment = match std::env::var("APP_ENV")
         .unwrap_or_default()
         .trim()
@@ -1072,10 +1068,6 @@ fn base_builder() -> Result<ConfigBuilder<DefaultState>, ConfigError> {
         .set_default("database.pool.connect_timeout_secs", 10u64)?
         .set_default("database.pool.idle_timeout_secs", 600u64)?
         .set_default("database.pool.max_lifetime_secs", 1800u64)?
-        .set_default(
-            "server.cert.provisioning_strategy",
-            default_provisioning_strategy,
-        )?
         .set_default("server.cert.email", "admin@example.com")?
         .set_default("server.cert.eku", vec![1, 3, 6, 1, 5, 5, 7, 3, 30])?
         .set_default("server.cert.organization", "adorsys GmbH & CO KG")?
@@ -1085,10 +1077,10 @@ fn base_builder() -> Result<ConfigBuilder<DefaultState>, ConfigError> {
         )?
         .set_default("server.cert.signing_key_cache_ttl", 0)?
         .set_default("server.cert.renewal_cron_schedule", "0 0 0 * * *")?
-        .set_default("server.cert.store.certificate_path", default_cert_path)?
-        .set_default("server.cert.store.signing_key_path", default_key_path)?
-        .set_default("server.cert.store.certificate_key", Option::<String>::None)?
-        .set_default("server.cert.store.signing_key_key", Option::<String>::None)?
+        .set_default("server.cert.store.certificate_path", Option::<String>::None)?
+        .set_default("server.cert.store.signing_key_path", Option::<String>::None)?
+        .set_default("server.cert.store.certificate", Option::<String>::None)?
+        .set_default("server.cert.store.signing_key", Option::<String>::None)?
         .set_default("aws.region", "us-east-1")?
         .set_default("vault.auth_method", "approle")?
         .set_default("vault.addr", "http://localhost:8200")?
@@ -1206,19 +1198,11 @@ mod tests {
             "database.url should not have a credential-bearing built-in default"
         );
         assert_eq!(config.database.backend, expected_db_backend);
-        #[cfg(feature = "acme")]
-        let (expected_strategy, expected_cert_path, expected_key_path) =
-            ("acme", Option::<String>::None, Option::<String>::None);
-        #[cfg(not(feature = "acme"))]
-        let (expected_strategy, expected_cert_path, expected_key_path) =
-            ("store", Option::<String>::None, Option::<String>::None);
-        assert_eq!(config.server.cert.provisioning_strategy, expected_strategy);
+        assert_eq!(config.server.cert.store.certificate_path, None);
+        assert_eq!(config.server.cert.store.signing_key_path, None);
+        assert_eq!(config.server.cert.store.certificate, None);
+        assert_eq!(config.server.cert.store.signing_key, None);
         assert_eq!(config.server.cert.signing_key_cache_ttl, 0);
-        assert_eq!(
-            config.server.cert.store.certificate_path,
-            expected_cert_path
-        );
-        assert_eq!(config.server.cert.store.signing_key_path, expected_key_path);
 
         assert_eq!(config.rate_limit.strict_burst_size, 10);
         assert_eq!(config.rate_limit.strict_period_secs, 60);
@@ -1272,7 +1256,6 @@ mod tests {
             ),
             ("server.cert.organization", "Test Org"),
             ("server.cert.eku", "1,3,6,1,5,5,7,3,30"),
-            ("server.cert.provisioning_strategy", "store"),
             ("server.cert.signing_key_cache_ttl", "0"),
             ("server.cert.store.certificate_path", "/certs/tls.crt"),
             ("server.cert.store.signing_key_path", "/certs/tls.key"),
@@ -1330,7 +1313,6 @@ mod tests {
             overridden.server.cert.dns_challenge_server_url.as_deref(),
             Some("http://pebble:8055")
         );
-        assert_eq!(overridden.server.cert.provisioning_strategy, "store");
         assert_eq!(overridden.server.cert.signing_key_cache_ttl, 0);
         assert_eq!(
             overridden.server.cert.store.certificate_path.as_deref(),
@@ -1997,16 +1979,16 @@ mod tests {
                 "Default config database URL references test_data: {db_url}"
             );
         }
-        if let Some(key) = default_config.server.cert.store.certificate_key.as_deref() {
+        if let Some(cert) = default_config.server.cert.store.certificate.as_deref() {
             assert!(
-                !key.contains("test_data"),
-                "Default config certificate_key references test_data: {key}"
+                !cert.contains("test_data"),
+                "Default config certificate references test_data: {cert}"
             );
         }
-        if let Some(key) = default_config.server.cert.store.signing_key_key.as_deref() {
+        if let Some(key) = default_config.server.cert.store.signing_key.as_deref() {
             assert!(
                 !key.contains("test_data"),
-                "Default config signing_key_key references test_data: {key}"
+                "Default config signing_key references test_data: {key}"
             );
         }
 

--- a/src/outbound/cert.rs
+++ b/src/outbound/cert.rs
@@ -1,8 +1,11 @@
 //! ACME / Store Certificate adapter implementing `CertificateProvider`.
 
+#[cfg(not(feature = "acme"))]
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
+#[cfg(not(feature = "acme"))]
 use base64::prelude::{BASE64_STANDARD, Engine as _};
+#[cfg(not(feature = "acme"))]
 use std::sync::Arc;
 
 use crate::domain::{
@@ -36,14 +39,9 @@ impl CertificateProvider for AcmeCertificateProvider {
     }
 }
 
-/// Filesystem-backed certificate provider used when the `acme` feature is **disabled**.
+/// Filesystem-backed certificate provider.
 ///
-/// Loads PEM certificate chain and PKCS#8 private key from filesystem paths,
-/// validates that the certificate and key match, and caches the material in
-/// memory behind an `ArcSwap` for atomic hot-reload without downtime.
-///
-/// Both `cert_path` and `key_path` must be set together — they are always
-/// sourced from the same location type (filesystem).
+/// Loads PEM certificate chain and PKCS#8 private key from filesystem paths.
 #[cfg(not(feature = "acme"))]
 #[derive(Clone)]
 pub struct ReloadingCertificateProvider {
@@ -81,13 +79,7 @@ impl CertificateProvider for ReloadingCertificateProvider {
     }
 }
 
-/// Inline certificate provider used when the `acme` feature is **disabled** and
-/// material is supplied entirely via environment variables (e.g.
-/// `APP_SERVER__CERT__STORE__CERTIFICATE` / `APP_SERVER__CERT__STORE__SIGNING_KEY`).
-///
-/// Both certificate chain and signing key must be provided together as inline PEM
-/// strings — they are always sourced from the same location type (inline).
-/// Material is validated once at construction; a mismatch is a hard startup error.
+/// Inline certificate provider
 #[cfg(not(feature = "acme"))]
 #[derive(Clone)]
 pub struct InlineCertificateProvider {
@@ -118,6 +110,7 @@ impl CertificateProvider for InlineCertificateProvider {
     }
 }
 
+#[cfg(not(feature = "acme"))]
 async fn load_and_validate_signing_material(
     cert_path: &str,
     key_path: &str,
@@ -136,6 +129,7 @@ async fn load_and_validate_signing_material(
     })
 }
 
+#[cfg(not(feature = "acme"))]
 pub(crate) fn pem_chain_to_base64_der(cert_pem: &str) -> Result<Vec<String>, StatusListError> {
     let certs = x509_parser::pem::Pem::iter_from_buffer(cert_pem.as_bytes())
         .map(|cert| {
@@ -193,12 +187,15 @@ pub(crate) fn validate_signing_material(
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(not(feature = "acme"))]
     use std::path::{Path, PathBuf};
 
+    #[cfg(not(feature = "acme"))]
     struct TempDir {
         path: PathBuf,
     }
 
+    #[cfg(not(feature = "acme"))]
     impl TempDir {
         fn new() -> Self {
             let path = std::env::temp_dir().join(format!(
@@ -215,6 +212,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "acme"))]
     impl Drop for TempDir {
         fn drop(&mut self) {
             let _ = std::fs::remove_dir_all(&self.path);
@@ -222,14 +220,9 @@ mod tests {
     }
 
     fn matching_cert_and_key() -> (String, String) {
-        let key = rcgen::KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256)
-            .expect("generate test key");
-        let cert = rcgen::CertificateParams::new(vec!["localhost".to_string()])
-            .expect("certificate params")
-            .self_signed(&key)
-            .expect("self-signed certificate")
-            .pem();
-        (cert, key.serialize_pem())
+        let certified_key = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+            .expect("generate test cert and key");
+        (certified_key.cert.pem(), certified_key.signing_key.serialize_pem())
     }
 
     #[test]

--- a/src/outbound/cert.rs
+++ b/src/outbound/cert.rs
@@ -222,7 +222,10 @@ mod tests {
     fn matching_cert_and_key() -> (String, String) {
         let certified_key = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
             .expect("generate test cert and key");
-        (certified_key.cert.pem(), certified_key.signing_key.serialize_pem())
+        (
+            certified_key.cert.pem(),
+            certified_key.signing_key.serialize_pem(),
+        )
     }
 
     #[test]

--- a/src/outbound/cert.rs
+++ b/src/outbound/cert.rs
@@ -49,8 +49,8 @@ pub struct StoreCertificateProvider {
 impl StoreCertificateProvider {
     pub fn new(cert_path: Option<String>, key_path: Option<String>) -> Self {
         Self {
-            cert_path,
-            key_path,
+            cert_path: cert_path.filter(|p| !p.trim().is_empty()),
+            key_path: key_path.filter(|p| !p.trim().is_empty()),
         }
     }
 }
@@ -59,23 +59,84 @@ impl StoreCertificateProvider {
 #[async_trait]
 impl CertificateProvider for StoreCertificateProvider {
     async fn certificate_chain(&self) -> Result<Option<Vec<String>>, StatusListError> {
-        if let Some(path) = &self.cert_path {
-            let content = tokio::fs::read_to_string(path)
-                .await
-                .map_err(|e| StatusListError::Backend(Box::new(e)))?;
-            Ok(Some(vec![content]))
+        let Some(path) = &self.cert_path else {
+            return Ok(None);
+        };
+        let content = tokio::fs::read(path)
+            .await
+            .map_err(|e| StatusListError::Backend(Box::new(e)))?;
+
+        use base64::prelude::{BASE64_STANDARD, Engine as _};
+        use x509_parser::pem::Pem as X509Pem;
+
+        let certs: Vec<String> = X509Pem::iter_from_buffer(&content)
+            .map(|cert| {
+                cert.map(|pem| BASE64_STANDARD.encode(&pem.contents))
+                    .map_err(|e| StatusListError::Backend(Box::new(e)))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        if certs.is_empty() {
+            if !content.is_empty() {
+                Ok(Some(vec![BASE64_STANDARD.encode(&content)]))
+            } else {
+                Ok(None)
+            }
         } else {
-            Ok(None)
+            Ok(Some(certs))
         }
     }
 
     async fn signing_key_pem(&self) -> Result<String, StatusListError> {
-        let path = self
-            .key_path
-            .as_deref()
-            .unwrap_or("test_data/ec-private.pem");
+        let path = self.key_path.as_deref().ok_or_else(|| {
+            StatusListError::Backend(Box::from(
+                "no signing key path configured (server.cert.store.signing_key_path); \
+                 a PEM-encoded PKCS#8 private key is required for token signing",
+            ))
+        })?;
         tokio::fs::read_to_string(path)
             .await
             .map_err(|e| StatusListError::Backend(Box::new(e)))
+    }
+}
+
+#[cfg(all(test, not(feature = "acme")))]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn signing_key_pem_fails_when_no_key_path_configured() {
+        let provider = StoreCertificateProvider::new(None, None);
+        let result = provider.signing_key_pem().await;
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("no signing key path configured"),
+            "unexpected error: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn signing_key_pem_fails_when_key_path_is_empty() {
+        let provider = StoreCertificateProvider::new(None, Some("   ".to_string()));
+        let result = provider.signing_key_pem().await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn certificate_chain_returns_none_when_no_cert_path() {
+        let provider = StoreCertificateProvider::new(None, None);
+        let result = provider.certificate_chain().await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn signing_key_pem_loads_valid_key() {
+        let provider =
+            StoreCertificateProvider::new(None, Some("test_data/ec-private.pem".to_string()));
+        let result = provider.signing_key_pem().await;
+        assert!(result.is_ok());
+        let key = result.unwrap();
+        assert!(key.contains("-----BEGIN"));
     }
 }

--- a/src/outbound/mod.rs
+++ b/src/outbound/mod.rs
@@ -1,10 +1,10 @@
-#[cfg(feature = "aws-secrets")]
+#[cfg(feature = "aws")]
 pub mod aws;
-#[cfg(feature = "azure-kv")]
+#[cfg(feature = "azure")]
 pub mod azure_kv;
 pub mod cache;
 pub mod cert;
-#[cfg(feature = "gcp-secrets")]
+#[cfg(feature = "gcp")]
 pub mod gcp_secret;
 #[cfg(feature = "memory")]
 pub mod memory;

--- a/src/server/health.rs
+++ b/src/server/health.rs
@@ -253,8 +253,8 @@ pub struct FilesystemCertCheck {
 impl FilesystemCertCheck {
     pub fn new(cert_path: Option<String>, key_path: Option<String>) -> Self {
         Self {
-            cert_path,
-            key_path,
+            cert_path: cert_path.filter(|p| !p.trim().is_empty()),
+            key_path: key_path.filter(|p| !p.trim().is_empty()),
         }
     }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -162,7 +162,7 @@ async fn build_state_impl(config: &AppConfig) -> EyeResult<BuildStateResult> {
     // readiness probe can reach the real adapter (the domain ports only expose
     // the higher-level repositories).
     #[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
-    let mut db_arc: Option<Arc<sea_orm::DatabaseConnection>> = None;
+    let db_arc: Option<Arc<sea_orm::DatabaseConnection>>;
 
     let (status_list_repo, credential_repo, status_list_snapshot): (
         Arc<dyn StatusListRepo>,
@@ -171,6 +171,10 @@ async fn build_state_impl(config: &AppConfig) -> EyeResult<BuildStateResult> {
     ) = match config.database.backend {
         #[cfg(feature = "memory")]
         DatabaseBackend::Memory => {
+            #[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
+            {
+                db_arc = None;
+            }
             let memory_snapshot = MemoryStatusListSnapshotRepo::default();
             let memory_lists = MemoryStatusLists::default().with_snapshot(&memory_snapshot);
             (

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -55,7 +55,7 @@ use crate::cert_manager::http_client::DefaultHttpClient;
 use crate::cert_manager::storage::MemoryStorage;
 #[cfg(feature = "acme")]
 use crate::cert_manager::{
-    CertManager, StoreProvisioningStrategy,
+    CertManager, MaterialSource, StoreProvisioningStrategy,
     storage::{CryptoCachePolicy, Storage},
 };
 use crate::config::{Config as AppConfig, DatabaseBackend};
@@ -619,35 +619,62 @@ fn store_certificate_strategy(config: &AppConfig) -> EyeResult<Option<StoreProvi
         ));
     }
 
-    let filesystem = (
-        cert_config.store.certificate_path.as_deref(),
-        cert_config.store.signing_key_path.as_deref(),
-    );
-    let storage = (
-        cert_config.store.certificate_key.as_deref(),
-        cert_config.store.signing_key_key.as_deref(),
-    );
+    let cert_source = match (
+        cert_config
+            .store
+            .certificate_path
+            .as_deref()
+            .filter(|s| !s.trim().is_empty()),
+        cert_config
+            .store
+            .certificate_key
+            .as_deref()
+            .filter(|s| !s.trim().is_empty()),
+    ) {
+        (Some(path), None) => MaterialSource::Filesystem(path.into()),
+        (None, Some(key)) => MaterialSource::Storage(key.into()),
+        (Some(_), Some(_)) => {
+            return Err(eyre!(
+                "store certificate provisioning cannot configure both server.cert.store.certificate_path and server.cert.store.certificate_key"
+            ));
+        }
+        (None, None) => {
+            return Err(eyre!(
+                "store certificate provisioning requires either server.cert.store.certificate_path or server.cert.store.certificate_key"
+            ));
+        }
+    };
 
-    match (filesystem, storage) {
-        ((Some(certificate_path), Some(signing_key_path)), (None, None)) => Ok(Some(
-            StoreProvisioningStrategy::filesystem(certificate_path, signing_key_path),
-        )),
-        ((None, None), (Some(certificate_key), Some(signing_key_key))) => Ok(Some(
-            StoreProvisioningStrategy::storage(certificate_key, signing_key_key),
-        )),
-        ((Some(_), Some(_)), (Some(_), Some(_))) => Err(eyre!(
-            "store provisioning must configure either filesystem paths or material backend keys, not both"
-        )),
-        ((Some(_), None) | (None, Some(_)), _) => Err(eyre!(
-            "filesystem store provisioning requires both server.cert.store.certificate_path and server.cert.store.signing_key_path"
-        )),
-        (_, (Some(_), None) | (None, Some(_))) => Err(eyre!(
-            "storage-backed store provisioning requires both server.cert.store.certificate_key and server.cert.store.signing_key_key"
-        )),
-        ((None, None), (None, None)) => Err(eyre!(
-            "store provisioning requires either filesystem paths or material backend keys"
-        )),
-    }
+    let key_source = match (
+        cert_config
+            .store
+            .signing_key_path
+            .as_deref()
+            .filter(|s| !s.trim().is_empty()),
+        cert_config
+            .store
+            .signing_key_key
+            .as_deref()
+            .filter(|s| !s.trim().is_empty()),
+    ) {
+        (Some(path), None) => MaterialSource::Filesystem(path.into()),
+        (None, Some(key)) => MaterialSource::Storage(key.into()),
+        (Some(_), Some(_)) => {
+            return Err(eyre!(
+                "store certificate provisioning cannot configure both server.cert.store.signing_key_path and server.cert.store.signing_key_key"
+            ));
+        }
+        (None, None) => {
+            return Err(eyre!(
+                "store certificate provisioning requires either server.cert.store.signing_key_path or server.cert.store.signing_key_key"
+            ));
+        }
+    };
+
+    Ok(Some(StoreProvisioningStrategy::new(
+        cert_source,
+        key_source,
+    )))
 }
 
 #[cfg(feature = "acme")]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -65,11 +65,7 @@ use crate::domain::{
     not(feature = "azure")
 ))]
 use crate::outbound::aws::AwsSecretsManager;
-#[cfg(all(
-    feature = "azure",
-    not(feature = "vault"),
-    not(feature = "gcp")
-))]
+#[cfg(all(feature = "azure", not(feature = "vault"), not(feature = "gcp")))]
 use crate::outbound::azure_kv::AzureKeyVaultClient;
 use crate::outbound::cache::MokaStatusListCache;
 #[cfg(feature = "acme")]
@@ -741,11 +737,7 @@ async fn build_crypto_storage(_config: &AppConfig) -> EyeResult<Box<dyn Storage>
         ))
     }
 
-    #[cfg(all(
-        feature = "azure",
-        not(feature = "vault"),
-        not(feature = "gcp")
-    ))]
+    #[cfg(all(feature = "azure", not(feature = "vault"), not(feature = "gcp")))]
     {
         tracing::info!("Using Azure Key Vault as secrets backend");
         let vault_url = _config.azure_keyvault.vault_url.clone().ok_or_else(|| {
@@ -786,12 +778,7 @@ async fn build_crypto_storage(_config: &AppConfig) -> EyeResult<Box<dyn Storage>
         ))
     }
 
-    #[cfg(not(any(
-        feature = "vault",
-        feature = "gcp",
-        feature = "azure",
-        feature = "aws"
-    )))]
+    #[cfg(not(any(feature = "vault", feature = "gcp", feature = "azure", feature = "aws")))]
     {
         tracing::info!("Using in-memory cryptographic-material backend");
         Ok(Box::new(MemoryStorage::default()))

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,6 +1,6 @@
 //! Composition root assembling outbound infrastructure adapters and creating the AppState container.
 
-#[cfg(feature = "aws-secrets")]
+#[cfg(feature = "aws")]
 use aws_config::{BehaviorVersion, Region};
 #[cfg(any(
     feature = "acme",
@@ -10,8 +10,6 @@ use aws_config::{BehaviorVersion, Region};
 ))]
 use color_eyre::eyre::Context;
 use color_eyre::eyre::Result as EyeResult;
-#[cfg(feature = "acme")]
-use color_eyre::eyre::eyre;
 #[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
 use sea_orm::{ConnectOptions, DbErr};
 #[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
@@ -29,7 +27,7 @@ use std::time::Duration;
 #[cfg(feature = "acme")]
 use tracing::warn;
 
-#[cfg(feature = "aws-secrets")]
+#[cfg(feature = "aws")]
 use crate::cert_manager::challenge::AwsRoute53DnsProvider;
 #[cfg(feature = "acme")]
 use crate::cert_manager::challenge::{
@@ -41,14 +39,14 @@ use crate::cert_manager::http_client::DefaultHttpClient;
 #[cfg(all(
     feature = "acme",
     not(feature = "vault"),
-    not(feature = "gcp-secrets"),
-    not(feature = "azure-kv"),
-    not(feature = "aws-secrets")
+    not(feature = "gcp"),
+    not(feature = "azure"),
+    not(feature = "aws")
 ))]
 use crate::cert_manager::storage::MemoryStorage;
 #[cfg(feature = "acme")]
 use crate::cert_manager::{
-    CertManager, MaterialSource, StoreProvisioningStrategy,
+    CertManager,
     storage::{CryptoCachePolicy, Storage},
 };
 use crate::config::{Config as AppConfig, DatabaseBackend};
@@ -61,25 +59,24 @@ use crate::domain::{
     service::Service,
 };
 #[cfg(all(
-    feature = "aws-secrets",
+    feature = "aws",
     not(feature = "vault"),
-    not(feature = "gcp-secrets"),
-    not(feature = "azure-kv")
+    not(feature = "gcp"),
+    not(feature = "azure")
 ))]
 use crate::outbound::aws::AwsSecretsManager;
 #[cfg(all(
-    feature = "azure-kv",
-    feature = "acme",
+    feature = "azure",
     not(feature = "vault"),
-    not(feature = "gcp-secrets")
+    not(feature = "gcp")
 ))]
 use crate::outbound::azure_kv::AzureKeyVaultClient;
 use crate::outbound::cache::MokaStatusListCache;
+#[cfg(feature = "acme")]
+use crate::outbound::cert::AcmeCertificateProvider;
 #[cfg(not(feature = "acme"))]
 use crate::outbound::cert::ReloadingCertificateProvider;
-#[cfg(feature = "acme")]
-use crate::outbound::cert::{AcmeCertificateProvider, validate_signing_material};
-#[cfg(all(feature = "gcp-secrets", feature = "acme", not(feature = "vault")))]
+#[cfg(all(feature = "gcp", not(feature = "vault")))]
 use crate::outbound::gcp_secret::GcpSecretManagerClient;
 #[cfg(feature = "memory")]
 use crate::outbound::memory::{MemoryCredentials, MemoryStatusListSnapshotRepo, MemoryStatusLists};
@@ -92,10 +89,22 @@ use crate::outbound::sql::{
 use crate::outbound::vault::VaultClient;
 use crate::server::AppState;
 use crate::server::health::{AlwaysReady, Readiness};
+#[cfg(any(
+    not(feature = "acme"),
+    any(feature = "sqlite", feature = "postgres", feature = "mysql")
+))]
 use crate::utils::file_watcher::FileWatcher;
 #[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
 use crate::utils::metrics::TARGET_DATABASE;
-use crate::utils::metrics::{TARGET_TOKEN_SIGNING_KEY, record_rotation};
+#[cfg(not(feature = "acme"))]
+use crate::utils::metrics::TARGET_TOKEN_SIGNING_KEY;
+#[cfg(any(
+    feature = "sqlite",
+    feature = "postgres",
+    feature = "mysql",
+    not(feature = "acme")
+))]
+use crate::utils::metrics::record_rotation;
 
 #[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
 fn classify_db_connect_error(err: &DbErr) -> &'static str {
@@ -241,73 +250,6 @@ async fn drain_and_close_database(mut db: Arc<sea_orm::DatabaseConnection>) {
             }
         }
     }
-}
-
-#[cfg(feature = "acme")]
-fn spawn_acme_store_rotation(config: AppConfig, manager: Arc<CertManager>) {
-    if !config
-        .server
-        .cert
-        .provisioning_strategy
-        .eq_ignore_ascii_case("store")
-    {
-        return;
-    }
-    let (Some(certificate_path), Some(signing_key_path)) = (
-        config.server.cert.store.certificate_path.clone(),
-        config.server.cert.store.signing_key_path.clone(),
-    ) else {
-        return;
-    };
-
-    FileWatcher::new(
-        vec![
-            certificate_path.clone().into(),
-            signing_key_path.clone().into(),
-        ],
-        Duration::from_secs(config.watcher.poll_interval_secs),
-    )
-    .spawn(TARGET_TOKEN_SIGNING_KEY, move || {
-        let manager = manager.clone();
-        let certificate_path = certificate_path.clone();
-        let signing_key_path = signing_key_path.clone();
-        async move {
-            tracing::info!(
-                event = "rotation_started",
-                rotation.target = TARGET_TOKEN_SIGNING_KEY,
-                "token signing material rotation started"
-            );
-            let result = async {
-                let certificate = tokio::fs::read_to_string(&certificate_path).await?;
-                let signing_key = tokio::fs::read_to_string(&signing_key_path).await?;
-                validate_signing_material(&certificate, &signing_key)
-                    .map_err(|err| color_eyre::eyre::eyre!("{err}"))?;
-                manager.request_certificate().await?;
-                Ok::<(), color_eyre::Report>(())
-            }
-            .await;
-
-            match result {
-                Ok(()) => {
-                    record_rotation(TARGET_TOKEN_SIGNING_KEY, true);
-                    tracing::info!(
-                        event = "rotation_succeeded",
-                        rotation.target = TARGET_TOKEN_SIGNING_KEY,
-                        "token signing material rotation succeeded"
-                    );
-                }
-                Err(err) => {
-                    record_rotation(TARGET_TOKEN_SIGNING_KEY, false);
-                    tracing::error!(
-                        event = "rotation_failed",
-                        rotation.target = TARGET_TOKEN_SIGNING_KEY,
-                        error = %err,
-                        "token signing material rotation failed"
-                    );
-                }
-            }
-        }
-    });
 }
 
 #[cfg(not(feature = "acme"))]
@@ -484,13 +426,6 @@ async fn build_state_impl(config: &AppConfig) -> EyeResult<BuildStateResult> {
         let cert_domains = [config.server.domain.as_str()];
         let material_storage = build_crypto_storage(config).await?;
 
-        let cert_strategy = store_certificate_strategy(config)?;
-        let uses_acme_strategy = config
-            .server
-            .cert
-            .provisioning_strategy
-            .eq_ignore_ascii_case("acme");
-
         let mut cert_manager_builder = CertManager::builder()
             .domains(cert_domains)
             .email(&config.server.cert.email)
@@ -502,31 +437,23 @@ async fn build_state_impl(config: &AppConfig) -> EyeResult<BuildStateResult> {
             .crypto_storage(material_storage)
             .eku(&config.server.cert.eku);
 
-        cert_manager_builder = if uses_acme_strategy {
-            let dns_provider = config
-                .server
-                .cert
-                .dns
-                .resolve(&app_env)
-                .wrap_err("Invalid DNS provider configuration")?;
-            if dns_provider.kind() == DnsProviderKind::Pebble && app_env == ENV_PRODUCTION {
-                warn!(
-                    "The 'pebble' DNS provider is a development-only fake DNS server \
-                     but APP_ENV=production; ACME challenges will not succeed against a real CA"
-                );
-            }
-            let challenge_handler =
-                build_dns_challenge_handler(dns_provider, config, &cert_domains).await?;
-            cert_manager_builder
-                .challenge_handler(challenge_handler)
-                .acme_strategy()
-        } else if let Some(cert_strategy) = cert_strategy {
-            cert_manager_builder.store_strategy(cert_strategy)
-        } else {
-            return Err(eyre!(
-                "store certificate provisioning strategy is missing after validation"
-            ));
-        };
+        let dns_provider = config
+            .server
+            .cert
+            .dns
+            .resolve(&app_env)
+            .wrap_err("Invalid DNS provider configuration")?;
+        if dns_provider.kind() == DnsProviderKind::Pebble && app_env == ENV_PRODUCTION {
+            warn!(
+                "The 'pebble' DNS provider is a development-only fake DNS server \
+                 but APP_ENV=production; ACME challenges will not succeed against a real CA"
+            );
+        }
+        let challenge_handler =
+            build_dns_challenge_handler(dns_provider, config, &cert_domains).await?;
+        cert_manager_builder = cert_manager_builder
+            .challenge_handler(challenge_handler)
+            .acme_strategy();
 
         if app_env == ENV_DEVELOPMENT {
             let root_cert = include_bytes!("../test_data/pebble.pem");
@@ -536,7 +463,6 @@ async fn build_state_impl(config: &AppConfig) -> EyeResult<BuildStateResult> {
 
         let certificate_manager = cert_manager_builder.build()?;
         let cert_manager = Arc::new(certificate_manager);
-        spawn_acme_store_rotation(config.clone(), cert_manager.clone());
         (
             Arc::new(AcmeCertificateProvider::new(cert_manager.clone())),
             Some(cert_manager),
@@ -549,35 +475,55 @@ async fn build_state_impl(config: &AppConfig) -> EyeResult<BuildStateResult> {
 
         let store = &config.server.cert.store;
 
-        let cert_path = store.certificate_path.as_deref().filter(|s| !s.trim().is_empty());
-        let key_path = store.signing_key_path.as_deref().filter(|s| !s.trim().is_empty());
-        let cert_inline = store.certificate.as_deref().filter(|s| !s.trim().is_empty());
-        let key_inline = store.signing_key.as_deref().filter(|s| !s.trim().is_empty());
+        let cert_path = store
+            .certificate_path
+            .as_deref()
+            .filter(|s| !s.trim().is_empty());
+        let key_path = store
+            .signing_key_path
+            .as_deref()
+            .filter(|s| !s.trim().is_empty());
+        let cert_inline = store
+            .certificate
+            .as_deref()
+            .filter(|s| !s.trim().is_empty());
+        let key_inline = store
+            .signing_key
+            .as_deref()
+            .filter(|s| !s.trim().is_empty());
 
-        let provider: Arc<dyn CertificateProvider> = match (cert_path, key_path, cert_inline, key_inline) {
+        let has_fs = cert_path.is_some() || key_path.is_some();
+        let has_inline = cert_inline.is_some() || key_inline.is_some();
+
+        let provider: Arc<dyn CertificateProvider> = match (
+            cert_path,
+            key_path,
+            cert_inline,
+            key_inline,
+        ) {
             // Filesystem mode: both paths → ReloadingCertificateProvider with hot-reload
             (Some(cp), Some(kp), None, None) => {
                 let p = ReloadingCertificateProvider::from_files(cp.to_owned(), kp.to_owned())
                     .await
-                    .map_err(|e| eyre!("{e}"))?;
+                    .map_err(|e| color_eyre::eyre::eyre!("{e}"))?;
                 spawn_cert_rotation(config.clone(), p.clone());
                 Arc::new(p)
             }
             // Inline mode: both inline PEM values → InlineCertificateProvider (validated at startup)
             (None, None, Some(ci), Some(ki)) => Arc::new(
                 InlineCertificateProvider::new(ci.to_owned(), ki.to_owned())
-                    .map_err(|e| eyre!("{e}"))?,
+                    .map_err(|e| color_eyre::eyre::eyre!("{e}"))?,
             ),
             // Conflict: cannot mix sources
-            (Some(_), _, Some(_), _) | (_, Some(_), _, Some(_)) => {
-                return Err(eyre!(
+            _ if has_fs && has_inline => {
+                return Err(color_eyre::eyre::eyre!(
                     "certificate and signing key must both come from the same source; \
                      do not mix filesystem paths with inline (env var) values"
                 ));
             }
             // Missing: neither source fully configured — fail immediately at startup
             _ => {
-                return Err(eyre!(
+                return Err(color_eyre::eyre::eyre!(
                     "static certificate mode requires both certificate and signing key; \
                      set APP_SERVER__CERT__STORE__CERTIFICATE_PATH + APP_SERVER__CERT__STORE__SIGNING_KEY_PATH \
                      (filesystem) OR APP_SERVER__CERT__STORE__CERTIFICATE + APP_SERVER__CERT__STORE__SIGNING_KEY \
@@ -773,7 +719,7 @@ async fn build_crypto_storage(_config: &AppConfig) -> EyeResult<Box<dyn Storage>
         ))
     }
 
-    #[cfg(all(feature = "gcp-secrets", not(feature = "vault")))]
+    #[cfg(all(feature = "gcp", not(feature = "vault")))]
     {
         tracing::info!("Using GCP Secret Manager as secrets backend");
         Ok(Box::new(
@@ -796,14 +742,14 @@ async fn build_crypto_storage(_config: &AppConfig) -> EyeResult<Box<dyn Storage>
     }
 
     #[cfg(all(
-        feature = "azure-kv",
+        feature = "azure",
         not(feature = "vault"),
-        not(feature = "gcp-secrets")
+        not(feature = "gcp")
     ))]
     {
         tracing::info!("Using Azure Key Vault as secrets backend");
         let vault_url = _config.azure_keyvault.vault_url.clone().ok_or_else(|| {
-            eyre!("Azure Key Vault configuration error: azure_keyvault.vault_url is required when azure-kv is enabled")
+            color_eyre::eyre::eyre!("Azure Key Vault configuration error: azure_keyvault.vault_url is required when azure is enabled")
         })?;
         Ok(Box::new(
             AzureKeyVaultClient::builder(vault_url)
@@ -820,10 +766,10 @@ async fn build_crypto_storage(_config: &AppConfig) -> EyeResult<Box<dyn Storage>
     }
 
     #[cfg(all(
-        feature = "aws-secrets",
+        feature = "aws",
         not(feature = "vault"),
-        not(feature = "gcp-secrets"),
-        not(feature = "azure-kv")
+        not(feature = "gcp"),
+        not(feature = "azure")
     ))]
     {
         tracing::info!("Using AWS Secrets Manager as cryptographic-material backend");
@@ -842,92 +788,14 @@ async fn build_crypto_storage(_config: &AppConfig) -> EyeResult<Box<dyn Storage>
 
     #[cfg(not(any(
         feature = "vault",
-        feature = "gcp-secrets",
-        feature = "azure-kv",
-        feature = "aws-secrets"
+        feature = "gcp",
+        feature = "azure",
+        feature = "aws"
     )))]
     {
         tracing::info!("Using in-memory cryptographic-material backend");
         Ok(Box::new(MemoryStorage::default()))
     }
-}
-
-#[cfg(feature = "acme")]
-fn store_certificate_strategy(config: &AppConfig) -> EyeResult<Option<StoreProvisioningStrategy>> {
-    let cert_config = &config.server.cert;
-    if cert_config
-        .provisioning_strategy
-        .eq_ignore_ascii_case("acme")
-    {
-        return Ok(None);
-    }
-
-    if !cert_config
-        .provisioning_strategy
-        .eq_ignore_ascii_case("store")
-    {
-        return Err(eyre!(
-            "unsupported certificate provisioning strategy '{}'; expected 'acme' or 'store'",
-            cert_config.provisioning_strategy
-        ));
-    }
-
-    let cert_source = match (
-        cert_config
-            .store
-            .certificate_path
-            .as_deref()
-            .filter(|s| !s.trim().is_empty()),
-        cert_config
-            .store
-            .certificate_key
-            .as_deref()
-            .filter(|s| !s.trim().is_empty()),
-    ) {
-        (Some(path), None) => MaterialSource::Filesystem(path.into()),
-        (None, Some(key)) => MaterialSource::Storage(key.into()),
-        (Some(_), Some(_)) => {
-            return Err(eyre!(
-                "store certificate provisioning cannot configure both server.cert.store.certificate_path and server.cert.store.certificate_key"
-            ));
-        }
-        (None, None) => {
-            return Err(eyre!(
-                "store certificate provisioning requires either server.cert.store.certificate_path or server.cert.store.certificate_key"
-            ));
-        }
-    };
-
-    let key_source = match (
-        cert_config
-            .store
-            .signing_key_path
-            .as_deref()
-            .filter(|s| !s.trim().is_empty()),
-        cert_config
-            .store
-            .signing_key_key
-            .as_deref()
-            .filter(|s| !s.trim().is_empty()),
-    ) {
-        (Some(path), None) => MaterialSource::Filesystem(path.into()),
-        (None, Some(key)) => MaterialSource::Storage(key.into()),
-        (Some(_), Some(_)) => {
-            return Err(eyre!(
-                "store certificate provisioning cannot configure both server.cert.store.signing_key_path and server.cert.store.signing_key_key"
-            ));
-        }
-        (None, None) => {
-            return Err(eyre!(
-                "store certificate provisioning requires either server.cert.store.signing_key_path or server.cert.store.signing_key_key"
-            ));
-        }
-    };
-
-    Ok(Some(StoreProvisioningStrategy::new(
-        cert_source,
-        key_source,
-    )))
 }
 
 #[cfg(feature = "acme")]
@@ -937,7 +805,7 @@ async fn build_dns_challenge_handler(
     cert_domains: &[&str],
 ) -> EyeResult<Dns01Handler> {
     let handler = match provider {
-        #[cfg(feature = "aws-secrets")]
+        #[cfg(feature = "aws")]
         ResolvedDnsProvider::Route53 => {
             let aws_config = aws_config::defaults(BehaviorVersion::latest())
                 .region(Region::new(config.aws.region.clone()))
@@ -945,10 +813,10 @@ async fn build_dns_challenge_handler(
                 .await;
             Dns01Handler::new(AwsRoute53DnsProvider::new(&aws_config))
         }
-        #[cfg(not(feature = "aws-secrets"))]
+        #[cfg(not(feature = "aws"))]
         ResolvedDnsProvider::Route53 => {
-            return Err(eyre!(
-                "Route53 DNS provider requested, but 'aws-secrets' feature is disabled at compile time."
+            return Err(color_eyre::eyre::eyre!(
+                "Route53 DNS provider requested, but 'aws' feature is disabled at compile time."
             ));
         }
         ResolvedDnsProvider::Cloudflare(cfg) => {
@@ -1030,7 +898,7 @@ mod tests {
         let domain = config.server.domain.clone();
         let domains = [domain.as_str()];
 
-        #[cfg(feature = "aws-secrets")]
+        #[cfg(feature = "aws")]
         assert!(
             build_dns_challenge_handler(DnsProviderKind::Route53, &mut config, &domains).is_ok()
         );
@@ -1110,18 +978,32 @@ mod general_tests {
             server
         };
 
+        #[cfg(not(feature = "acme"))]
+        let (cert_pem, key_pem) = {
+            let certified_key = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+                .expect("generate test cert and key");
+            (
+                certified_key.cert.pem(),
+                certified_key.signing_key.serialize_pem(),
+            )
+        };
+
         let config = AppConfig::load_from_overrides(&[
             ("APP_DATABASE__BACKEND", "memory"),
             ("APP_DATABASE__URL", "memory:"),
+            #[cfg(not(feature = "acme"))]
+            ("APP_SERVER__CERT__STORE__CERTIFICATE", &cert_pem),
+            #[cfg(not(feature = "acme"))]
+            ("APP_SERVER__CERT__STORE__SIGNING_KEY", &key_pem),
             #[cfg(feature = "vault")]
             ("APP_VAULT__ADDR", &mock_vault.uri()),
             #[cfg(feature = "vault")]
             ("APP_VAULT__ROLE_ID", "test-role"),
             #[cfg(feature = "vault")]
             ("APP_VAULT__SECRET_ID", "test-secret"),
-            #[cfg(feature = "gcp-secrets")]
+            #[cfg(feature = "gcp")]
             ("APP_GCP_SECRET_MANAGER__PROJECT_ID", "test-project"),
-            #[cfg(feature = "azure-kv")]
+            #[cfg(feature = "azure")]
             (
                 "APP_AZURE_KEYVAULT__VAULT_URL",
                 "https://test.vault.azure.net/",
@@ -1132,6 +1014,94 @@ mod general_tests {
         if let Err(ref e) = build_state(&config).await {
             panic!("build_state failed under default configuration: {e:?}");
         }
+    }
+
+    #[cfg(not(feature = "acme"))]
+    #[tokio::test]
+    async fn build_state_succeeds_with_filesystem_cert_and_key() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let (cert_pem, key_pem) = {
+            let certified_key = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+                .expect("generate test cert and key");
+            (
+                certified_key.cert.pem(),
+                certified_key.signing_key.serialize_pem(),
+            )
+        };
+
+        let temp_dir = std::env::temp_dir().join(format!(
+            "setup-fs-test-{}-{}",
+            std::process::id(),
+            time::OffsetDateTime::now_utc().unix_timestamp_nanos()
+        ));
+        std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+        let cert_path = temp_dir.join("tls.crt");
+        let key_path = temp_dir.join("tls.key");
+        std::fs::write(&cert_path, cert_pem).expect("write cert");
+        std::fs::write(&key_path, key_pem).expect("write key");
+
+        let config = AppConfig::load_from_overrides(&[
+            ("APP_DATABASE__BACKEND", "memory"),
+            ("APP_DATABASE__URL", "memory:"),
+            (
+                "APP_SERVER__CERT__STORE__CERTIFICATE_PATH",
+                cert_path.to_str().unwrap(),
+            ),
+            (
+                "APP_SERVER__CERT__STORE__SIGNING_KEY_PATH",
+                key_path.to_str().unwrap(),
+            ),
+        ])
+        .expect("load config");
+
+        let result = build_state(&config).await;
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        assert!(result.is_ok(), "build_state failed: {:?}", result.err());
+    }
+
+    #[cfg(not(feature = "acme"))]
+    #[tokio::test]
+    async fn build_state_fails_when_missing_certificate_material() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let config = AppConfig::load_from_overrides(&[
+            ("APP_DATABASE__BACKEND", "memory"),
+            ("APP_DATABASE__URL", "memory:"),
+        ])
+        .expect("load config");
+
+        let err = build_state(&config)
+            .await
+            .expect_err("should fail when no cert material provided");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("static certificate mode requires both certificate and signing key"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[cfg(not(feature = "acme"))]
+    #[tokio::test]
+    async fn build_state_fails_when_mixing_filesystem_and_inline_material() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let config = AppConfig::load_from_overrides(&[
+            ("APP_DATABASE__BACKEND", "memory"),
+            ("APP_DATABASE__URL", "memory:"),
+            ("APP_SERVER__CERT__STORE__CERTIFICATE_PATH", "/tmp/cert.pem"),
+            ("APP_SERVER__CERT__STORE__SIGNING_KEY", "inline-key-pem"),
+        ])
+        .expect("load config");
+
+        let err = build_state(&config)
+            .await
+            .expect_err("should fail when mixing sources");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("certificate and signing key must both come from the same source"),
+            "unexpected error: {msg}"
+        );
     }
 
     #[cfg(feature = "postgres")]

--- a/src/utils/cert_manager.rs
+++ b/src/utils/cert_manager.rs
@@ -15,7 +15,7 @@ pub use builder::CertificateManagerBuilder;
 use challenge::CleanupFuture;
 pub use errors::CertError;
 pub use strategy::{
-    AcmeProvisioningStrategy, CertProvisioningStrategy, StoreProvisioningSource,
+    AcmeProvisioningStrategy, CertProvisioningStrategy, MaterialSource, StoreProvisioningSource,
     StoreProvisioningStrategy,
 };
 

--- a/src/utils/cert_manager/challenge.rs
+++ b/src/utils/cert_manager/challenge.rs
@@ -1,7 +1,7 @@
 mod dns01;
 mod http01;
 
-#[cfg(feature = "aws-secrets")]
+#[cfg(feature = "aws")]
 pub use dns01::AwsRoute53DnsProvider;
 pub use dns01::{
     AcmeDnsCredentials, AcmeDnsProvider, AzureDnsProvider, CloudflareDnsProvider, Dns01Handler,

--- a/src/utils/cert_manager/challenge/dns01/mod.rs
+++ b/src/utils/cert_manager/challenge/dns01/mod.rs
@@ -3,7 +3,7 @@ mod azure;
 mod cloudflare;
 mod gcloud;
 mod pebble;
-#[cfg(feature = "aws-secrets")]
+#[cfg(feature = "aws")]
 mod route53;
 mod token;
 
@@ -12,7 +12,7 @@ pub use azure::{AzureDnsProvider, ServicePrincipal};
 pub use cloudflare::CloudflareDnsProvider;
 pub use gcloud::GoogleCloudDnsProvider;
 pub use pebble::PebbleDnsProvider;
-#[cfg(feature = "aws-secrets")]
+#[cfg(feature = "aws")]
 pub use route53::AwsRoute53DnsProvider;
 
 use std::{sync::Arc, time::Duration};

--- a/src/utils/cert_manager/strategy.rs
+++ b/src/utils/cert_manager/strategy.rs
@@ -47,6 +47,15 @@ impl CertProvisioningStrategy for AcmeProvisioningStrategy {
     }
 }
 
+/// Source of individual cryptographic material (certificate or private key).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MaterialSource {
+    /// Load from a filesystem path.
+    Filesystem(PathBuf),
+    /// Load from the configured cryptographic material storage by key.
+    Storage(String),
+}
+
 /// Source for directly provisioned certificate material.
 #[derive(Debug, Clone)]
 pub enum StoreProvisioningSource {
@@ -60,82 +69,73 @@ pub enum StoreProvisioningSource {
         certificate_key: String,
         signing_key_key: String,
     },
+    /// Load certificate and signing key from independent sources.
+    Mixed {
+        certificate_source: MaterialSource,
+        signing_key_source: MaterialSource,
+    },
 }
 
 /// Store-based provisioning strategy.
 #[derive(Debug, Clone)]
 pub struct StoreProvisioningStrategy {
-    source: StoreProvisioningSource,
+    certificate_source: MaterialSource,
+    signing_key_source: MaterialSource,
 }
 
 impl StoreProvisioningStrategy {
+    /// Build a store strategy with explicit sources for certificate and signing key.
+    pub fn new(certificate_source: MaterialSource, signing_key_source: MaterialSource) -> Self {
+        Self {
+            certificate_source,
+            signing_key_source,
+        }
+    }
+
     /// Build a store strategy that loads certificate material from filesystem paths.
     pub fn filesystem(cert_path: impl Into<PathBuf>, key_path: impl Into<PathBuf>) -> Self {
         Self {
-            source: StoreProvisioningSource::Filesystem {
-                certificate_path: cert_path.into(),
-                signing_key_path: key_path.into(),
-            },
+            certificate_source: MaterialSource::Filesystem(cert_path.into()),
+            signing_key_source: MaterialSource::Filesystem(key_path.into()),
         }
     }
 
     /// Build a store strategy that loads certificate material from the manager's configured storages.
     pub fn storage(certificate_key: impl Into<String>, signing_key_key: impl Into<String>) -> Self {
         Self {
-            source: StoreProvisioningSource::Storage {
-                certificate_key: certificate_key.into(),
-                signing_key_key: signing_key_key.into(),
-            },
+            certificate_source: MaterialSource::Storage(certificate_key.into()),
+            signing_key_source: MaterialSource::Storage(signing_key_key.into()),
+        }
+    }
+
+    async fn load_source(
+        source: &MaterialSource,
+        manager: &CertManager,
+        label: &str,
+    ) -> Result<Vec<u8>, CertError> {
+        match source {
+            MaterialSource::Filesystem(path) => fs::read(path).await.map_err(|e| {
+                CertError::Validation(format!(
+                    "failed to read {label} file '{}': {e}",
+                    path.display()
+                ))
+            }),
+            MaterialSource::Storage(key) => {
+                let material_storage = manager.crypto_storage()?;
+                let secret = material_storage.load_secret(key).await?.ok_or_else(|| {
+                    CertError::Validation(format!("store {label} key '{key}' was not found"))
+                })?;
+                decode_text_material(secret, label)
+            }
         }
     }
 
     async fn load_material(&self, manager: &CertManager) -> Result<(Vec<u8>, Vec<u8>), CertError> {
-        match &self.source {
-            StoreProvisioningSource::Filesystem {
-                certificate_path,
-                signing_key_path,
-            } => {
-                let certificate = fs::read(certificate_path).await.map_err(|e| {
-                    CertError::Validation(format!(
-                        "failed to read certificate file '{}': {e}",
-                        certificate_path.display()
-                    ))
-                })?;
-                let signing_key = fs::read(signing_key_path).await.map_err(|e| {
-                    CertError::Validation(format!(
-                        "failed to read signing key file '{}': {e}",
-                        signing_key_path.display()
-                    ))
-                })?;
-                Ok((certificate, signing_key))
-            }
-            StoreProvisioningSource::Storage {
-                certificate_key,
-                signing_key_key,
-            } => {
-                let material_storage = manager.crypto_storage()?;
-                let certificate = material_storage
-                    .load_secret(certificate_key)
-                    .await?
-                    .ok_or_else(|| {
-                        CertError::Validation(format!(
-                            "store certificate key '{certificate_key}' was not found"
-                        ))
-                    })?;
-                let signing_key = material_storage
-                    .load_secret(signing_key_key)
-                    .await?
-                    .ok_or_else(|| {
-                        CertError::Validation(format!(
-                            "store signing key '{signing_key_key}' was not found"
-                        ))
-                    })?;
-                Ok((
-                    decode_text_material(certificate, "certificate")?,
-                    decode_text_material(signing_key, "signing key")?,
-                ))
-            }
-        }
+        let certificate =
+            Self::load_source(&self.certificate_source, manager, "certificate").await?;
+        let signing_key =
+            Self::load_source(&self.signing_key_source, manager, "signing key").await?;
+        Ok((certificate, signing_key))
     }
 }
 

--- a/src/utils/cert_manager/tests.rs
+++ b/src/utils/cert_manager/tests.rs
@@ -25,14 +25,32 @@ fn init_crypto() {
 }
 
 fn matching_cert_and_key() -> (String, String) {
-    let key =
-        rcgen::KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256).expect("generate test key");
-    let cert = rcgen::CertificateParams::new(vec!["example.com".to_string()])
-        .expect("certificate params")
-        .self_signed(&key)
-        .expect("self-signed certificate")
-        .pem();
-    (cert, key.serialize_pem())
+    let certified_key = rcgen::generate_simple_self_signed(vec!["example.com".to_string()])
+        .expect("generate test cert and key");
+    (certified_key.cert.pem(), certified_key.signing_key.serialize_pem())
+}
+
+struct TempDir {
+    path: std::path::PathBuf,
+}
+
+impl TempDir {
+    fn new() -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "status-list-cert-mgr-test-{}-{}",
+            std::process::id(),
+            time::OffsetDateTime::now_utc().unix_timestamp_nanos()
+        ));
+        std::fs::create_dir_all(&path).expect("create temp dir");
+        let path = std::fs::canonicalize(&path).unwrap_or(path);
+        Self { path }
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
 }
 
 #[derive(Clone)]
@@ -640,17 +658,19 @@ async fn test_store_storage_strategy_accepts_base64_der_material() {
 async fn test_store_mixed_strategy_filesystem_cert_storage_key() {
     init_crypto();
 
-    let cert_path = "test_data/pebble.pem";
-    let key_pem = include_str!("../../../test_data/ec-private.pem");
+    let (cert_pem, key_pem) = matching_cert_and_key();
+    let dir = TempDir::new();
+    let cert_path = dir.path.join("cert.pem");
+    tokio::fs::write(&cert_path, &cert_pem).await.unwrap();
 
     let material_storage = MockStorage::new();
-    material_storage.store("source-key", key_pem).await.unwrap();
+    material_storage.store("source-key", &key_pem).await.unwrap();
 
     let manager = CertManager::builder()
         .domains(["example.com"])
         .crypto_storage(material_storage)
         .store_strategy(StoreProvisioningStrategy::new(
-            MaterialSource::Filesystem(cert_path.into()),
+            MaterialSource::Filesystem(cert_path.to_str().unwrap().into()),
             MaterialSource::Storage("source-key".to_string()),
         ))
         .build()
@@ -669,15 +689,14 @@ async fn test_store_mixed_strategy_filesystem_cert_storage_key() {
 async fn test_store_mixed_strategy_storage_cert_filesystem_key() {
     init_crypto();
 
-    let source_cert_data: CertificateData =
-        serde_json::from_str(include_str!("../../../test_data/cert_data.json")).unwrap();
-    let cert_pem = source_cert_data.certificate.as_str();
-    let key_path = "test_data/ec-private.pem";
-    let key_pem = include_str!("../../../test_data/ec-private.pem");
+    let (cert_pem, key_pem) = matching_cert_and_key();
+    let dir = TempDir::new();
+    let key_path = dir.path.join("key.pem");
+    tokio::fs::write(&key_path, &key_pem).await.unwrap();
 
     let material_storage = MockStorage::new();
     material_storage
-        .store("source-cert", cert_pem)
+        .store("source-cert", &cert_pem)
         .await
         .unwrap();
 
@@ -686,7 +705,7 @@ async fn test_store_mixed_strategy_storage_cert_filesystem_key() {
         .crypto_storage(material_storage)
         .store_strategy(StoreProvisioningStrategy::new(
             MaterialSource::Storage("source-cert".to_string()),
-            MaterialSource::Filesystem(key_path.into()),
+            MaterialSource::Filesystem(key_path.to_str().unwrap().into()),
         ))
         .build()
         .unwrap();

--- a/src/utils/cert_manager/tests.rs
+++ b/src/utils/cert_manager/tests.rs
@@ -27,7 +27,10 @@ fn init_crypto() {
 fn matching_cert_and_key() -> (String, String) {
     let certified_key = rcgen::generate_simple_self_signed(vec!["example.com".to_string()])
         .expect("generate test cert and key");
-    (certified_key.cert.pem(), certified_key.signing_key.serialize_pem())
+    (
+        certified_key.cert.pem(),
+        certified_key.signing_key.serialize_pem(),
+    )
 }
 
 struct TempDir {
@@ -664,7 +667,10 @@ async fn test_store_mixed_strategy_filesystem_cert_storage_key() {
     tokio::fs::write(&cert_path, &cert_pem).await.unwrap();
 
     let material_storage = MockStorage::new();
-    material_storage.store("source-key", &key_pem).await.unwrap();
+    material_storage
+        .store("source-key", &key_pem)
+        .await
+        .unwrap();
 
     let manager = CertManager::builder()
         .domains(["example.com"])

--- a/src/utils/cert_manager/tests.rs
+++ b/src/utils/cert_manager/tests.rs
@@ -634,6 +634,66 @@ async fn test_store_storage_strategy_accepts_base64_der_material() {
     assert_eq!(manager.signing_key_pem().await.unwrap(), key_pem);
 }
 
+#[tokio::test]
+async fn test_store_mixed_strategy_filesystem_cert_storage_key() {
+    init_crypto();
+
+    let cert_path = "test_data/pebble.pem";
+    let key_pem = include_str!("../../../test_data/ec-private.pem");
+
+    let material_storage = MockStorage::new();
+    material_storage.store("source-key", key_pem).await.unwrap();
+
+    let manager = CertManager::builder()
+        .domains(["example.com"])
+        .crypto_storage(material_storage)
+        .store_strategy(StoreProvisioningStrategy::new(
+            MaterialSource::Filesystem(cert_path.into()),
+            MaterialSource::Storage("source-key".to_string()),
+        ))
+        .build()
+        .unwrap();
+
+    let cert_data = manager.request_certificate().await.unwrap();
+    assert!(
+        cert_data
+            .certificate
+            .contains("-----BEGIN CERTIFICATE-----")
+    );
+    assert_eq!(manager.signing_key_pem().await.unwrap(), key_pem);
+}
+
+#[tokio::test]
+async fn test_store_mixed_strategy_storage_cert_filesystem_key() {
+    init_crypto();
+
+    let source_cert_data: CertificateData =
+        serde_json::from_str(include_str!("../../../test_data/cert_data.json")).unwrap();
+    let cert_pem = source_cert_data.certificate.as_str();
+    let key_path = "test_data/ec-private.pem";
+    let key_pem = include_str!("../../../test_data/ec-private.pem");
+
+    let material_storage = MockStorage::new();
+    material_storage
+        .store("source-cert", cert_pem)
+        .await
+        .unwrap();
+
+    let manager = CertManager::builder()
+        .domains(["example.com"])
+        .crypto_storage(material_storage)
+        .store_strategy(StoreProvisioningStrategy::new(
+            MaterialSource::Storage("source-cert".to_string()),
+            MaterialSource::Filesystem(key_path.into()),
+        ))
+        .build()
+        .unwrap();
+
+    let cert_data = manager.request_certificate().await.unwrap();
+    assert_eq!(cert_data.certificate, cert_pem);
+    assert_eq!(manager.signing_key_pem().await.unwrap(), key_pem);
+}
+
 #[test]
 fn test_tld_plus_one_function() {
     init_crypto();

--- a/src/utils/file_watcher.rs
+++ b/src/utils/file_watcher.rs
@@ -257,6 +257,7 @@ mod tests {
                 time::OffsetDateTime::now_utc().unix_timestamp_nanos()
             ));
             std::fs::create_dir_all(&path).expect("create temp dir");
+            let path = std::fs::canonicalize(&path).unwrap_or(path);
             Self { path }
         }
     }
@@ -365,10 +366,11 @@ mod tests {
             }
         });
 
+        tokio::time::sleep(Duration::from_millis(100)).await;
         tokio::fs::write(&path, "second")
             .await
             .expect("write update");
-        timeout(Duration::from_secs(3), rx.recv())
+        timeout(Duration::from_secs(5), rx.recv())
             .await
             .expect("watcher callback timed out")
             .expect("watcher callback");

--- a/src/utils/metrics.rs
+++ b/src/utils/metrics.rs
@@ -27,6 +27,7 @@ static ROTATION_METRICS: OnceLock<Mutex<Option<(u64, RotationMetrics)>>> = OnceL
 
 #[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
 pub(crate) const TARGET_DATABASE: &str = "database";
+#[cfg(any(not(feature = "acme"), test))]
 pub(crate) const TARGET_TOKEN_SIGNING_KEY: &str = "token_signing_key";
 
 #[derive(Clone)]

--- a/tests/azure_keyvault.rs
+++ b/tests/azure_keyvault.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "azure-kv")]
+#![cfg(feature = "azure")]
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/tests/cert_provisioning.rs
+++ b/tests/cert_provisioning.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "aws-secrets")]
+#![cfg(feature = "aws")]
 
 //! Integration tests for the ACME certificate provisioning flow.
 //!

--- a/tests/gcp_secrets_manager.rs
+++ b/tests/gcp_secrets_manager.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "gcp-secrets")]
+#![cfg(feature = "gcp")]
 
 use std::time::Duration;
 


### PR DESCRIPTION
- Streamlined `CertStoreConfig` for same-source loading (filesystem or inline env vars) and removed fallback to bundled test keys.
- Enforced mutual exclusion between `acme` and static loading (`not(feature = "acme")`), eliminating runtime `provisioning_strategy` in favor of compile-time feature flags.
- Renamed cloud provider features to `aws`, `gcp`, and `azure` with transitive `acme` enablement, updating CI matrix, Docker, Compose, Helm, and documentation accordingly.