### PR TITLE
feat(auth): introduce AuthenticatedIssuer struct for better issuer management

### DIFF
--- a/src/server/auth/mod.rs
+++ b/src/server/auth/mod.rs
@@ -4,17 +4,19 @@ pub mod errors;
 
 use axum::{
     body::Body,
-    extract::{Request, State},
+    extract::{FromRequestParts, Request, State},
+    http::request::Parts,
     middleware::Next,
     response::IntoResponse,
 };
 use errors::AuthenticationError;
-use hyper::header;
+use hyper::{StatusCode, header};
 use jsonwebtoken::{DecodingKey, Validation};
 use serde::{Deserialize, Serialize};
+use std::future::Future;
 
 use crate::domain::models::credential::Issuer;
-use crate::server::AppState;
+use crate::server::{AppState, error::ApiError};
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Claims {
@@ -32,19 +34,65 @@ pub struct AuthenticatedIssuer {
 }
 
 impl AuthenticatedIssuer {
-    pub fn new(issuer: Issuer) -> Self {
+    /// Build an authenticated issuer principal from a verified issuer identity.
+    pub(crate) fn new(issuer: Issuer) -> Self {
         Self { issuer }
     }
 
+    /// Borrow the verified issuer identity associated with this principal.
     pub fn issuer(&self) -> &Issuer {
         &self.issuer
     }
 
+    /// Consume the principal and return the verified issuer identity.
     pub fn into_issuer(self) -> Issuer {
         self.issuer
     }
 }
 
+impl From<AuthenticatedIssuer> for Issuer {
+    fn from(principal: AuthenticatedIssuer) -> Self {
+        principal.issuer
+    }
+}
+
+impl AsRef<Issuer> for AuthenticatedIssuer {
+    fn as_ref(&self) -> &Issuer {
+        self.issuer()
+    }
+}
+
+impl AsRef<str> for AuthenticatedIssuer {
+    fn as_ref(&self) -> &str {
+        &self.issuer.0
+    }
+}
+
+impl<S> FromRequestParts<S> for AuthenticatedIssuer
+where
+    S: Send + Sync,
+{
+    type Rejection = ApiError;
+
+    fn from_request_parts(
+        parts: &mut Parts,
+        _state: &S,
+    ) -> impl Future<Output = Result<Self, Self::Rejection>> + Send {
+        let principal = parts.extensions.get::<AuthenticatedIssuer>().cloned();
+        async move {
+            principal.ok_or_else(|| {
+                ApiError::new(
+                    StatusCode::UNAUTHORIZED,
+                    "missing_auth_context",
+                    Some("Authenticated issuer context is missing".into()),
+                )
+            })
+        }
+    }
+}
+
+/// Formats the underlying issuer identifier, preserving the canonical string
+/// representation used by tracing fields.
 impl std::fmt::Display for AuthenticatedIssuer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.issuer.0.fmt(f)
@@ -99,7 +147,7 @@ mod tests {
     use super::*;
     use crate::test_utils::test_app_state;
     use axum::{
-        Extension, Router,
+        Router,
         body::{Body, to_bytes},
         extract::Request,
         http::{StatusCode, header},
@@ -318,7 +366,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_request_extension_contains_issuer() {
+    async fn test_authenticated_issuer_extractor_returns_principal() {
         let private_pem = test_ec_private_pem();
         let state = test_app_state(None).await;
 
@@ -331,9 +379,7 @@ mod tests {
             .await
             .unwrap();
 
-        async fn extension_test_handler(
-            Extension(principal): Extension<AuthenticatedIssuer>,
-        ) -> String {
+        async fn extension_test_handler(principal: AuthenticatedIssuer) -> String {
             assert_eq!(principal.issuer(), &Issuer("test-issuer".into()));
             principal.into_issuer().0
         }
@@ -358,5 +404,27 @@ mod tests {
         let bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
         let body = String::from_utf8(bytes.to_vec()).unwrap();
         assert_eq!(body, "test-issuer");
+    }
+
+    #[tokio::test]
+    async fn test_authenticated_issuer_extractor_returns_401_when_context_missing() {
+        let state = test_app_state(None).await;
+
+        async fn principal_handler(_principal: AuthenticatedIssuer) -> &'static str {
+            "Ok"
+        }
+
+        let app = Router::new()
+            .route("/test", get(principal_handler))
+            .with_state(state);
+
+        let request = Request::builder().uri("/test").body(Body::empty()).unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+        let bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["error"], "missing_auth_context");
     }
 }

--- a/src/server/auth/mod.rs
+++ b/src/server/auth/mod.rs
@@ -13,12 +13,42 @@ use hyper::header;
 use jsonwebtoken::{DecodingKey, Validation};
 use serde::{Deserialize, Serialize};
 
+use crate::domain::models::credential::Issuer;
 use crate::server::AppState;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Claims {
     iss: String,
     exp: usize,
+}
+
+/// Authenticated management principal derived from a validated issuer JWT.
+///
+/// Handlers should depend on this typed principal instead of extracting a raw
+/// issuer string from request extensions.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AuthenticatedIssuer {
+    issuer: Issuer,
+}
+
+impl AuthenticatedIssuer {
+    pub fn new(issuer: Issuer) -> Self {
+        Self { issuer }
+    }
+
+    pub fn issuer(&self) -> &Issuer {
+        &self.issuer
+    }
+
+    pub fn into_issuer(self) -> Issuer {
+        self.issuer
+    }
+}
+
+impl std::fmt::Display for AuthenticatedIssuer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.issuer.0.fmt(f)
+    }
 }
 
 /// Authentication middleware acting as a safeguard for unauthorized issuers
@@ -58,14 +88,15 @@ pub async fn auth(
 
     let token_data = jsonwebtoken::decode::<Claims>(token, &decoding_key, &validation)?;
 
-    request.extensions_mut().insert(token_data.claims.iss);
+    request
+        .extensions_mut()
+        .insert(AuthenticatedIssuer::new(Issuer(token_data.claims.iss)));
     Ok(next.run(request).await)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::models::credential::Issuer;
     use crate::test_utils::test_app_state;
     use axum::{
         Extension, Router,
@@ -300,9 +331,11 @@ mod tests {
             .await
             .unwrap();
 
-        async fn extension_test_handler(Extension(issuer): Extension<String>) -> String {
-            assert_eq!(issuer, "test-issuer");
-            issuer
+        async fn extension_test_handler(
+            Extension(principal): Extension<AuthenticatedIssuer>,
+        ) -> String {
+            assert_eq!(principal.issuer(), &Issuer("test-issuer".into()));
+            principal.into_issuer().0
         }
 
         let app = Router::new()

--- a/src/server/handlers/status_list/get_status_list.rs
+++ b/src/server/handlers/status_list/get_status_list.rs
@@ -269,18 +269,11 @@ fn build_cache_control(token_ttl_secs: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::models::credential::Issuer;
-    use crate::server::auth::AuthenticatedIssuer;
     use crate::server::handlers::status_list::publish_status::publish_status;
     use crate::server::handlers::status_list::utils::request::StatusesRequest;
-    use crate::test_utils::test_app_state;
-    use axum::Extension;
+    use crate::test_utils::{authenticated_issuer, test_app_state};
     use axum::extract::Json;
     use axum::http::HeaderMap;
-
-    fn authenticated_issuer(issuer: impl Into<String>) -> AuthenticatedIssuer {
-        AuthenticatedIssuer::new(Issuer(issuer.into()))
-    }
 
     #[test]
     fn test_accepts_gzip_simple() {
@@ -393,7 +386,7 @@ mod tests {
         // Publish first
         publish_status(
             State(app_state.clone()),
-            Extension(authenticated_issuer("issuer1".to_string())),
+            authenticated_issuer("issuer1"),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )
@@ -433,7 +426,7 @@ mod tests {
 
         publish_status(
             State(app_state.clone()),
-            Extension(authenticated_issuer("issuer1".to_string())),
+            authenticated_issuer("issuer1"),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )
@@ -470,7 +463,7 @@ mod tests {
 
         publish_status(
             State(app_state.clone()),
-            Extension(authenticated_issuer("issuer1".to_string())),
+            authenticated_issuer("issuer1"),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )
@@ -510,7 +503,7 @@ mod tests {
 
         publish_status(
             State(app_state.clone()),
-            Extension(authenticated_issuer("issuer1".to_string())),
+            authenticated_issuer("issuer1"),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )
@@ -544,7 +537,7 @@ mod tests {
 
         publish_status(
             State(app_state.clone()),
-            Extension(authenticated_issuer("issuer1".to_string())),
+            authenticated_issuer("issuer1"),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )
@@ -577,7 +570,7 @@ mod tests {
 
         publish_status(
             State(app_state.clone()),
-            Extension(authenticated_issuer("issuer1".to_string())),
+            authenticated_issuer("issuer1"),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )
@@ -643,7 +636,7 @@ mod tests {
 
         publish_status(
             State(app_state.clone()),
-            Extension(authenticated_issuer("issuer1".to_string())),
+            authenticated_issuer("issuer1"),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )

--- a/src/server/handlers/status_list/get_status_list.rs
+++ b/src/server/handlers/status_list/get_status_list.rs
@@ -269,12 +269,18 @@ fn build_cache_control(token_ttl_secs: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::models::credential::Issuer;
+    use crate::server::auth::AuthenticatedIssuer;
     use crate::server::handlers::status_list::publish_status::publish_status;
     use crate::server::handlers::status_list::utils::request::StatusesRequest;
     use crate::test_utils::test_app_state;
     use axum::Extension;
     use axum::extract::Json;
     use axum::http::HeaderMap;
+
+    fn authenticated_issuer(issuer: impl Into<String>) -> AuthenticatedIssuer {
+        AuthenticatedIssuer::new(Issuer(issuer.into()))
+    }
 
     #[test]
     fn test_accepts_gzip_simple() {
@@ -387,7 +393,7 @@ mod tests {
         // Publish first
         publish_status(
             State(app_state.clone()),
-            Extension("issuer1".to_string()),
+            Extension(authenticated_issuer("issuer1".to_string())),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )
@@ -427,7 +433,7 @@ mod tests {
 
         publish_status(
             State(app_state.clone()),
-            Extension("issuer1".to_string()),
+            Extension(authenticated_issuer("issuer1".to_string())),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )
@@ -464,7 +470,7 @@ mod tests {
 
         publish_status(
             State(app_state.clone()),
-            Extension("issuer1".to_string()),
+            Extension(authenticated_issuer("issuer1".to_string())),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )
@@ -504,7 +510,7 @@ mod tests {
 
         publish_status(
             State(app_state.clone()),
-            Extension("issuer1".to_string()),
+            Extension(authenticated_issuer("issuer1".to_string())),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )
@@ -538,7 +544,7 @@ mod tests {
 
         publish_status(
             State(app_state.clone()),
-            Extension("issuer1".to_string()),
+            Extension(authenticated_issuer("issuer1".to_string())),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )
@@ -571,7 +577,7 @@ mod tests {
 
         publish_status(
             State(app_state.clone()),
-            Extension("issuer1".to_string()),
+            Extension(authenticated_issuer("issuer1".to_string())),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )
@@ -637,7 +643,7 @@ mod tests {
 
         publish_status(
             State(app_state.clone()),
-            Extension("issuer1".to_string()),
+            Extension(authenticated_issuer("issuer1".to_string())),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )

--- a/src/server/handlers/status_list/publish_status.rs
+++ b/src/server/handlers/status_list/publish_status.rs
@@ -1,5 +1,4 @@
 use axum::{
-    Extension,
     extract::{Json, Path, State},
     http::StatusCode,
     response::IntoResponse,
@@ -19,7 +18,7 @@ use super::utils::request::StatusesRequest;
 #[tracing::instrument(skip_all, fields(list_id = %list_id, issuer = %principal), err(level = "info", Debug))]
 pub async fn publish_status(
     State(appstate): State<AppState>,
-    Extension(principal): Extension<AuthenticatedIssuer>,
+    principal: AuthenticatedIssuer,
     Path(list_id): Path<String>,
     Json(payload): Json<StatusesRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
@@ -45,7 +44,7 @@ pub async fn publish_status(
         .service
         .publish_status_list(
             list_id,
-            principal.into_issuer(),
+            principal.into(),
             sub,
             statuses,
             appstate.token_exp_secs,
@@ -65,11 +64,7 @@ mod tests {
     use crate::server::handlers::status_list::utils::request::{
         Status as RequestStatus, StatusEntry as RequestStatusEntry,
     };
-    use crate::test_utils::test_app_state;
-
-    fn authenticated_issuer(issuer: impl Into<String>) -> AuthenticatedIssuer {
-        AuthenticatedIssuer::new(Issuer(issuer.into()))
-    }
+    use crate::test_utils::{authenticated_issuer, test_app_state};
 
     #[tokio::test]
     async fn test_publish_token_status_invalid_list_id() {
@@ -79,7 +74,7 @@ mod tests {
 
         let result = publish_status(
             State(appstate),
-            Extension(authenticated_issuer(&issuer)),
+            authenticated_issuer(issuer),
             Path("not-a-uuid".to_string()),
             Json(payload),
         )
@@ -99,7 +94,7 @@ mod tests {
 
         let response = publish_status(
             State(app_state.clone()),
-            Extension(authenticated_issuer("issuer".to_string())),
+            authenticated_issuer("issuer"),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )
@@ -120,7 +115,7 @@ mod tests {
 
         let res1 = publish_status(
             State(app_state.clone()),
-            Extension(authenticated_issuer("issuer".to_string())),
+            authenticated_issuer("issuer"),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )
@@ -131,7 +126,7 @@ mod tests {
 
         let res2 = publish_status(
             State(app_state.clone()),
-            Extension(authenticated_issuer("issuer".to_string())),
+            authenticated_issuer("issuer"),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )
@@ -144,6 +139,9 @@ mod tests {
         assert_eq!(err.status, StatusCode::CONFLICT);
     }
 
+    /// Publish is insert-only for a list ID: once `issuer1` creates a list,
+    /// another authenticated issuer cannot overwrite or hijack it with PUT.
+    /// The original issuer's record must remain intact.
     #[tokio::test]
     async fn test_publish_status_rejects_wrong_issuer_republish() {
         let token_id = uuid::Uuid::new_v4().to_string();
@@ -151,7 +149,7 @@ mod tests {
 
         publish_status(
             State(app_state.clone()),
-            Extension(authenticated_issuer("issuer1")),
+            authenticated_issuer("issuer1"),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )
@@ -160,7 +158,7 @@ mod tests {
 
         let result = publish_status(
             State(app_state.clone()),
-            Extension(authenticated_issuer("issuer2")),
+            authenticated_issuer("issuer2"),
             Path(token_id.clone()),
             Json(StatusesRequest {
                 statuses: vec![RequestStatusEntry {
@@ -233,7 +231,7 @@ mod tests {
             async move {
                 publish_status(
                     State(state),
-                    Extension(authenticated_issuer(issuer)),
+                    authenticated_issuer(issuer),
                     Path(list_id),
                     Json(StatusesRequest {
                         statuses: vec![RequestStatusEntry {
@@ -343,7 +341,7 @@ mod tests {
             async move {
                 publish_status(
                     State(state),
-                    Extension(authenticated_issuer(issuer)),
+                    authenticated_issuer(issuer),
                     Path(list_id),
                     Json(StatusesRequest {
                         statuses: vec![RequestStatusEntry {
@@ -425,7 +423,7 @@ mod tests {
 
         let result = publish_status(
             State(app_state),
-            Extension(authenticated_issuer("issuer".to_string())),
+            authenticated_issuer("issuer"),
             Path(token_id),
             Json(StatusesRequest {
                 statuses: status_entries,
@@ -453,7 +451,7 @@ mod tests {
 
         let result = publish_status(
             State(app_state),
-            Extension(authenticated_issuer("issuer".to_string())),
+            authenticated_issuer("issuer"),
             Path(token_id),
             Json(StatusesRequest {
                 statuses: status_entries,
@@ -484,7 +482,7 @@ mod tests {
 
         let result = publish_status(
             State(app_state),
-            Extension(authenticated_issuer("issuer".to_string())),
+            authenticated_issuer("issuer"),
             Path(token_id),
             Json(StatusesRequest {
                 statuses: status_entries,

--- a/src/server/handlers/status_list/publish_status.rs
+++ b/src/server/handlers/status_list/publish_status.rs
@@ -5,10 +5,7 @@ use axum::{
     response::IntoResponse,
 };
 
-use crate::{
-    domain::models::credential::Issuer,
-    server::{AppState, error::ApiError},
-};
+use crate::server::{AppState, auth::AuthenticatedIssuer, error::ApiError};
 
 use super::utils::request::StatusesRequest;
 
@@ -19,10 +16,10 @@ use super::utils::request::StatusesRequest;
 /// `err(level = "info")` for the reason on `update_status`: the default ERROR
 /// level would page on write contention and on a racing publish, both 409s the
 /// response layer already logs at the right severity.
-#[tracing::instrument(skip_all, fields(list_id = %list_id, issuer = %issuer), err(level = "info", Debug))]
+#[tracing::instrument(skip_all, fields(list_id = %list_id, issuer = %principal), err(level = "info", Debug))]
 pub async fn publish_status(
     State(appstate): State<AppState>,
-    Extension(issuer): Extension<String>,
+    Extension(principal): Extension<AuthenticatedIssuer>,
     Path(list_id): Path<String>,
     Json(payload): Json<StatusesRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
@@ -48,7 +45,7 @@ pub async fn publish_status(
         .service
         .publish_status_list(
             list_id,
-            Issuer(issuer),
+            principal.into_issuer(),
             sub,
             statuses,
             appstate.token_exp_secs,
@@ -64,10 +61,15 @@ pub async fn publish_status(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::models::credential::Issuer;
     use crate::server::handlers::status_list::utils::request::{
         Status as RequestStatus, StatusEntry as RequestStatusEntry,
     };
     use crate::test_utils::test_app_state;
+
+    fn authenticated_issuer(issuer: impl Into<String>) -> AuthenticatedIssuer {
+        AuthenticatedIssuer::new(Issuer(issuer.into()))
+    }
 
     #[tokio::test]
     async fn test_publish_token_status_invalid_list_id() {
@@ -77,7 +79,7 @@ mod tests {
 
         let result = publish_status(
             State(appstate),
-            Extension(issuer),
+            Extension(authenticated_issuer(&issuer)),
             Path("not-a-uuid".to_string()),
             Json(payload),
         )
@@ -97,7 +99,7 @@ mod tests {
 
         let response = publish_status(
             State(app_state.clone()),
-            Extension("issuer".to_string()),
+            Extension(authenticated_issuer("issuer".to_string())),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )
@@ -118,7 +120,7 @@ mod tests {
 
         let res1 = publish_status(
             State(app_state.clone()),
-            Extension("issuer".to_string()),
+            Extension(authenticated_issuer("issuer".to_string())),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )
@@ -129,7 +131,7 @@ mod tests {
 
         let res2 = publish_status(
             State(app_state.clone()),
-            Extension("issuer".to_string()),
+            Extension(authenticated_issuer("issuer".to_string())),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )
@@ -140,6 +142,44 @@ mod tests {
             Err(e) => e,
         };
         assert_eq!(err.status, StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn test_publish_status_rejects_wrong_issuer_republish() {
+        let token_id = uuid::Uuid::new_v4().to_string();
+        let app_state = test_app_state(None).await;
+
+        publish_status(
+            State(app_state.clone()),
+            Extension(authenticated_issuer("issuer1")),
+            Path(token_id.clone()),
+            Json(StatusesRequest { statuses: vec![] }),
+        )
+        .await
+        .unwrap();
+
+        let result = publish_status(
+            State(app_state.clone()),
+            Extension(authenticated_issuer("issuer2")),
+            Path(token_id.clone()),
+            Json(StatusesRequest {
+                statuses: vec![RequestStatusEntry {
+                    index: 0,
+                    status: RequestStatus::INVALID,
+                }],
+            }),
+        )
+        .await;
+
+        let err = match result {
+            Ok(_) => panic!("expected different issuer to be rejected for existing list_id"),
+            Err(e) => e,
+        };
+        assert_eq!(err.status, StatusCode::CONFLICT);
+        assert_eq!(err.error, "status_list_already_exists");
+
+        let record = app_state.service.get_status_list(&token_id).await.unwrap();
+        assert_eq!(record.issuer, Issuer("issuer1".into()));
     }
 
     /// The losing publisher of a `list_id` race gets 409, not 500 — end to end,
@@ -193,7 +233,7 @@ mod tests {
             async move {
                 publish_status(
                     State(state),
-                    Extension(issuer.to_string()),
+                    Extension(authenticated_issuer(issuer)),
                     Path(list_id),
                     Json(StatusesRequest {
                         statuses: vec![RequestStatusEntry {
@@ -303,7 +343,7 @@ mod tests {
             async move {
                 publish_status(
                     State(state),
-                    Extension(issuer.to_string()),
+                    Extension(authenticated_issuer(issuer)),
                     Path(list_id),
                     Json(StatusesRequest {
                         statuses: vec![RequestStatusEntry {
@@ -385,7 +425,7 @@ mod tests {
 
         let result = publish_status(
             State(app_state),
-            Extension("issuer".to_string()),
+            Extension(authenticated_issuer("issuer".to_string())),
             Path(token_id),
             Json(StatusesRequest {
                 statuses: status_entries,
@@ -413,7 +453,7 @@ mod tests {
 
         let result = publish_status(
             State(app_state),
-            Extension("issuer".to_string()),
+            Extension(authenticated_issuer("issuer".to_string())),
             Path(token_id),
             Json(StatusesRequest {
                 statuses: status_entries,
@@ -444,7 +484,7 @@ mod tests {
 
         let result = publish_status(
             State(app_state),
-            Extension("issuer".to_string()),
+            Extension(authenticated_issuer("issuer".to_string())),
             Path(token_id),
             Json(StatusesRequest {
                 statuses: status_entries,

--- a/src/server/handlers/status_list/update_status.rs
+++ b/src/server/handlers/status_list/update_status.rs
@@ -5,10 +5,7 @@ use axum::{
 };
 use hyper::StatusCode;
 
-use crate::{
-    domain::models::credential::Issuer,
-    server::{AppState, error::ApiError},
-};
+use crate::server::{AppState, auth::AuthenticatedIssuer, error::ApiError};
 
 use super::utils::request::StatusesRequest;
 
@@ -20,10 +17,10 @@ use super::utils::request::StatusesRequest;
 /// which would page on routine write contention and on optimistic-concurrency
 /// conflicts. Severity belongs to [`ApiError`]'s `IntoResponse`, which
 /// discriminates on status; this event only adds span context.
-#[tracing::instrument(skip_all, fields(list_id = %list_id, issuer = %issuer), err(level = "info", Debug))]
+#[tracing::instrument(skip_all, fields(list_id = %list_id, issuer = %principal), err(level = "info", Debug))]
 pub async fn update_status(
     State(appstate): State<AppState>,
-    Extension(issuer): Extension<String>,
+    Extension(principal): Extension<AuthenticatedIssuer>,
     Path(list_id): Path<String>,
     Json(payload): Json<StatusesRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
@@ -43,7 +40,7 @@ pub async fn update_status(
     appstate
         .service
         .update_statuses(
-            &Issuer(issuer),
+            principal.issuer(),
             &list_id,
             statuses,
             appstate.token_exp_secs,
@@ -59,11 +56,16 @@ pub async fn update_status(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::models::credential::Issuer;
     use crate::server::handlers::status_list::publish_status::publish_status;
     use crate::server::handlers::status_list::utils::request::{
         Status as RequestStatus, StatusEntry as RequestStatusEntry,
     };
     use crate::test_utils::test_app_state;
+
+    fn authenticated_issuer(issuer: impl Into<String>) -> AuthenticatedIssuer {
+        AuthenticatedIssuer::new(Issuer(issuer.into()))
+    }
 
     #[tokio::test]
     async fn test_update_token_status_invalid_list_id() {
@@ -73,7 +75,7 @@ mod tests {
 
         let result = update_status(
             State(appstate),
-            Extension(issuer),
+            Extension(authenticated_issuer(&issuer)),
             Path("not-a-uuid".to_string()),
             Json(payload),
         )
@@ -90,7 +92,7 @@ mod tests {
         // First publish
         publish_status(
             State(app_state.clone()),
-            Extension("issuer1".to_string()),
+            Extension(authenticated_issuer("issuer1".to_string())),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )
@@ -100,7 +102,7 @@ mod tests {
         // Then update
         let update_res = update_status(
             State(app_state.clone()),
-            Extension("issuer1".to_string()),
+            Extension(authenticated_issuer("issuer1".to_string())),
             Path(token_id.clone()),
             Json(StatusesRequest {
                 statuses: vec![RequestStatusEntry {
@@ -126,7 +128,7 @@ mod tests {
 
         publish_status(
             State(app_state.clone()),
-            Extension("issuer1".to_string()),
+            Extension(authenticated_issuer("issuer1".to_string())),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )
@@ -135,7 +137,7 @@ mod tests {
 
         let update_res = update_status(
             State(app_state.clone()),
-            Extension("issuer2".to_string()),
+            Extension(authenticated_issuer("issuer2".to_string())),
             Path(token_id.clone()),
             Json(StatusesRequest {
                 statuses: vec![RequestStatusEntry {
@@ -146,7 +148,12 @@ mod tests {
         )
         .await;
 
-        assert!(update_res.is_err());
+        let err = match update_res {
+            Ok(_) => panic!("expected wrong issuer update to be rejected"),
+            Err(e) => e,
+        };
+        assert_eq!(err.status, StatusCode::FORBIDDEN);
+        assert_eq!(err.error, "issuer_mismatch");
     }
 
     #[tokio::test]
@@ -156,7 +163,7 @@ mod tests {
 
         publish_status(
             State(app_state.clone()),
-            Extension("issuer1".to_string()),
+            Extension(authenticated_issuer("issuer1".to_string())),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )
@@ -167,7 +174,7 @@ mod tests {
 
         let update_res = update_status(
             State(app_state.clone()),
-            Extension("issuer1".to_string()),
+            Extension(authenticated_issuer("issuer1".to_string())),
             Path(token_id.clone()),
             Json(StatusesRequest {
                 statuses: vec![
@@ -194,7 +201,7 @@ mod tests {
 
         publish_status(
             State(app_state.clone()),
-            Extension("issuer1".to_string()),
+            Extension(authenticated_issuer("issuer1".to_string())),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )
@@ -205,7 +212,7 @@ mod tests {
 
         let update_res = update_status(
             State(app_state.clone()),
-            Extension("issuer1".to_string()),
+            Extension(authenticated_issuer("issuer1".to_string())),
             Path(token_id.clone()),
             Json(StatusesRequest {
                 statuses: vec![RequestStatusEntry {
@@ -226,7 +233,7 @@ mod tests {
 
         let result = update_status(
             State(app_state),
-            Extension("issuer1".to_string()),
+            Extension(authenticated_issuer("issuer1".to_string())),
             Path(nonexistent_id),
             Json(StatusesRequest {
                 statuses: vec![RequestStatusEntry {
@@ -248,7 +255,7 @@ mod tests {
         // Publish initial status list
         publish_status(
             State(app_state.clone()),
-            Extension("issuer1".to_string()),
+            Extension(authenticated_issuer("issuer1".to_string())),
             Path(token_id.clone()),
             Json(StatusesRequest {
                 statuses: vec![RequestStatusEntry {
@@ -267,7 +274,7 @@ mod tests {
         // Perform an update to advance updated_at
         update_status(
             State(app_state.clone()),
-            Extension("issuer1".to_string()),
+            Extension(authenticated_issuer("issuer1".to_string())),
             Path(token_id.clone()),
             Json(StatusesRequest {
                 statuses: vec![RequestStatusEntry {
@@ -285,7 +292,7 @@ mod tests {
         // enforce optimistic locking. The SQL backends enforce it via updated_at checks.
         let result = update_status(
             State(app_state.clone()),
-            Extension("issuer1".to_string()),
+            Extension(authenticated_issuer("issuer1".to_string())),
             Path(token_id.clone()),
             Json(StatusesRequest {
                 statuses: vec![RequestStatusEntry {
@@ -309,7 +316,7 @@ mod tests {
 
         publish_status(
             State(app_state.clone()),
-            Extension("issuer1".to_string()),
+            Extension(authenticated_issuer("issuer1".to_string())),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )
@@ -321,7 +328,7 @@ mod tests {
 
         let update_res = update_status(
             State(app_state.clone()),
-            Extension("issuer1".to_string()),
+            Extension(authenticated_issuer("issuer1".to_string())),
             Path(token_id.clone()),
             Json(StatusesRequest {
                 statuses: vec![RequestStatusEntry {

--- a/src/server/handlers/status_list/update_status.rs
+++ b/src/server/handlers/status_list/update_status.rs
@@ -1,5 +1,4 @@
 use axum::{
-    Extension,
     extract::{Json, Path, State},
     response::IntoResponse,
 };
@@ -20,7 +19,7 @@ use super::utils::request::StatusesRequest;
 #[tracing::instrument(skip_all, fields(list_id = %list_id, issuer = %principal), err(level = "info", Debug))]
 pub async fn update_status(
     State(appstate): State<AppState>,
-    Extension(principal): Extension<AuthenticatedIssuer>,
+    principal: AuthenticatedIssuer,
     Path(list_id): Path<String>,
     Json(payload): Json<StatusesRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
@@ -40,7 +39,7 @@ pub async fn update_status(
     appstate
         .service
         .update_statuses(
-            principal.issuer(),
+            principal.as_ref(),
             &list_id,
             statuses,
             appstate.token_exp_secs,
@@ -56,16 +55,11 @@ pub async fn update_status(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::models::credential::Issuer;
     use crate::server::handlers::status_list::publish_status::publish_status;
     use crate::server::handlers::status_list::utils::request::{
         Status as RequestStatus, StatusEntry as RequestStatusEntry,
     };
-    use crate::test_utils::test_app_state;
-
-    fn authenticated_issuer(issuer: impl Into<String>) -> AuthenticatedIssuer {
-        AuthenticatedIssuer::new(Issuer(issuer.into()))
-    }
+    use crate::test_utils::{authenticated_issuer, test_app_state};
 
     #[tokio::test]
     async fn test_update_token_status_invalid_list_id() {
@@ -75,7 +69,7 @@ mod tests {
 
         let result = update_status(
             State(appstate),
-            Extension(authenticated_issuer(&issuer)),
+            authenticated_issuer(issuer),
             Path("not-a-uuid".to_string()),
             Json(payload),
         )
@@ -92,7 +86,7 @@ mod tests {
         // First publish
         publish_status(
             State(app_state.clone()),
-            Extension(authenticated_issuer("issuer1".to_string())),
+            authenticated_issuer("issuer1"),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )
@@ -102,7 +96,7 @@ mod tests {
         // Then update
         let update_res = update_status(
             State(app_state.clone()),
-            Extension(authenticated_issuer("issuer1".to_string())),
+            authenticated_issuer("issuer1"),
             Path(token_id.clone()),
             Json(StatusesRequest {
                 statuses: vec![RequestStatusEntry {
@@ -128,7 +122,7 @@ mod tests {
 
         publish_status(
             State(app_state.clone()),
-            Extension(authenticated_issuer("issuer1".to_string())),
+            authenticated_issuer("issuer1"),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )
@@ -137,7 +131,7 @@ mod tests {
 
         let update_res = update_status(
             State(app_state.clone()),
-            Extension(authenticated_issuer("issuer2".to_string())),
+            authenticated_issuer("issuer2"),
             Path(token_id.clone()),
             Json(StatusesRequest {
                 statuses: vec![RequestStatusEntry {
@@ -154,6 +148,9 @@ mod tests {
         };
         assert_eq!(err.status, StatusCode::FORBIDDEN);
         assert_eq!(err.error, "issuer_mismatch");
+
+        let record = app_state.service.get_status_list(&token_id).await.unwrap();
+        assert!(record.status_list.lst.is_empty());
     }
 
     #[tokio::test]
@@ -163,7 +160,7 @@ mod tests {
 
         publish_status(
             State(app_state.clone()),
-            Extension(authenticated_issuer("issuer1".to_string())),
+            authenticated_issuer("issuer1"),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )
@@ -174,7 +171,7 @@ mod tests {
 
         let update_res = update_status(
             State(app_state.clone()),
-            Extension(authenticated_issuer("issuer1".to_string())),
+            authenticated_issuer("issuer1"),
             Path(token_id.clone()),
             Json(StatusesRequest {
                 statuses: vec![
@@ -201,7 +198,7 @@ mod tests {
 
         publish_status(
             State(app_state.clone()),
-            Extension(authenticated_issuer("issuer1".to_string())),
+            authenticated_issuer("issuer1"),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )
@@ -212,7 +209,7 @@ mod tests {
 
         let update_res = update_status(
             State(app_state.clone()),
-            Extension(authenticated_issuer("issuer1".to_string())),
+            authenticated_issuer("issuer1"),
             Path(token_id.clone()),
             Json(StatusesRequest {
                 statuses: vec![RequestStatusEntry {
@@ -233,7 +230,7 @@ mod tests {
 
         let result = update_status(
             State(app_state),
-            Extension(authenticated_issuer("issuer1".to_string())),
+            authenticated_issuer("issuer1"),
             Path(nonexistent_id),
             Json(StatusesRequest {
                 statuses: vec![RequestStatusEntry {
@@ -255,7 +252,7 @@ mod tests {
         // Publish initial status list
         publish_status(
             State(app_state.clone()),
-            Extension(authenticated_issuer("issuer1".to_string())),
+            authenticated_issuer("issuer1"),
             Path(token_id.clone()),
             Json(StatusesRequest {
                 statuses: vec![RequestStatusEntry {
@@ -274,7 +271,7 @@ mod tests {
         // Perform an update to advance updated_at
         update_status(
             State(app_state.clone()),
-            Extension(authenticated_issuer("issuer1".to_string())),
+            authenticated_issuer("issuer1"),
             Path(token_id.clone()),
             Json(StatusesRequest {
                 statuses: vec![RequestStatusEntry {
@@ -292,7 +289,7 @@ mod tests {
         // enforce optimistic locking. The SQL backends enforce it via updated_at checks.
         let result = update_status(
             State(app_state.clone()),
-            Extension(authenticated_issuer("issuer1".to_string())),
+            authenticated_issuer("issuer1"),
             Path(token_id.clone()),
             Json(StatusesRequest {
                 statuses: vec![RequestStatusEntry {
@@ -316,7 +313,7 @@ mod tests {
 
         publish_status(
             State(app_state.clone()),
-            Extension(authenticated_issuer("issuer1".to_string())),
+            authenticated_issuer("issuer1"),
             Path(token_id.clone()),
             Json(StatusesRequest { statuses: vec![] }),
         )
@@ -328,7 +325,7 @@ mod tests {
 
         let update_res = update_status(
             State(app_state.clone()),
-            Extension(authenticated_issuer("issuer1".to_string())),
+            authenticated_issuer("issuer1"),
             Path(token_id.clone()),
             Json(StatusesRequest {
                 statuses: vec![RequestStatusEntry {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -15,6 +15,7 @@ use crate::outbound::sql::{
     SeaOrmStore, SqlCredentialRepo, SqlStatusListRepo, SqlStatusListSnapshotRepo,
 };
 use crate::server::AppState;
+use crate::server::auth::AuthenticatedIssuer;
 use crate::server::health::Readiness;
 #[cfg(feature = "acme")]
 use crate::{cert_manager::storage::StorageError, utils::cert_manager::storage::Storage};
@@ -22,6 +23,10 @@ use async_trait::async_trait;
 #[cfg(feature = "acme")]
 use std::collections::HashMap;
 use std::sync::Arc;
+
+pub(crate) fn authenticated_issuer(issuer: impl Into<String>) -> AuthenticatedIssuer {
+    AuthenticatedIssuer::new(crate::domain::models::credential::Issuer(issuer.into()))
+}
 
 #[cfg(feature = "acme")]
 #[allow(dead_code)]


### PR DESCRIPTION
**Summary**

Introduces a typed authenticated issuer principal for management routes.

**Changes**

- Added `AuthenticatedIssuer` as the typed auth context for validated issuer JWTs.
- Updated auth middleware to store `AuthenticatedIssuer` in request extensions instead of a raw `String`.
- Updated authenticated publish/update handlers to extract `Extension<AuthenticatedIssuer>`.
- Kept service-layer ownership validation in place as defense in depth.
- Updated handler tests to use typed principals.
- Strengthened wrong-issuer update coverage to assert `403 issuer_mismatch`.
- Added wrong-issuer republish coverage to ensure an existing list cannot be replaced by another issuer.

**Verification**

- `cargo fmt --check`
- `cargo test auth`
- `cargo test status_list`
- `cargo test`