### PR TITLE
fix(ci): fetch repo and pass repository flag for digest artifact download

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -256,7 +256,7 @@ jobs:
       - name: Download built digest
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh run download "$GITHUB_RUN_ID" --name "image-digest-${{ matrix.variant.suffix }}" --dir .
+        run: gh run download "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" --name "image-digest-${{ matrix.variant.suffix }}" --dir .
 
       - name: Resolve the architecture manifests to scan
         # Resolving each child manifest fixes which arches are scanned by construction,
@@ -499,6 +499,11 @@ jobs:
     env:
       SUFFIX: ${{ matrix.variant.suffix }}
     steps:
+      - name: Fetch Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
       - name: Login to GHCR
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
@@ -509,7 +514,7 @@ jobs:
       - name: Download built digest
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh run download "$GITHUB_RUN_ID" --name "image-digest-${{ matrix.variant.suffix }}" --dir .
+        run: gh run download "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" --name "image-digest-${{ matrix.variant.suffix }}" --dir .
 
       - name: Extract release tags
         # The `v*.*.*` glob absorbs prereleases, so `latest` is withheld explicitly.

--- a/.github/workflows/scheduled-image-scan.yml
+++ b/.github/workflows/scheduled-image-scan.yml
@@ -375,7 +375,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -uo pipefail
-          if ! gh run download "$GITHUB_RUN_ID" --dir artifacts; then
+          if ! gh run download "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" --dir artifacts; then
             echo "::warning::no artifacts could be downloaded from this run."
             mkdir -p artifacts
           fi


### PR DESCRIPTION
### Summary

- Adds `actions/checkout` step to the `promote-tags` job in `.github/workflows/deploy.yml` so that a git repository context is present.
- Explicitly adds `-R "$GITHUB_REPOSITORY"` to `gh run download` in both `deploy.yml` and `scheduled-image-scan.yml` to ensure artifact downloading succeeds even without local git repo inference.
- Retains existing semver tag formatting (without `v` prefix) as configured.

### Root Cause
During release tag promotion, the `promote-tags` job failed at `gh run download` with `fatal: not a git repository (or any of the parent directories): .git` because the repo was not checked out and no repository target was specified to the GitHub CLI.