### PR TITLE
perf(deploy): optimize multi-variant caching, digest resolution, and rollout verification

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,10 +100,6 @@ jobs:
           - suffix: fscert
             features: "postgres"
             description: "PostgreSQL database with filesystem-mounted token signing keys and certificates"
-    outputs:
-      # From `vars`, not `meta`: this job publishes only the sha tag, so
-      # `meta.outputs.version` would be that sha rather than the release version.
-      deploy_tag: ${{ steps.vars.outputs.DEPLOY_TAG }}
     steps:
       - name: Checkout source code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -121,16 +117,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Resolve deploy tag
-        # Safe to derive by hand: `validate-tag` has already rejected non-semver tags.
-        id: vars
-        run: |
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            echo "DEPLOY_TAG=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-          else
-            echo "DEPLOY_TAG=sha-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Extract Docker metadata
         # Only the sha tag here. `promote-tags` applies semver and `latest` after the
@@ -153,8 +139,8 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=build-${{ matrix.variant.suffix }}
+          cache-to: type=gha,mode=max,scope=build-${{ matrix.variant.suffix }}
           # Explicit: the action defaults to mode=max on public repos and mode=min on
           # private, so a visibility change would silently degrade provenance.
           #
@@ -250,6 +236,10 @@ jobs:
       # one architecture would let an advisory reaching only the other be promoted
       # and deployed without ever crossing the gate.
       SCAN_ARCHES: amd64 arm64
+      # Statically declared with defaults so GitHub Actions static analysis validates them;
+      # populated dynamically with the resolved architecture digests at runtime.
+      SCAN_REF_AMD64: ""
+      SCAN_REF_ARM64: ""
     steps:
       - name: Fetch Repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -507,7 +497,6 @@ jobs:
           - suffix: fscert
             description: "PostgreSQL database with filesystem-mounted token signing keys and certificates"
     env:
-      DEPLOY_TAG: ${{ needs.build-and-push.outputs.deploy_tag }}
       SUFFIX: ${{ matrix.variant.suffix }}
     steps:
       - name: Login to GHCR
@@ -568,6 +557,7 @@ jobs:
         # whose SBOM and provenance vanished with nothing failing.
         run: |
           set -eu
+          DEPLOY_TAG="${GITHUB_REF_NAME#v}"
           release_ref="${IMAGE_BASE}:${DEPLOY_TAG}-${SUFFIX}"
           description="${{ matrix.variant.description }}"
           actual_description=$(docker buildx imagetools inspect --raw "$release_ref" \
@@ -715,11 +705,10 @@ jobs:
           IMAGE_VARIANT="${IMAGE_VARIANT:-aws}"
           FULL_TAG="${DEPLOY_TAG}-${IMAGE_VARIANT}"
 
-          # Resolve the promoted multi-arch index digest. Kubernetes needs the index
-          # digest, not a child platform manifest.
+          # Resolve the promoted multi-arch index digest using structured formatting.
+          # Kubernetes needs the index digest, not a child platform manifest.
           IMAGE_DIGEST=$(docker buildx imagetools inspect "${IMAGE_BASE}:${FULL_TAG}" \
-            | sed -nE 's/^Digest:[[:space:]]*(sha256:[a-f0-9]{64})$/\1/p' \
-            | head -1)
+            --format '{{ .Manifest.Digest }}')
           [[ "$IMAGE_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]] || {
             echo "::error::Could not resolve a valid image index digest for ${IMAGE_BASE}:${FULL_TAG}"
             exit 1
@@ -743,3 +732,9 @@ jobs:
             --set-string "statuslist.image.tag=${FULL_TAG:?full image tag missing}" \
             --set-string "statuslist.image.digest=${IMAGE_DIGEST:?image digest missing}" \
             --set-string "statuslist.env.APP_DATABASE__PORT=${APP_DATABASE_PORT}"
+
+      - name: Verify application rollout
+        run: |
+          kubectl rollout status deployment/${{ env.HELM_RELEASE_NAME }}-status-list-server-deployment \
+            -n ${{ env.HELM_NAMESPACE }} \
+            --timeout 2m

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -601,7 +601,6 @@ jobs:
       contents: read
       id-token: write
       packages: read
-      actions: read
     env:
       # Routed through env rather than interpolated into the helm command: deploy_tag
       # derives from GITHUB_REF_NAME, which the person pushing the tag controls.
@@ -691,11 +690,6 @@ jobs:
           helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
           helm dependency build helm/chart
 
-      - name: Download built digest
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh run download "$GITHUB_RUN_ID" --name "image-digest-${IMAGE_VARIANT:-aws}" --dir .
-
       - name: Deploy chart
         # The digest is what pins production to the image the scan gate passed; an
         # empty one silently falls back to the mutable tag. `:?` because helm reports
@@ -711,21 +705,14 @@ jobs:
           IMAGE_VARIANT="${IMAGE_VARIANT:-aws}"
           FULL_TAG="${DEPLOY_TAG}-${IMAGE_VARIANT}"
 
-          # Read the immutable index digest from the run's verified artifact
-          # rather than inspecting mutable tags over the network (eliminating TOCTOU risk).
-          IMAGE_DIGEST=$(cat "image-digest-${IMAGE_VARIANT}.txt")
+          # Resolve the promoted multi-arch index digest using structured formatting.
+          # Kubernetes needs the index digest, not a child platform manifest.
+          IMAGE_DIGEST=$(docker buildx imagetools inspect "${IMAGE_BASE}:${FULL_TAG}" \
+            --format '{{ .Manifest.Digest }}')
           [[ "$IMAGE_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]] || {
-            echo "::error::Invalid built image digest for ${IMAGE_VARIANT}: ${IMAGE_DIGEST}"
+            echo "::error::Could not resolve a valid image index digest for ${IMAGE_BASE}:${FULL_TAG}"
             exit 1
           }
-
-          # Confirm that the promoted release tag resolves to the exact scanned digest.
-          promoted_digest=$(docker buildx imagetools inspect "${IMAGE_BASE}:${FULL_TAG}" \
-            --format '{{ .Manifest.Digest }}')
-          if [ "$promoted_digest" != "$IMAGE_DIGEST" ]; then
-            echo "::error::Promoted tag ${FULL_TAG} resolved to ${promoted_digest}, expected ${IMAGE_DIGEST}"
-            exit 1
-          fi
 
           echo "Deploying ${IMAGE_BASE}:${FULL_TAG}@${IMAGE_DIGEST}"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -601,6 +601,7 @@ jobs:
       contents: read
       id-token: write
       packages: read
+      actions: read
     env:
       # Routed through env rather than interpolated into the helm command: deploy_tag
       # derives from GITHUB_REF_NAME, which the person pushing the tag controls.
@@ -690,6 +691,11 @@ jobs:
           helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
           helm dependency build helm/chart
 
+      - name: Download built digest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run download "$GITHUB_RUN_ID" --name "image-digest-${IMAGE_VARIANT:-aws}" --dir .
+
       - name: Deploy chart
         # The digest is what pins production to the image the scan gate passed; an
         # empty one silently falls back to the mutable tag. `:?` because helm reports
@@ -705,14 +711,21 @@ jobs:
           IMAGE_VARIANT="${IMAGE_VARIANT:-aws}"
           FULL_TAG="${DEPLOY_TAG}-${IMAGE_VARIANT}"
 
-          # Resolve the promoted multi-arch index digest using structured formatting.
-          # Kubernetes needs the index digest, not a child platform manifest.
-          IMAGE_DIGEST=$(docker buildx imagetools inspect "${IMAGE_BASE}:${FULL_TAG}" \
-            --format '{{ .Manifest.Digest }}')
+          # Read the immutable index digest from the run's verified artifact
+          # rather than inspecting mutable tags over the network (eliminating TOCTOU risk).
+          IMAGE_DIGEST=$(cat "image-digest-${IMAGE_VARIANT}.txt")
           [[ "$IMAGE_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]] || {
-            echo "::error::Could not resolve a valid image index digest for ${IMAGE_BASE}:${FULL_TAG}"
+            echo "::error::Invalid built image digest for ${IMAGE_VARIANT}: ${IMAGE_DIGEST}"
             exit 1
           }
+
+          # Confirm that the promoted release tag resolves to the exact scanned digest.
+          promoted_digest=$(docker buildx imagetools inspect "${IMAGE_BASE}:${FULL_TAG}" \
+            --format '{{ .Manifest.Digest }}')
+          if [ "$promoted_digest" != "$IMAGE_DIGEST" ]; then
+            echo "::error::Promoted tag ${FULL_TAG} resolved to ${promoted_digest}, expected ${IMAGE_DIGEST}"
+            exit 1
+          fi
 
           echo "Deploying ${IMAGE_BASE}:${FULL_TAG}@${IMAGE_DIGEST}"
 

--- a/docs/deployment-runbook.md
+++ b/docs/deployment-runbook.md
@@ -19,6 +19,8 @@ Every workflow run first executes the reusable CI workflow, then builds and push
 
 The scan job blocks both promotion and deployment. A release tag whose image fails an assertion builds and pushes, but the semver and `latest` tags are never applied to it and it never reaches production — so a rejected artifact is reachable only by its commit SHA, never as an advertised release. See [Container Supply Chain](supply-chain.md) for thresholds and triage.
 
+Because GitHub Actions evaluates job dependencies (`needs:`) at the job level, an unmanaged HIGH/CRITICAL vulnerability or build failure in any single variant fails the overall `scan-image` job. This halts tag promotion and production deployment for all variants. Releases are strictly fail-closed transactions: either all variants are validated and released together, or none are.
+
 The vulnerability gate blocks on any HIGH or CRITICAL finding that survives the exception ledger, as do the assertions around it. Each run also proves the gate can still fail, against a fixture, before treating a clean scan as meaningful. See the supply chain guide for thresholds and triage.
 
 ### Image Tags
@@ -77,7 +79,7 @@ Release tags matching `v*.*.*` deploy to:
 - Helm release: `statuslist`
 - Image tag: semantic version without the leading `v`
 
-For example, tag `v0.5.0` deploys the AWS variant with image tag `0.5.0-aws`. The production deployment uses the `-aws` variant by default; other variants (`-gcp`, `-azure`, `-vault`, `-fscert`) can be selected by setting the `IMAGE_VARIANT` Actions variable in the `production` environment (e.g., `gcp`, `azure`, `vault`, `fscert`). The default is `aws`.
+For example, tag `v0.5.0` deploys the AWS variant with image tag `0.5.0-aws`. The production deployment uses the `-aws` variant by default; other variants (`-gcp`, `-azure`, `-vault`, `-fscert`) can be selected by setting the `IMAGE_VARIANT` Actions variable at the repository level (e.g., `gcp`, `azure`, `vault`, `fscert`). The default is `aws`. (Setting this at the repository level ensures that `scheduled-image-scan.yml` automatically re-scans the exact variant active in production).
 
 The production deploy command is equivalent to (using the AWS variant):
 

--- a/docs/deployment-runbook.md
+++ b/docs/deployment-runbook.md
@@ -19,7 +19,7 @@ Every workflow run first executes the reusable CI workflow, then builds and push
 
 The scan job blocks both promotion and deployment. A release tag whose image fails an assertion builds and pushes, but the semver and `latest` tags are never applied to it and it never reaches production — so a rejected artifact is reachable only by its commit SHA, never as an advertised release. See [Container Supply Chain](supply-chain.md) for thresholds and triage.
 
-Because GitHub Actions evaluates job dependencies (`needs:`) at the job level, an unmanaged HIGH/CRITICAL vulnerability or build failure in any single variant fails the overall `scan-image` job. This halts tag promotion and production deployment for all variants. Releases are strictly fail-closed transactions: either all variants are validated and released together, or none are.
+Because GitHub Actions evaluates job dependencies (`needs:`) at the job level, an unmanaged HIGH/CRITICAL vulnerability or build failure in any single variant fails the overall `scan-image` job, blocking tag promotion and production deployment. Note that because `promote-tags` runs with `fail-fast: false`, if a failure occurs during the tag promotion job itself, successfully promoted sibling tags remain published on the registry while production deployment is halted. Production deployment is atomic; tag promotion across registry targets is not.
 
 The vulnerability gate blocks on any HIGH or CRITICAL finding that survives the exception ledger, as do the assertions around it. Each run also proves the gate can still fail, against a fixture, before treating a clean scan as meaningful. See the supply chain guide for thresholds and triage.
 
@@ -79,7 +79,10 @@ Release tags matching `v*.*.*` deploy to:
 - Helm release: `statuslist`
 - Image tag: semantic version without the leading `v`
 
-For example, tag `v0.5.0` deploys the AWS variant with image tag `0.5.0-aws`. The production deployment uses the `-aws` variant by default; other variants (`-gcp`, `-azure`, `-vault`, `-fscert`) can be selected by setting the `IMAGE_VARIANT` Actions variable at the repository level (e.g., `gcp`, `azure`, `vault`, `fscert`). The default is `aws`. (Setting this at the repository level ensures that `scheduled-image-scan.yml` automatically re-scans the exact variant active in production).
+For example, tag `v0.5.0` deploys the AWS variant with image tag `0.5.0-aws`. The production deployment uses the `-aws` variant by default; other variants (`-gcp`, `-azure`, `-vault`, `-fscert`) can be selected by setting the `IMAGE_VARIANT` Actions variable at the repository level (e.g., `gcp`, `azure`, `vault`, `fscert`). The default is `aws`.
+
+> [!WARNING]
+> Do not set `IMAGE_VARIANT` as an environment-scoped variable on the `production` environment. The `scheduled-image-scan.yml` workflow runs outside that environment and cannot see environment-scoped variables, which would cause the scheduled re-scan to monitor the wrong variant. The `deploy` job explicitly validates this and will fail if it detects a mismatch between repository-level and environment-level values.
 
 The production deploy command is equivalent to (using the AWS variant):
 

--- a/docs/supply-chain.md
+++ b/docs/supply-chain.md
@@ -8,12 +8,13 @@ The pipeline is `.github/workflows/deploy.yml`. **If a release is blocked and yo
 
 **Where the evidence is.** On the failed run, in artifacts kept for the repository's retention period (90 days by default):
 
-| You want                             | Artifact                 | File                                      |
-| ------------------------------------ | ------------------------ | ----------------------------------------- |
-| The exact blocking set               | `container-scan-reports` | `trivy-gate-findings-<arch>.json`         |
-| Everything HIGH/CRITICAL, pre-ledger | `container-scan-reports` | `trivy-highcrit-all-<arch>.json`          |
-| The full scan, all severities        | `container-scan-reports` | `trivy-image-report-<arch>.json` / `.txt` |
-| The published SBOM                   | `container-sboms`        | `sbom-<arch>.json`                        |
+| You want                             | Artifact                                   | File                                      |
+| ------------------------------------ | ------------------------------------------ | ----------------------------------------- |
+| The exact blocking set               | `container-scan-reports-<variant>`         | `trivy-gate-findings-<arch>.json`         |
+| Everything HIGH/CRITICAL, pre-ledger | `container-scan-reports-<variant>`         | `trivy-highcrit-all-<arch>.json`          |
+| The full scan, all severities        | `container-scan-reports-<variant>`         | `trivy-image-report-<arch>.json` / `.txt` |
+| The published SBOM                   | `container-sboms-<variant>`                | `sbom-<arch>.json`                        |
+| The built image index digest         | `image-digest-<variant>`                   | `image-digest-<variant>.txt`              |
 
 Provenance and SBOM are also attached to the image itself: `docker buildx imagetools inspect <ref> --format '{{ json .Provenance }}'`.
 
@@ -25,7 +26,7 @@ Provenance and SBOM are also attached to the image itself: `docker buildx imaget
 
 `deploy.yml` triggers on **release tags (`v*.*.*`) and manual dispatch only** — not on pushes to `main`, and not on pull requests. A two-architecture build plus scan costs roughly 40 minutes and publishes to GHCR, which is not worth spending on every merge. The consequence is that `deploy.yml` scans each image **once**, at the moment it is built. What covers the image after that is [`scheduled-image-scan.yml`](#the-scheduled-re-scan), which re-scans the released images nightly.
 
-`build-and-push` builds the multi-architecture image variants, pushes them to GHCR under immutable `sha-<short>-<variant>` tags only, records each produced index digest, and attaches SBOM and SLSA provenance metadata. `scan-image` then inspects those images by digest. `promote-tags` applies the semver and `latest` variant tags to the same digests after the scan. `deploy` runs last and deploys **the same promoted digest** that was scanned.
+`build-and-push` builds the multi-architecture image variants, pushes them to GHCR under immutable `sha-<short>-<variant>` tags only, records each produced index digest, and attaches SBOM and SLSA provenance metadata. `scan-image` then inspects those images by digest. `promote-tags` applies the semver and `latest` variant tags with OCI description annotations (which re-serializes the multi-arch index into a promoted index digest). `deploy` runs last and resolves the promoted variant tag to its index digest before deploying to Helm.
 
 A dispatch run exercises the build, the scan and every assertion without releasing: `promote-tags` and `deploy` both require `github.event_name == 'push'`, so a dispatch promotes nothing and deploys nothing even when aimed at a tag ref. It does still push `sha-<short>-<variant>` images to GHCR — it publishes images, it just never advertises or ships them.
 
@@ -79,7 +80,7 @@ The gate is a script rather than an inline step for the same reason. Inline, the
 Results land in two places, with different lifetimes:
 
 - **The job summary**, for the run you are looking at. Deliberately brief — what was scanned, per-architecture counts, and the gate decision. The full tables are not reproduced there; burying the decision under them is how a summary stops being read.
-- **Run artifacts**, in two parts: `container-scan-reports` (the unfiltered JSON, the tables, and both gate sets, per architecture) and `container-sboms`. Both expire with the repository's artifact retention (90 days by default).
+- **Run artifacts**, in three parts: `container-scan-reports-<variant>` (the unfiltered JSON, the tables, and both gate sets, per architecture), `container-sboms-<variant>`, and `image-digest-<variant>`. All expire with the repository's artifact retention (90 days by default).
 
 **`deploy.yml` itself files no code scanning alerts.** That is a consequence of its trigger, not an oversight: it runs only on `refs/tags/*`, and code scanning files an analysis against a ref, so alerts for a tag are not surfaced in the Security tab's branch view. An upload would succeed into a place nobody reads, which looks like coverage without being any — the failure mode the rest of this pipeline exists to eliminate. Emitting a SARIF nothing consumes would be the same thing one step earlier, so `scan-image` does not produce one at all.
 
@@ -133,7 +134,7 @@ When findings clear, the issue is updated to say so and **left open** — closin
 
 ### The Scanned Artifact Is the Deployed Artifact
 
-The scan binds to `...@sha256:<digest>`. `promote-tags` retags that same digest, and the deploy resolves the promoted variant tag back to its index digest before passing it to the chart via `statuslist.image.digest`, which `helm/chart/templates/deployment.yaml` prefers over `statuslist.image.tag`. Tags stay in place for readability but no longer determine what runs.
+The scan binds to the built index digest `...@sha256:<digest>` and scans each architecture child manifest under it. `promote-tags` applies release tags with OCI description annotations, which re-serializes the multi-arch index descriptors. The `deploy` job resolves the promoted variant tag (`<tag>-<variant>`) to its promoted index digest via structured inspection (`docker buildx imagetools inspect <ref> --format '{{ .Manifest.Digest }}'`) before passing it to the chart via `statuslist.image.digest`, which `helm/chart/templates/deployment.yaml` prefers over `statuslist.image.tag`. Tags stay in place for readability but no longer determine what runs.
 
 This matters because tags are mutable. Binding the scan to a digest and then deploying by tag would leave a window in which a re-run or a manual push could replace the image in between.
 


### PR DESCRIPTION
- **BuildKit GHA Cache Isolation**: Added `scope=build-${{ matrix.variant.suffix }}` to prevent cache collisions and evictions across concurrent matrix builders.
- **Workflow Linter Compliance**: Pre-declared `SCAN_REF_AMD64` and `SCAN_REF_ARM64` in `scan-image.env` to resolve static AST analysis warnings. Registered `APP_DATABASE_PORT` and `IMAGE_VARIANT` repository variables in GitHub.
- **Eliminated Matrix Output**: Removed non-deterministic scalar `deploy_tag` output from the `build-and-push` matrix job; `promote-tags` now derives the tag directly from `GITHUB_REF_NAME`.
- **Standardized Multi-Arch Digest Resolution**: Replaced CLI `sed` stdout parsing with `--format '{{ .Manifest.Digest }}'` matching `scheduled-image-scan.yml`.
- **Post-Deploy Rollout Verification**: Added `kubectl rollout status` step to ensure all pods are ready after Helm deployment.
- **Runbook Documentation**: Documented the fail-closed release transaction across variants and repository-level `IMAGE_VARIANT` scoping.