### PR TITLE
feat(auth): enhance JWT management claims validation and configuration

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -176,6 +176,14 @@ APP_STATUS_LIST__TOKEN_TTL_SECS=300
 # will be removed in a future release.
 APP_STATUS_LIST__SNAPSHOT_RETENTION_SECS=7776000
 
+# Management JWT authentication policy
+# Clock skew leeway in seconds for exp, iat, and nbf validation.
+APP_MANAGEMENT_AUTH__LEEWAY_SECS=60
+# Maximum accepted management JWT lifetime in seconds, computed as exp - iat.
+APP_MANAGEMENT_AUTH__MAX_TOKEN_LIFETIME_SECS=3600
+# Optional comma-separated accepted aud values. Leave empty to disable aud validation.
+APP_MANAGEMENT_AUTH__AUDIENCES=
+
 # Rate limiting (#171): strict (write endpoints), permissive (public reads)
 APP_RATE_LIMIT__STRICT_BURST_SIZE=10
 APP_RATE_LIMIT__STRICT_PERIOD_SECS=60

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The server compiles with modular feature flags to gate database drivers and clou
 Examples:
 
 ```bash
+# Build with PostgreSQL support and filesystem key + certificate chain loading 
 cargo run --features postgres
 
 # Build with PostgreSQL and AWS integration

--- a/README.md
+++ b/README.md
@@ -113,34 +113,6 @@ The server reads configuration from environment variables (or an optional `.env`
 
 Refer to [`.env.template`](.env.template) for the complete configuration dictionary, data types, and default values. For backend-specific configuration, see [Database Backends](docs/database-backends.md), [Secret Backends](docs/secrets-backends.md), and [DNS Providers](docs/dns-providers.md).
 
-### Validation
-
-Startup validation fails fast for invalid operator configuration, including invalid certificate renewal cron expressions and non-positive management JWT max lifetimes.
-
-## Security
-
-### Authentication
-
-Protected management endpoints use JWT bearer authentication. Issuers must first register a public key with `/api/v1/credentials`; subsequent management tokens must:
-
-- Be signed with the private key corresponding to the registered public key.
-- Have `iss` matching the registered issuer.
-- Have numeric `iat` and `exp` claims.
-- Have `exp` later than `iat`, with `exp - iat` no greater than `management_auth.max_token_lifetime_secs` (default: 3600 seconds).
-- Not have an `iat` in the future beyond `management_auth.leeway_secs` (default: 60 seconds).
-- If present, have `nbf` no later than the current time plus `management_auth.leeway_secs`.
-- When `management_auth.audiences` is configured, contain an `aud` claim matching one of the configured values; when `management_auth.audiences` is empty, `aud` is not validated.
-
-Example claims:
-
-```json
-{
-  "iss": "test-issuer",
-  "exp": 1752515200,
-  "iat": 1752511600,
-  "nbf": 1752511600
-}
-```
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ The server compiles with modular feature flags to gate database drivers and clou
 Examples:
 
 ```bash
-# Build with PostgreSQL support and filesystem key + certificate chain loading
 cargo run --features postgres
 
 # Build with PostgreSQL and AWS integration
@@ -112,7 +111,6 @@ The server reads configuration from environment variables (or an optional `.env`
 - **Defaults**: Every setting includes a default value. The server starts in zero-infrastructure in-memory mode without any custom variables.
 
 Refer to [`.env.template`](.env.template) for the complete configuration dictionary, data types, and default values. For backend-specific configuration, see [Database Backends](docs/database-backends.md), [Secret Backends](docs/secrets-backends.md), and [DNS Providers](docs/dns-providers.md).
-
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The server uses JWT-based authentication with the following requirements:
    - Have `exp` later than `iat`, with `exp - iat` no greater than `management_auth.max_token_lifetime_secs` (default: 3600 seconds)
    - Not have an `iat` in the future beyond `management_auth.leeway_secs` (default: 60 seconds)
    - If present, have `nbf` (not before) no later than the current time plus `management_auth.leeway_secs`
-   - If present, have `aud` matching one of `management_auth.audiences`; leave `management_auth.audiences` empty to accept tokens without `aud`
+   - When `management_auth.audiences` is configured, contain an `aud` claim matching one of the configured values; when `management_auth.audiences` is empty, `aud` is not validated
 
 Example JWT token header:
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,11 @@ The server uses JWT-based authentication with the following requirements:
 3. The JWT token must:
    - Be signed with the private key corresponding to the registered public key
    - Have `iss` (issuer) claim matching the registered issuer
-   - Have valid `exp` (expiration) and `iat` (issued at) claims
+   - Have numeric `iat` (issued at) and `exp` (expiration) claims
+   - Have `exp` later than `iat`, with `exp - iat` no greater than `management_auth.max_token_lifetime_secs` (default: 3600 seconds)
+   - Not have an `iat` in the future beyond `management_auth.leeway_secs` (default: 60 seconds)
+   - If present, have `nbf` (not before) no later than the current time plus `management_auth.leeway_secs`
+   - If present, have `aud` matching one of `management_auth.audiences`; leave `management_auth.audiences` empty to accept tokens without `aud`
 
 Example JWT token header:
 
@@ -178,7 +182,8 @@ Example JWT token claims:
 {
   "iss": "test-issuer",
   "exp": 1752515200,
-  "iat": 1752515200
+  "iat": 1752511600,
+  "nbf": 1752511600
 }
 ```
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -460,10 +460,10 @@ components:
         - `iat`: issued-at timestamp
         - `exp`: expiration timestamp
 
-        The optional `nbf` claim is honored when present. The optional `aud`
-        claim is accepted only when it matches one of the configured
-        `management_auth.audiences` values; tokens without `aud` are accepted
-        when no audience is configured.
+        The optional `nbf` claim is honored when present. When
+        `management_auth.audiences` is configured, the token must contain an
+        `aud` claim matching one of the configured values. When
+        `management_auth.audiences` is empty, `aud` is not validated.
 
         The server validates the signature using the registered JWK, verifies
         that the `iss` claim matches the registered issuer, rejects future

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -460,8 +460,15 @@ components:
         - `iat`: issued-at timestamp
         - `exp`: expiration timestamp
 
-        The server validates the signature using the registered JWK and verifies
-        that the `iss` claim matches the registered issuer.
+        The optional `nbf` claim is honored when present. The optional `aud`
+        claim is accepted only when it matches one of the configured
+        `management_auth.audiences` values; tokens without `aud` are accepted
+        when no audience is configured.
+
+        The server validates the signature using the registered JWK, verifies
+        that the `iss` claim matches the registered issuer, rejects future
+        `iat`/`nbf` values outside the configured leeway, and rejects tokens
+        whose lifetime (`exp - iat`) exceeds the configured maximum.
 
         Mutual TLS (mTLS) for issuer authentication is not implemented in the
         current release; this security scheme may be added in a future version.
@@ -665,6 +672,7 @@ components:
             - index_too_large
             # 401 — emitted by the authentication middleware
             - invalid_auth_header
+            - invalid_token
             - jwt_error
             - unsupported_algorithm
             - issuer_not_found

--- a/src/config.rs
+++ b/src/config.rs
@@ -84,6 +84,7 @@ pub struct Config {
     pub azure_keyvault: AzureKeyVaultConfig,
     pub cache: CacheConfig,
     pub status_list: StatusListConfig,
+    pub management_auth: ManagementAuthConfig,
     pub rate_limit: RateLimitConfig,
     pub limits: LimitsConfig,
     pub telemetry: TelemetryConfig,
@@ -112,6 +113,18 @@ pub struct LimitsConfig {
     pub max_status_index: i32,
     pub max_statuses_per_request: usize,
     pub max_serialized_list_size: usize,
+}
+
+/// JWT validation policy for protected management endpoints.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ManagementAuthConfig {
+    /// Clock skew leeway in seconds for `exp`, `iat`, and `nbf`.
+    pub leeway_secs: u64,
+    /// Maximum accepted lifetime in seconds, computed as `exp - iat`.
+    pub max_token_lifetime_secs: u64,
+    /// Accepted management-token audiences. Empty means the `aud` claim is not required.
+    #[serde(deserialize_with = "deserialize_vec_from_string_or_vec")]
+    pub audiences: Vec<String>,
 }
 
 /// Telemetry configuration controlling tracing and metrics export.
@@ -1092,6 +1105,9 @@ fn base_builder() -> Result<ConfigBuilder<DefaultState>, ConfigError> {
         .set_default("status_list.token_exp_secs", 900)?
         .set_default("status_list.token_ttl_secs", 300)?
         .set_default("status_list.snapshot_retention_secs", 7776000)?
+        .set_default("management_auth.leeway_secs", 60)?
+        .set_default("management_auth.max_token_lifetime_secs", 3600)?
+        .set_default("management_auth.audiences", Vec::<String>::new())?
         .set_default("rate_limit.strict_burst_size", 10)?
         .set_default("rate_limit.strict_period_secs", 60)?
         .set_default("rate_limit.permissive_burst_size", 100)?
@@ -1159,6 +1175,9 @@ mod tests {
         assert_eq!(config.azure_keyvault.secrets_cache_ttl, 300);
         assert_eq!(config.status_list.token_exp_secs, 900);
         assert_eq!(config.status_list.token_ttl_secs, 300);
+        assert_eq!(config.management_auth.leeway_secs, 60);
+        assert_eq!(config.management_auth.max_token_lifetime_secs, 3600);
+        assert!(config.management_auth.audiences.is_empty());
         assert_eq!(config.server.cert.renewal_cron_schedule, "0 0 0 * * *");
         assert_eq!(config.server.cert.dns_challenge_server_url, None);
         assert_eq!(config.server.aggregation_uri, None);
@@ -1250,6 +1269,12 @@ mod tests {
             ("cache.max_capacity", "2000"),
             ("status_list.token_exp_secs", "1800"),
             ("status_list.token_ttl_secs", "600"),
+            ("management_auth.leeway_secs", "30"),
+            ("management_auth.max_token_lifetime_secs", "900"),
+            (
+                "management_auth.audiences",
+                "status-list-server-management,internal-management",
+            ),
             ("rate_limit.strict_burst_size", "3"),
             ("rate_limit.strict_period_secs", "120"),
             ("rate_limit.permissive_burst_size", "500"),
@@ -1292,6 +1317,15 @@ mod tests {
         assert_eq!(overridden.cache.max_capacity, 2000);
         assert_eq!(overridden.status_list.token_exp_secs, 1800);
         assert_eq!(overridden.status_list.token_ttl_secs, 600);
+        assert_eq!(overridden.management_auth.leeway_secs, 30);
+        assert_eq!(overridden.management_auth.max_token_lifetime_secs, 900);
+        assert_eq!(
+            overridden.management_auth.audiences,
+            vec![
+                "status-list-server-management".to_string(),
+                "internal-management".to_string()
+            ]
+        );
         assert_eq!(overridden.server.cert.renewal_cron_schedule, "0 0 12 * * *");
         assert_eq!(
             overridden.server.cert.dns_challenge_server_url.as_deref(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -123,8 +123,32 @@ pub struct ManagementAuthConfig {
     /// Maximum accepted lifetime in seconds, computed as `exp - iat`.
     pub max_token_lifetime_secs: u64,
     /// Accepted management-token audiences. Empty means the `aud` claim is not required.
-    #[serde(deserialize_with = "deserialize_vec_from_string_or_vec")]
+    #[serde(deserialize_with = "deserialize_audience_list")]
     pub audiences: Vec<String>,
+}
+
+impl ManagementAuthConfig {
+    fn validate(&self) -> Result<(), ConfigError> {
+        if self.max_token_lifetime_secs == 0 {
+            return Err(ConfigError::Message(
+                "management_auth.max_token_lifetime_secs must be greater than 0".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+fn deserialize_audience_list<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let values = deserialize_vec_from_string_or_vec(deserializer)?;
+    Ok(values
+        .into_iter()
+        .map(|value: String| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .collect())
 }
 
 /// Telemetry configuration controlling tracing and metrics export.
@@ -1017,6 +1041,7 @@ impl Config {
         if let Some(query) = trim_non_empty(config.database.query.as_deref()) {
             validate_database_query(query)?;
         }
+        config.management_auth.validate()?;
         Ok(config)
     }
 }
@@ -1707,6 +1732,34 @@ mod tests {
                 .unwrap()
                 .accounts
                 .is_empty()
+        );
+    }
+
+    #[test]
+    fn test_management_auth_validations() {
+        let zero_lifetime =
+            Config::load_from_overrides(&[("management_auth.max_token_lifetime_secs", "0")]);
+        assert!(
+            zero_lifetime.is_err(),
+            "zero management token lifetime should fail config loading"
+        );
+
+        let empty_audiences =
+            Config::load_from_overrides(&[("APP_MANAGEMENT_AUTH__AUDIENCES", "")])
+                .expect("empty audience env value should load");
+        assert!(empty_audiences.management_auth.audiences.is_empty());
+
+        let trimmed_audiences = Config::load_from_overrides(&[(
+            "APP_MANAGEMENT_AUTH__AUDIENCES",
+            "status-list-server-management, internal-management, ",
+        )])
+        .expect("comma-separated audiences should load");
+        assert_eq!(
+            trimmed_audiences.management_auth.audiences,
+            vec![
+                "status-list-server-management".to_string(),
+                "internal-management".to_string()
+            ]
         );
     }
 

--- a/src/server/auth/errors.rs
+++ b/src/server/auth/errors.rs
@@ -13,6 +13,8 @@ pub enum AuthenticationError {
     InternalServer,
     #[error("Missing or invalid Authorization header")]
     InvalidAuthorizationHeader,
+    #[error("Invalid authentication token")]
+    InvalidClaims,
     #[error("{0}")]
     JwtError(#[from] JwtError),
     #[error("Unsupported algorithm")]
@@ -32,13 +34,17 @@ impl AuthenticationError {
             AuthenticationError::IssuerNotFound => Cow::Borrowed("issuer_not_found"),
             AuthenticationError::InternalServer => Cow::Borrowed("internal_error"),
             AuthenticationError::InvalidAuthorizationHeader => Cow::Borrowed("invalid_auth_header"),
+            AuthenticationError::InvalidClaims => Cow::Borrowed("invalid_token"),
             AuthenticationError::JwtError(_) => Cow::Borrowed("jwt_error"),
             AuthenticationError::UnsupportedAlgorithm => Cow::Borrowed("unsupported_algorithm"),
         }
     }
 
     pub fn get_error_message(&self) -> String {
-        self.to_string()
+        match self {
+            AuthenticationError::JwtError(_) => "Invalid authentication token".to_string(),
+            _ => self.to_string(),
+        }
     }
 }
 

--- a/src/server/auth/mod.rs
+++ b/src/server/auth/mod.rs
@@ -17,6 +17,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use crate::server::AppState;
 
 const JWT_REQUIRED_SPEC_CLAIMS: &[&str] = &["iss", "exp"];
+const JWT_REQUIRED_SPEC_CLAIMS_WITH_AUDIENCE: &[&str] = &["iss", "exp", "aud"];
 
 #[derive(Debug, Serialize, Deserialize)]
 struct UnverifiedIssuerClaims {
@@ -42,24 +43,32 @@ impl ManagementClaims {
         max_token_lifetime_secs: u64,
     ) -> Result<(), AuthenticationError> {
         if self.exp <= self.iat {
+            tracing::error!("Management JWT rejected: exp must be later than iat");
             return Err(AuthenticationError::InvalidClaims);
         }
 
         if self.iat > now.saturating_add(leeway_secs) {
+            tracing::error!(
+                "Management JWT rejected: iat is in the future beyond configured leeway"
+            );
             return Err(AuthenticationError::InvalidClaims);
         }
 
         if let Some(nbf) = self.nbf
             && nbf > now.saturating_add(leeway_secs)
         {
+            tracing::error!(
+                "Management JWT rejected: nbf is in the future beyond configured leeway"
+            );
             return Err(AuthenticationError::InvalidClaims);
         }
 
-        let lifetime = self
-            .exp
-            .checked_sub(self.iat)
-            .ok_or(AuthenticationError::InvalidClaims)?;
+        let lifetime = self.exp.checked_sub(self.iat).ok_or_else(|| {
+            tracing::error!("Management JWT rejected: exp must be later than iat");
+            AuthenticationError::InvalidClaims
+        })?;
         if lifetime > max_token_lifetime_secs {
+            tracing::error!("Management JWT rejected: token lifetime exceeds configured maximum");
             return Err(AuthenticationError::InvalidClaims);
         }
 
@@ -74,7 +83,7 @@ struct TestClaims {
     iat: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     nbf: Option<u64>,
-    exp: usize,
+    exp: u64,
 }
 
 /// Authentication middleware acting as a safeguard for unauthorized issuers
@@ -92,8 +101,19 @@ pub async fn auth(
         .and_then(|auth| auth.strip_prefix("Bearer "))
         .ok_or(AuthenticationError::InvalidAuthorizationHeader)?;
 
-    let alg = jsonwebtoken::decode_header(token)?.alg;
-    let issuer = insecure_decode::<UnverifiedIssuerClaims>(token)?.claims.iss;
+    let alg = jsonwebtoken::decode_header(token)
+        .map_err(|e| {
+            tracing::error!("Failed to decode management JWT header: {e:?}");
+            AuthenticationError::JwtError(e)
+        })?
+        .alg;
+    let issuer = insecure_decode::<UnverifiedIssuerClaims>(token)
+        .map_err(|e| {
+            tracing::error!("Failed to decode management JWT issuer claim: {e:?}");
+            AuthenticationError::JwtError(e)
+        })?
+        .claims
+        .iss;
 
     let credential = state
         .service
@@ -112,15 +132,22 @@ pub async fn auth(
     let mut validation = Validation::new(alg);
     validation.leeway = state.management_auth.leeway_secs;
     validation.validate_nbf = true;
-    // jsonwebtoken can require registered claims like `iss` and `exp`; `iat`
-    // is required by deserializing into `ManagementClaims`.
-    validation.set_required_spec_claims(JWT_REQUIRED_SPEC_CLAIMS);
     validation.set_issuer(&[&credential.issuer.0]);
     if !state.management_auth.audiences.is_empty() {
+        validation.set_required_spec_claims(JWT_REQUIRED_SPEC_CLAIMS_WITH_AUDIENCE);
         validation.set_audience(&state.management_auth.audiences);
+    } else {
+        // jsonwebtoken can require registered claims like `iss` and `exp`;
+        // `iat` is required by deserializing into `ManagementClaims`.
+        validation.set_required_spec_claims(JWT_REQUIRED_SPEC_CLAIMS);
+        validation.validate_aud = false;
     }
 
-    let token_data = jsonwebtoken::decode::<ManagementClaims>(token, &decoding_key, &validation)?;
+    let token_data = jsonwebtoken::decode::<ManagementClaims>(token, &decoding_key, &validation)
+        .map_err(|e| {
+            tracing::error!("Failed to decode management JWT: {e:?}");
+            AuthenticationError::JwtError(e)
+        })?;
     let now = current_unix_timestamp()?;
     token_data.claims.validate_policy(
         now,
@@ -196,7 +223,7 @@ mod tests {
             iss: issuer.to_string(),
             iat: now,
             nbf: None,
-            exp: (now + 3600) as usize,
+            exp: now + 3600,
         };
 
         let header = Header::new(alg);
@@ -346,7 +373,7 @@ mod tests {
             iss: "test-issuer".to_string(),
             iat: now - 7200,
             nbf: None,
-            exp: (now - 3600) as usize,
+            exp: now - 3600,
         };
 
         let encoding_key = EncodingKey::from_ec_pem(private_pem.as_bytes()).unwrap();
@@ -501,6 +528,73 @@ mod tests {
                 "iss": "test-issuer",
                 "iat": now,
                 "aud": "other-service",
+                "exp": now + 3600
+            }),
+            &encoding_key,
+        );
+
+        let response = call_with_token(app, token).await;
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_audience_claim_is_ignored_when_no_audience_is_configured() {
+        let private_pem = test_ec_private_pem();
+        let state = test_state_with_registered_issuer().await;
+        let app = create_test_router(state);
+        let now = now();
+
+        let encoding_key = EncodingKey::from_ec_pem(private_pem.as_bytes()).unwrap();
+        let token = sign_claims(
+            serde_json::json!({
+                "iss": "test-issuer",
+                "iat": now,
+                "aud": "other-service",
+                "exp": now + 3600
+            }),
+            &encoding_key,
+        );
+
+        let response = call_with_token(app, token).await;
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_matching_audience_claim_succeeds_when_audience_is_configured() {
+        let private_pem = test_ec_private_pem();
+        let mut state = test_state_with_registered_issuer().await;
+        state.management_auth.audiences = vec!["status-list-server-management".to_string()];
+        let app = create_test_router(state);
+        let now = now();
+
+        let encoding_key = EncodingKey::from_ec_pem(private_pem.as_bytes()).unwrap();
+        let token = sign_claims(
+            serde_json::json!({
+                "iss": "test-issuer",
+                "iat": now,
+                "aud": "status-list-server-management",
+                "exp": now + 3600
+            }),
+            &encoding_key,
+        );
+
+        let response = call_with_token(app, token).await;
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_missing_audience_claim_is_rejected_when_audience_is_configured() {
+        let private_pem = test_ec_private_pem();
+        let mut state = test_state_with_registered_issuer().await;
+        state.management_auth.audiences = vec!["status-list-server-management".to_string()];
+        let app = create_test_router(state);
+        let now = now();
+
+        let encoding_key = EncodingKey::from_ec_pem(private_pem.as_bytes()).unwrap();
+        let token = sign_claims(
+            serde_json::json!({
+                "iss": "test-issuer",
+                "iat": now,
                 "exp": now + 3600
             }),
             &encoding_key,

--- a/src/server/auth/mod.rs
+++ b/src/server/auth/mod.rs
@@ -12,12 +12,68 @@ use errors::AuthenticationError;
 use hyper::header;
 use jsonwebtoken::{DecodingKey, Validation};
 use serde::{Deserialize, Serialize};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::server::AppState;
 
+const JWT_REQUIRED_SPEC_CLAIMS: &[&str] = &["iss", "exp"];
+
 #[derive(Debug, Serialize, Deserialize)]
-struct Claims {
+struct UnverifiedIssuerClaims {
     iss: String,
+}
+
+/// Required management claims are non-optional (`iss`, `iat`, `exp`).
+/// Optional claims are deserialized as `Option` and validated when present.
+#[derive(Debug, Serialize, Deserialize)]
+struct ManagementClaims {
+    iss: String,
+    iat: u64,
+    #[serde(default)]
+    nbf: Option<u64>,
+    exp: u64,
+}
+
+impl ManagementClaims {
+    fn validate_policy(
+        &self,
+        now: u64,
+        leeway_secs: u64,
+        max_token_lifetime_secs: u64,
+    ) -> Result<(), AuthenticationError> {
+        if self.exp <= self.iat {
+            return Err(AuthenticationError::InvalidClaims);
+        }
+
+        if self.iat > now.saturating_add(leeway_secs) {
+            return Err(AuthenticationError::InvalidClaims);
+        }
+
+        if let Some(nbf) = self.nbf
+            && nbf > now.saturating_add(leeway_secs)
+        {
+            return Err(AuthenticationError::InvalidClaims);
+        }
+
+        let lifetime = self
+            .exp
+            .checked_sub(self.iat)
+            .ok_or(AuthenticationError::InvalidClaims)?;
+        if lifetime > max_token_lifetime_secs {
+            return Err(AuthenticationError::InvalidClaims);
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, Serialize, Deserialize)]
+struct TestClaims {
+    iss: String,
+    iat: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nbf: Option<u64>,
     exp: usize,
 }
 
@@ -37,7 +93,7 @@ pub async fn auth(
         .ok_or(AuthenticationError::InvalidAuthorizationHeader)?;
 
     let alg = jsonwebtoken::decode_header(token)?.alg;
-    let issuer = insecure_decode::<Claims>(token)?.claims.iss;
+    let issuer = insecure_decode::<UnverifiedIssuerClaims>(token)?.claims.iss;
 
     let credential = state
         .service
@@ -54,12 +110,33 @@ pub async fn auth(
     let decoding_key = DecodingKey::from_jwk(&public_key)?;
 
     let mut validation = Validation::new(alg);
+    validation.leeway = state.management_auth.leeway_secs;
+    validation.validate_nbf = true;
+    // jsonwebtoken can require registered claims like `iss` and `exp`; `iat`
+    // is required by deserializing into `ManagementClaims`.
+    validation.set_required_spec_claims(JWT_REQUIRED_SPEC_CLAIMS);
     validation.set_issuer(&[&credential.issuer.0]);
+    if !state.management_auth.audiences.is_empty() {
+        validation.set_audience(&state.management_auth.audiences);
+    }
 
-    let token_data = jsonwebtoken::decode::<Claims>(token, &decoding_key, &validation)?;
+    let token_data = jsonwebtoken::decode::<ManagementClaims>(token, &decoding_key, &validation)?;
+    let now = current_unix_timestamp()?;
+    token_data.claims.validate_policy(
+        now,
+        state.management_auth.leeway_secs,
+        state.management_auth.max_token_lifetime_secs,
+    )?;
 
     request.extensions_mut().insert(token_data.claims.iss);
     Ok(next.run(request).await)
+}
+
+fn current_unix_timestamp() -> Result<u64, AuthenticationError> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .map_err(|_| AuthenticationError::InternalServer)
 }
 
 #[cfg(test)]
@@ -75,7 +152,6 @@ mod tests {
         routing::get,
     };
     use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
-    use std::time::{SystemTime, UNIX_EPOCH};
     use tower::ServiceExt;
 
     fn create_test_router(app_state: AppState) -> Router {
@@ -109,19 +185,50 @@ mod tests {
         .unwrap()
     }
 
-    fn create_test_token(issuer: &str, secret: &EncodingKey, alg: Algorithm) -> String {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs() as usize;
+    fn now() -> u64 {
+        current_unix_timestamp().unwrap()
+    }
 
-        let claims = Claims {
+    fn create_test_token(issuer: &str, secret: &EncodingKey, alg: Algorithm) -> String {
+        let now = now();
+
+        let claims = TestClaims {
             iss: issuer.to_string(),
-            exp: now + 3600,
+            iat: now,
+            nbf: None,
+            exp: (now + 3600) as usize,
         };
 
         let header = Header::new(alg);
         encode(&header, &claims, secret).unwrap()
+    }
+
+    fn sign_claims(claims: serde_json::Value, secret: &EncodingKey) -> String {
+        let header = Header::new(Algorithm::ES256);
+        encode(&header, &claims, secret).unwrap()
+    }
+
+    async fn test_state_with_registered_issuer() -> AppState {
+        let state = test_app_state(None).await;
+        state
+            .service
+            .publish_credential(crate::domain::models::credential::Credential {
+                issuer: Issuer("test-issuer".into()),
+                public_key: test_public_jwk(),
+            })
+            .await
+            .unwrap();
+        state
+    }
+
+    async fn call_with_token(app: Router, token: String) -> axum::response::Response {
+        let request = Request::builder()
+            .uri("/test")
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .body(Body::empty())
+            .unwrap();
+
+        app.oneshot(request).await.unwrap()
     }
 
     #[tokio::test]
@@ -187,17 +294,7 @@ mod tests {
     #[tokio::test]
     async fn test_successful_authentication() {
         let private_pem = test_ec_private_pem();
-        let state = test_app_state(None).await;
-
-        state
-            .service
-            .publish_credential(crate::domain::models::credential::Credential {
-                issuer: Issuer("test-issuer".into()),
-                public_key: test_public_jwk(),
-            })
-            .await
-            .unwrap();
-
+        let state = test_state_with_registered_issuer().await;
         let app = create_test_router(state);
 
         let encoding_key = EncodingKey::from_ec_pem(private_pem.as_bytes()).unwrap();
@@ -221,16 +318,7 @@ mod tests {
     async fn test_token_verification_failure_wrong_key() {
         let wrong_private_pem = "-----BEGIN PRIVATE KEY-----\nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgUBIUj4mRpgdolCfi\najH0ju3KgSj8xQAlcvidrAkwOzChRANCAAQ4Wvc8XUs0zEqMKGtRYFnvYtDlzdH2\n7N3Eo65Js7drssgg7eKUSIlnJWMXHxqr8SfECuXi7sewuw2+mxs2adC5\n-----END PRIVATE KEY-----";
 
-        let state = test_app_state(None).await;
-        state
-            .service
-            .publish_credential(crate::domain::models::credential::Credential {
-                issuer: Issuer("test-issuer".into()),
-                public_key: test_public_jwk(),
-            })
-            .await
-            .unwrap();
-
+        let state = test_state_with_registered_issuer().await;
         let app = create_test_router(state);
 
         let wrong_encoding_key = EncodingKey::from_ec_pem(wrong_private_pem.as_bytes()).unwrap();
@@ -249,27 +337,16 @@ mod tests {
     #[tokio::test]
     async fn test_expired_token() {
         let private_pem = test_ec_private_pem();
-        let state = test_app_state(None).await;
-
-        state
-            .service
-            .publish_credential(crate::domain::models::credential::Credential {
-                issuer: Issuer("test-issuer".into()),
-                public_key: test_public_jwk(),
-            })
-            .await
-            .unwrap();
-
+        let state = test_state_with_registered_issuer().await;
         let app = create_test_router(state);
 
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs() as usize;
+        let now = now();
 
-        let expired_claims = Claims {
+        let expired_claims = TestClaims {
             iss: "test-issuer".to_string(),
-            exp: now - 3600,
+            iat: now - 7200,
+            nbf: None,
+            exp: (now - 3600) as usize,
         };
 
         let encoding_key = EncodingKey::from_ec_pem(private_pem.as_bytes()).unwrap();
@@ -284,6 +361,173 @@ mod tests {
 
         let response = app.oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_missing_issuer_claim_is_rejected() {
+        let private_pem = test_ec_private_pem();
+        let state = test_state_with_registered_issuer().await;
+        let app = create_test_router(state);
+        let now = now();
+
+        let encoding_key = EncodingKey::from_ec_pem(private_pem.as_bytes()).unwrap();
+        let token = sign_claims(
+            serde_json::json!({
+                "iat": now,
+                "exp": now + 3600
+            }),
+            &encoding_key,
+        );
+
+        let response = call_with_token(app, token).await;
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_missing_expiration_claim_is_rejected() {
+        let private_pem = test_ec_private_pem();
+        let state = test_state_with_registered_issuer().await;
+        let app = create_test_router(state);
+        let now = now();
+
+        let encoding_key = EncodingKey::from_ec_pem(private_pem.as_bytes()).unwrap();
+        let token = sign_claims(
+            serde_json::json!({
+                "iss": "test-issuer",
+                "iat": now
+            }),
+            &encoding_key,
+        );
+
+        let response = call_with_token(app, token).await;
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_missing_issued_at_claim_is_rejected() {
+        let private_pem = test_ec_private_pem();
+        let state = test_state_with_registered_issuer().await;
+        let app = create_test_router(state);
+        let now = now();
+
+        let encoding_key = EncodingKey::from_ec_pem(private_pem.as_bytes()).unwrap();
+        let token = sign_claims(
+            serde_json::json!({
+                "iss": "test-issuer",
+                "exp": now + 3600
+            }),
+            &encoding_key,
+        );
+
+        let response = call_with_token(app, token).await;
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_future_issued_at_claim_is_rejected() {
+        let private_pem = test_ec_private_pem();
+        let state = test_state_with_registered_issuer().await;
+        let app = create_test_router(state);
+        let now = now();
+
+        let encoding_key = EncodingKey::from_ec_pem(private_pem.as_bytes()).unwrap();
+        let token = sign_claims(
+            serde_json::json!({
+                "iss": "test-issuer",
+                "iat": now + 120,
+                "exp": now + 3600
+            }),
+            &encoding_key,
+        );
+
+        let response = call_with_token(app, token).await;
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_future_not_before_claim_is_rejected() {
+        let private_pem = test_ec_private_pem();
+        let state = test_state_with_registered_issuer().await;
+        let app = create_test_router(state);
+        let now = now();
+
+        let encoding_key = EncodingKey::from_ec_pem(private_pem.as_bytes()).unwrap();
+        let token = sign_claims(
+            serde_json::json!({
+                "iss": "test-issuer",
+                "iat": now,
+                "nbf": now + 120,
+                "exp": now + 3600
+            }),
+            &encoding_key,
+        );
+
+        let response = call_with_token(app, token).await;
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_too_long_lived_token_is_rejected() {
+        let private_pem = test_ec_private_pem();
+        let state = test_state_with_registered_issuer().await;
+        let app = create_test_router(state);
+        let now = now();
+
+        let encoding_key = EncodingKey::from_ec_pem(private_pem.as_bytes()).unwrap();
+        let token = sign_claims(
+            serde_json::json!({
+                "iss": "test-issuer",
+                "iat": now,
+                "exp": now + 3601
+            }),
+            &encoding_key,
+        );
+
+        let response = call_with_token(app, token).await;
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_wrong_audience_claim_is_rejected() {
+        let private_pem = test_ec_private_pem();
+        let mut state = test_state_with_registered_issuer().await;
+        state.management_auth.audiences = vec!["status-list-server-management".to_string()];
+        let app = create_test_router(state);
+        let now = now();
+
+        let encoding_key = EncodingKey::from_ec_pem(private_pem.as_bytes()).unwrap();
+        let token = sign_claims(
+            serde_json::json!({
+                "iss": "test-issuer",
+                "iat": now,
+                "aud": "other-service",
+                "exp": now + 3600
+            }),
+            &encoding_key,
+        );
+
+        let response = call_with_token(app, token).await;
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_jwt_errors_have_generic_response_message() {
+        let state = test_app_state(None).await;
+        let app = create_test_router(state);
+
+        let request = Request::builder()
+            .uri("/test")
+            .header(header::AUTHORIZATION, "Bearer invalid_jwt_token")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+        let bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["error"], "jwt_error");
+        assert_eq!(body["error_description"], "Invalid authentication token");
     }
 
     #[tokio::test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -17,6 +17,26 @@ pub struct ManagementAuthConfig {
     pub audiences: Vec<String>,
 }
 
+impl Default for ManagementAuthConfig {
+    fn default() -> Self {
+        Self {
+            leeway_secs: 60,
+            max_token_lifetime_secs: 3600,
+            audiences: Vec::new(),
+        }
+    }
+}
+
+impl From<&crate::config::ManagementAuthConfig> for ManagementAuthConfig {
+    fn from(config: &crate::config::ManagementAuthConfig) -> Self {
+        Self {
+            leeway_secs: config.leeway_secs,
+            max_token_lifetime_secs: config.max_token_lifetime_secs,
+            audiences: config.audiences.clone(),
+        }
+    }
+}
+
 /// Shared application state injected into web handlers.
 #[derive(Debug, Clone)]
 pub struct AppState {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -9,6 +9,14 @@ pub mod rate_limit;
 use crate::domain::service::Service;
 use std::sync::Arc;
 
+/// JWT policy for protected management endpoints.
+#[derive(Debug, Clone)]
+pub struct ManagementAuthConfig {
+    pub leeway_secs: u64,
+    pub max_token_lifetime_secs: u64,
+    pub audiences: Vec<String>,
+}
+
 /// Shared application state injected into web handlers.
 #[derive(Debug, Clone)]
 pub struct AppState {
@@ -22,6 +30,7 @@ pub struct AppState {
     pub max_statuses_per_request: usize,
     pub max_serialized_list_size: usize,
     pub snapshot_retention_secs: u64,
+    pub management_auth: ManagementAuthConfig,
     /// Dependency readiness checks backing the `/health/ready` endpoint.
     pub readiness: health::Readiness,
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -582,11 +582,7 @@ async fn build_state_impl(config: &AppConfig) -> EyeResult<BuildStateResult> {
         max_statuses_per_request: config.limits.max_statuses_per_request,
         max_serialized_list_size: config.limits.max_serialized_list_size,
         snapshot_retention_secs: config.status_list.snapshot_retention_secs,
-        management_auth: crate::server::ManagementAuthConfig {
-            leeway_secs: config.management_auth.leeway_secs,
-            max_token_lifetime_secs: config.management_auth.max_token_lifetime_secs,
-            audiences: config.management_auth.audiences.clone(),
-        },
+        management_auth: crate::server::ManagementAuthConfig::from(&config.management_auth),
         readiness,
     };
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -582,6 +582,11 @@ async fn build_state_impl(config: &AppConfig) -> EyeResult<BuildStateResult> {
         max_statuses_per_request: config.limits.max_statuses_per_request,
         max_serialized_list_size: config.limits.max_serialized_list_size,
         snapshot_retention_secs: config.status_list.snapshot_retention_secs,
+        management_auth: crate::server::ManagementAuthConfig {
+            leeway_secs: config.management_auth.leeway_secs,
+            max_token_lifetime_secs: config.management_auth.max_token_lifetime_secs,
+            audiences: config.management_auth.audiences.clone(),
+        },
         readiness,
     };
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -90,11 +90,7 @@ pub(crate) async fn test_app_state_without_snapshots() -> AppState {
         max_statuses_per_request: 5_000,
         max_serialized_list_size: 1_048_576,
         snapshot_retention_secs: 0,
-        management_auth: crate::server::ManagementAuthConfig {
-            leeway_secs: 60,
-            max_token_lifetime_secs: 3600,
-            audiences: Vec::new(),
-        },
+        management_auth: crate::server::ManagementAuthConfig::default(),
         readiness: crate::server::health::Readiness::new(Vec::new()),
     }
 }
@@ -185,11 +181,7 @@ async fn build_test_app_state(
         max_statuses_per_request: 5_000,
         max_serialized_list_size,
         snapshot_retention_secs: 7776000,
-        management_auth: crate::server::ManagementAuthConfig {
-            leeway_secs: 60,
-            max_token_lifetime_secs: 3600,
-            audiences: Vec::new(),
-        },
+        management_auth: crate::server::ManagementAuthConfig::default(),
         readiness: Readiness::default(),
     }
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -90,6 +90,11 @@ pub(crate) async fn test_app_state_without_snapshots() -> AppState {
         max_statuses_per_request: 5_000,
         max_serialized_list_size: 1_048_576,
         snapshot_retention_secs: 0,
+        management_auth: crate::server::ManagementAuthConfig {
+            leeway_secs: 60,
+            max_token_lifetime_secs: 3600,
+            audiences: Vec::new(),
+        },
         readiness: crate::server::health::Readiness::new(Vec::new()),
     }
 }
@@ -180,6 +185,11 @@ async fn build_test_app_state(
         max_statuses_per_request: 5_000,
         max_serialized_list_size,
         snapshot_retention_secs: 7776000,
+        management_auth: crate::server::ManagementAuthConfig {
+            leeway_secs: 60,
+            max_token_lifetime_secs: 3600,
+            audiences: Vec::new(),
+        },
         readiness: Readiness::default(),
     }
 }


### PR DESCRIPTION
## Summary

Hardened management JWT claim validation beyond issuer and expiration checks.

## Changes

- Added explicit management auth policy configuration:
  - `management_auth.leeway_secs`
  - `management_auth.max_token_lifetime_secs`
  - `management_auth.audiences`
- Required verified management tokens to include `iss`, `iat`, and `exp`.
- Validated optional `nbf` when present.
- Rejected tokens with:
  - missing required claims
  - expired `exp`
  - future `iat`
  - future `nbf`
  - `exp <= iat`
  - lifetime longer than configured maximum
  - mismatched `aud` when accepted audiences are configured
- Sanitized JWT validation error responses so clients receive generic token failure messages.
- Updated README and OpenAPI docs to reflect the actual management JWT requirements.

## Tests

- Added negative auth tests for missing, expired, future, too-long-lived, and audience-mismatched tokens.
- Added config coverage for the new management auth settings.

## Verification

- `cargo fmt --check`
- `cargo test server::auth`
- `cargo test test_config_loading`
- `cargo test`
