### PR TITLE
fix: unset CARGO_BUILD_TARGET when installing cargo tools in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,12 @@ WORKDIR /app
 # Declared above ARG FEATURES so a feature-set change does not invalidate this layer.
 ARG CARGO_AUDITABLE_VERSION=0.7.5
 ARG RUST_AUDIT_INFO_VERSION=0.5.4
+# Unset CARGO_BUILD_TARGET so cargo compiles the build tools natively for the builder host
+# (e.g. x86_64) rather than cross-compiling them for TARGETARCH.
 RUN --mount=type=cache,target=/root/.cargo/registry,id=registry-cache-${TARGETPLATFORM} \
     set -eu; \
-    cargo install --locked --root /usr/local cargo-auditable@${CARGO_AUDITABLE_VERSION}; \
-    cargo install --locked --root /usr/local rust-audit-info@${RUST_AUDIT_INFO_VERSION}
+    env -u CARGO_BUILD_TARGET cargo install --locked --root /usr/local cargo-auditable@${CARGO_AUDITABLE_VERSION}; \
+    env -u CARGO_BUILD_TARGET cargo install --locked --root /usr/local rust-audit-info@${RUST_AUDIT_INFO_VERSION}
 
 ARG FEATURES="postgres,aws"
 


### PR DESCRIPTION
## Description
Fixes multi-platform image build failures in the deployment workflow (`deploy.yml`).

### Root Cause
In `Dockerfile`, `blackdex/rust-musl:aarch64-musl` defines `CARGO_BUILD_TARGET=aarch64-unknown-linux-musl` in its container environment.
When building for `arm64` on an `x86_64` runner (`$BUILDPLATFORM`), `cargo install cargo-auditable` and `rust-audit-info` respected `CARGO_BUILD_TARGET` and cross-compiled those tools as `aarch64` binaries instead of native `x86_64` host binaries.
When the subsequent build step attempted to execute `cargo auditable build ...` on the builder machine, the kernel returned `ENOEXEC` and the shell threw:
```text
/usr/local/bin/cargo-auditable: 14: Syntax error: ")" unexpected
```

### Solution
Unset `CARGO_BUILD_TARGET` via `env -u CARGO_BUILD_TARGET` when installing `cargo-auditable` and `rust-audit-info`, ensuring they are compiled natively for the container's host execution environment.

### Verification
- Confirmed inside `blackdex/rust-musl:aarch64-musl` on `linux/amd64` that `cargo-auditable` and `rust-audit-info` build as `x86-64` ELF binaries.
- Ran a test build with `cargo auditable build --release --target=aarch64-unknown-linux-musl` and verified that `rust-audit-info` successfully extracts the embedded `.dep-v0` SBOM metadata.