### PR TITLE
fix(docs): update error response formats to use JSON instead of plaintext

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -166,9 +166,7 @@ each tier keyed and tuned independently:
 
 The writes tier is applied **before** the `auth` middleware (rate limiting by IP
 happens first, then authentication rejects unauthenticated requests with `401`).
-When a bucket is exhausted the server returns `429 Too Many Requests` with a
-plain-text body `Too Many Requests! Wait for <n>s` (emitted by the governor
-middleware; it is not RFC 7807 problem+json).
+When a bucket is exhausted the server returns `429 Too Many Requests`.
 
 > **Note:** Governor state is held in-memory per-replica. In a horizontally
 > scaled deployment each instance maintains its own token bucket, so the
@@ -211,10 +209,9 @@ defaults, not guarantees.
 | `500`  | Internal server error                                                 |
 | `503`  | Service temporarily unavailable                                       |
 
-Authentication errors use RFC 7807 `application/problem+json`; the body
+Authentication and handler-level errors use the shared JSON error shape
+`{"error": "<code>", "error_description": "<human-readable text>"}`. The body
 carries `Cache-Control: no-store, max-age=0` so error states are not cached.
-Handler-level status-list errors (`StatusListError`) return plain-text bodies
-(see tracking issue #156 for RFC 7807 adoption).
 
 ## Developer Integration
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -19,14 +19,6 @@ info:
     `update_conflict`. `error_description` is for humans and its wording is not
     part of the contract.
 
-    Two endpoints predate this shape and still return plain text: see the
-    `UnprocessableEntity` and `TooManyRequests` responses below.
-
-    > **Note:** RFC 7807 problem details (`application/problem+json`) are the
-    > intended long-term format for the whole API. Adoption is tracked in issue
-    > #156; until it lands, the schema documented here is what the server
-    > actually sends.
-
     Status list tokens are signed by the server and delivered as
     `application/statuslist+jwt` or `application/statuslist+cwt`. JWT-format
     tokens are gzip-compressed only when the client requests it via
@@ -52,9 +44,7 @@ info:
         Tunables: `permissive_burst_size`, `permissive_period_secs`
         (defaults: 100 / 60s).
 
-    When a quota is exhausted the server returns `429 Too Many Requests` with
-    a plain-text body of the form `Too Many Requests! Wait for <n>s` (emitted by
-    the `tower-governor` middleware; it is not RFC 7807 problem+json).
+    When a quota is exhausted the server returns `429 Too Many Requests`.
 
     ## Request bounds
 
@@ -653,8 +643,8 @@ components:
         The error body returned by every JSON error response. Serialized from
         `server::error::ErrorResponse`.
 
-        RFC 7807 problem details are the intended long-term replacement
-        (issue #156); this schema documents the current wire format.
+        This shape follows the `cloud-identity-wallet` house pattern used for
+        cross-project consistency across ADORSYS identity services.
       required:
         - error
       properties:
@@ -690,8 +680,12 @@ components:
             - credentials_already_exist
             - update_conflict
             - write_contention
+            # 413
+            - payload_too_large
             # 422
             - status_too_large
+            # 429
+            - too_many_requests
             # 500 / 503
             - internal_error
             - service_unavailable
@@ -845,10 +839,12 @@ components:
         `limits.max_body_size_bytes` (default 2 MiB). Rejected by the
         `RequestBodyLimitLayer` before the handler runs.
       content:
-        text/plain:
+        application/json:
           schema:
-            type: string
-          example: "length limit reached"
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: "payload_too_large"
+            error_description: "The request body exceeds the configured maximum size"
 
     UnprocessableEntity:
       description: |
@@ -856,27 +852,26 @@ components:
         exceeds the operator-configurable `limits.max_serialized_list_size`
         (default 1 MiB), or (for `POST /api/v1/credentials`) the supplied
         public key could not be parsed into a JWK.
-
-        > **Note:** This error currently returns a plain-text body.  RFC 7807
-        > `application/problem+json` adoption is tracked in issue #156.
       content:
-        text/plain:
+        application/json:
           schema:
-            type: string
-          example: "Serialized status list size exceeds the configured maximum"
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: "status_too_large"
+            error_description: "Serialized status list size exceeds the configured maximum"
 
     TooManyRequests:
       description: |
         The client has exceeded the configured rate-limit quota for the route
         tier (strict, per-issuer, or permissive — see the Rate limiting section
-        in the API description). Emitted by the `tower-governor` middleware as a
-        plain-text body of the form `Too Many Requests! Wait for <n>s`; it is
-        not RFC 7807 problem+json.
+        in the API description).
       content:
-        text/plain:
+        application/json:
           schema:
-            type: string
-          example: "Too Many Requests! Wait for 42s"
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: "too_many_requests"
+            error_description: "Too many requests"
 
     UpdateConflict:
       description: |


### PR DESCRIPTION
## Summary

Conform the OpenAPI error documentation to the implemented `ApiError` wire format.

## Changes

- Replaced remaining stale `problem+json` / RFC 7807 migration language in `docs/openapi.yaml`.
- Documented all OpenAPI error response components as `application/json` using the shared `ErrorResponse` schema.
- Added `payload_too_large` and `too_many_requests` to the shared error-code enum.
- Recorded the rationale that the `{error, error_description}` format follows the `cloud-identity-wallet` house pattern for ADORSYS identity services.
- Updated `docs/architecture.md` to describe the implemented shared JSON error shape instead of RFC 7807/plain-text handler errors.

## Verification

- `python3 -c 'import yaml; yaml.safe_load(open("docs/openapi.yaml")); print("ok")'`
- `cargo test server::error --lib`
- `cargo test server::auth::errors --lib`

## Notes

No generated-client deserialization test was added because the repo does not currently include a generated client or OpenAPI client test harness.