### PR TITLE
ci: Integrate Boringcache for Cargo and Docker builds

### DIFF
--- a/.boringcache.toml
+++ b/.boringcache.toml
@@ -1,0 +1,35 @@
+workspace = "boringcache/status-list-server"
+
+[entries.cargo-target]
+kind = "cargo-target"
+tag = "cargo-target"
+path = "target"
+
+[entries.coverage-target]
+kind = "cargo-target"
+tag = "cargo-coverage-target"
+path = "target"
+
+[profiles.dependencies]
+entries = ["cargo-registry-cache", "cargo-registry-index"]
+
+[profiles.cargo]
+entries = ["cargo-target", "cargo-git-db"]
+
+[profiles.coverage]
+entries = ["coverage-target", "cargo-git-db"]
+
+[adapters.cargo]
+profiles = ["cargo"]
+compiler-cache = "sccache"
+fail-on-cache-error = true
+
+[adapters.sccache]
+tag = "rust"
+
+[adapters.docker]
+command = ["docker", "buildx", "bake", "--file", ".github/docker-bake.hcl", "--metadata-file", "target/docker-metadata.json"]
+tag = "docker"
+mount-cache = true
+tool-cache = ["sccache:rust-docker"]
+fail-on-cache-error = true

--- a/.github/docker-bake.hcl
+++ b/.github/docker-bake.hcl
@@ -1,0 +1,33 @@
+variable "RELEASE_BUILD" {
+  default = false
+}
+
+variable "BUILD_VARIANT" {
+  default = "smoke"
+}
+
+variable "FEATURES" {
+  default = null
+}
+
+variable "DOCKER_METADATA_OUTPUT_JSON" {
+  default = "{\"tags\":[],\"labels\":{}}"
+}
+
+target "default" {
+  matrix     = { variant = [BUILD_VARIANT] }
+  name       = variant
+  context    = "."
+  dockerfile = "Dockerfile"
+  args       = { FEATURES = FEATURES }
+  tags       = jsondecode(DOCKER_METADATA_OUTPUT_JSON).tags
+  labels     = jsondecode(DOCKER_METADATA_OUTPUT_JSON).labels
+  platforms  = RELEASE_BUILD ? ["linux/amd64", "linux/arm64"] : []
+  output     = RELEASE_BUILD ? ["type=registry"] : []
+
+  # Keep release provenance explicit regardless of repository visibility.
+  attest = RELEASE_BUILD ? ["type=provenance,mode=max", "type=sbom"] : []
+  annotations = RELEASE_BUILD ? [
+    "index,manifest:org.opencontainers.image.description=${jsondecode(DOCKER_METADATA_OUTPUT_JSON).labels["org.opencontainers.image.description"]}"
+  ] : []
+}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,6 +3,12 @@ name: "CI"
 on:
   merge_group:
   workflow_dispatch:
+    inputs:
+      cli_version:
+        description: Optional exact BoringCache CLI release
+        required: false
+        default: ""
+        type: string
   workflow_call:
   pull_request:
   push:
@@ -193,6 +199,9 @@ jobs:
   cargo-build:
     name: Cargo Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     needs: cargo-fmt
     timeout-minutes: 45
 
@@ -202,10 +211,24 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: BoringCache Cargo
+        uses: boringcache/one@a610ec5a564efd9b360925056dbade04deb5def6 # v1.30.0
+        with:
+          cli-version: ${{ inputs.cli_version }}
+          mode: archive
+          cache-profiles: dependencies
+          trust-policy: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && 'auto' || 'restore' }}
+          fail-on-cache-error: true
+
+      - name: Install sccache
+        uses: taiki-e/install-action@c44f6b046f1c29ae5918b1e0bfdbb2f1813836fd # v2.84.1
+        with:
+          tool: sccache@0.17.0
+
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
-          cache-shared-key: "workspace"
+          cache: false
 
       - name: Install build dependencies
         run: |
@@ -213,10 +236,12 @@ jobs:
           sudo apt-get install -y cmake golang-go
 
       - name: Cargo Build
-        run: cargo build --workspace --all-targets --all-features
+        run: |
+          boringcache cargo --${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && 'write' || 'read-only' }} --skip-save build --workspace --all-targets --all-features
 
       - name: Memory-only Build
-        run: cargo check --no-default-features --features memory
+        run: |
+          boringcache cargo --${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && 'write' || 'read-only' }} --skip-restore --skip-save check --no-default-features --features memory
 
       - name: Release image feature set
         # The Dockerfile default is still the local smoke-build feature set.
@@ -232,7 +257,7 @@ jobs:
             exit 1
           fi
           echo "release image features: ${features}"
-          cargo check --workspace --features "${features}"
+          boringcache cargo --${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && 'write' || 'read-only' }} --skip-restore check --workspace --features "${features}"
 
       - name: Verify domain layer purity
         run: |
@@ -248,6 +273,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -269,11 +295,24 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: BoringCache Cargo
+        uses: boringcache/one@a610ec5a564efd9b360925056dbade04deb5def6 # v1.30.0
+        with:
+          cli-version: ${{ inputs.cli_version }}
+          mode: archive
+          cache-profiles: dependencies
+          trust-policy: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && 'auto' || 'restore' }}
+          fail-on-cache-error: true
+
+      - name: Install sccache
+        uses: taiki-e/install-action@c44f6b046f1c29ae5918b1e0bfdbb2f1813836fd # v2.84.1
+        with:
+          tool: sccache@0.17.0
+
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
-          cache-shared-key: "workspace"
-          cache-save-if: "false"
+          cache: false
 
       - name: Install build dependencies
         run: |
@@ -281,13 +320,17 @@ jobs:
           sudo apt-get install -y cmake golang-go
 
       - name: Cargo check release variant
-        run: cargo check --workspace --features "${FEATURES}"
+        run: |
+          boringcache cargo --${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && 'write' || 'read-only' }} --skip-save check --workspace --features "${FEATURES}"
         env:
           FEATURES: ${{ matrix.variant.features }}
 
   docker-build:
     name: Docker Build Smoke
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Fetch Repository
@@ -295,19 +338,23 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Docker build (production features)
-        # No FEATURES build-arg: the Dockerfile default is already the release set, and
-        # a second copy would drift.
-        #
-        # No gha cache: Docker layer caching is intentionally disabled to avoid cache
-        # bloat. The cargo build cache is shared across jobs; Docker layer caching
-        # would add ~2GB per run without significant benefit for this smoke build,
-        # evicting the cargo caches the other jobs rely on.
-        run: docker build .
+      - name: Prepare Docker output
+        run: mkdir -p target
+
+      - name: BoringCache Docker
+        uses: boringcache/one@a610ec5a564efd9b360925056dbade04deb5def6 # v1.30.0
+        with:
+          cli-version: ${{ inputs.cli_version }}
+          mode: docker
+          trust-policy: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && 'auto' || 'restore' }}
+          fail-on-cache-error: true
 
   cargo-clippy:
     name: Cargo Clippy Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     needs:
       - cargo-build
       - release-variant-checks
@@ -318,19 +365,36 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: BoringCache Cargo
+        uses: boringcache/one@a610ec5a564efd9b360925056dbade04deb5def6 # v1.30.0
+        with:
+          cli-version: ${{ inputs.cli_version }}
+          mode: archive
+          cache-profiles: dependencies
+          trust-policy: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && 'auto' || 'restore' }}
+          fail-on-cache-error: true
+
+      - name: Install sccache
+        uses: taiki-e/install-action@c44f6b046f1c29ae5918b1e0bfdbb2f1813836fd # v2.84.1
+        with:
+          tool: sccache@0.17.0
+
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
+          cache: false
           components: clippy
-          cache-shared-key: "workspace"
-          cache-save-if: "false"
 
       - name: Clippy Check
-        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+        run: |
+          boringcache cargo --${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && 'write' || 'read-only' }} --skip-save clippy --workspace --all-targets --all-features -- -D warnings
 
   cargo-nextest:
     name: Cargo Nextest
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     needs: cargo-build
 
     steps:
@@ -339,11 +403,24 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: BoringCache Cargo
+        uses: boringcache/one@a610ec5a564efd9b360925056dbade04deb5def6 # v1.30.0
+        with:
+          cli-version: ${{ inputs.cli_version }}
+          mode: archive
+          cache-profiles: dependencies
+          trust-policy: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && 'auto' || 'restore' }}
+          fail-on-cache-error: true
+
+      - name: Install sccache
+        uses: taiki-e/install-action@c44f6b046f1c29ae5918b1e0bfdbb2f1813836fd # v2.84.1
+        with:
+          tool: sccache@0.17.0
+
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
-          cache-shared-key: "workspace"
-          cache-save-if: "false"
+          cache: false
 
       - name: Install Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
@@ -355,11 +432,15 @@ jobs:
           tool: nextest@0.9.101
 
       - name: Run Cargo Tests
-        run: cargo nextest run --workspace --all-targets --all-features
+        run: |
+          boringcache cargo --${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && 'write' || 'read-only' }} --skip-save nextest run --workspace --all-targets --all-features
 
   cargo-doc:
     name: Cargo Documentation
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     needs: cargo-build
 
     steps:
@@ -368,14 +449,28 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: BoringCache Cargo
+        uses: boringcache/one@a610ec5a564efd9b360925056dbade04deb5def6 # v1.30.0
+        with:
+          cli-version: ${{ inputs.cli_version }}
+          mode: archive
+          cache-profiles: dependencies
+          trust-policy: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && 'auto' || 'restore' }}
+          fail-on-cache-error: true
+
+      - name: Install sccache
+        uses: taiki-e/install-action@c44f6b046f1c29ae5918b1e0bfdbb2f1813836fd # v2.84.1
+        with:
+          tool: sccache@0.17.0
+
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
-          cache-shared-key: "workspace"
-          cache-save-if: "false"
+          cache: false
 
       - name: Generate Documentation
-        run: cargo doc --workspace --all-features --no-deps --document-private-items
+        run: |
+          boringcache cargo --${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && 'write' || 'read-only' }} --skip-save doc --workspace --all-features --no-deps --document-private-items
         env:
           RUSTDOCFLAGS: -D warnings
 
@@ -389,6 +484,9 @@ jobs:
     if: ${{ needs.check-crate-type.outputs.is_lib == 'true' }}
     name: Cargo test doc
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     timeout-minutes: 45
 
     steps:
@@ -397,11 +495,24 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: BoringCache Cargo
+        uses: boringcache/one@a610ec5a564efd9b360925056dbade04deb5def6 # v1.30.0
+        with:
+          cli-version: ${{ inputs.cli_version }}
+          mode: archive
+          cache-profiles: dependencies
+          trust-policy: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && 'auto' || 'restore' }}
+          fail-on-cache-error: true
+
+      - name: Install sccache
+        uses: taiki-e/install-action@c44f6b046f1c29ae5918b1e0bfdbb2f1813836fd # v2.84.1
+        with:
+          tool: sccache@0.17.0
+
       - name: Install stable toolchain
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
-          cache-shared-key: "workspace"
-          cache-save-if: "false"
+          cache: false
 
       - name: Install build dependencies
         run: |
@@ -409,7 +520,8 @@ jobs:
           sudo apt-get install -y cmake golang-go
 
       - name: Cargo test doc
-        run: cargo test --doc --workspace --all-features
+        run: |
+          boringcache cargo --${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && 'write' || 'read-only' }} --skip-save test --doc --workspace --all-features
 
   cargo-machete:
     name: Cargo Machete Check
@@ -918,6 +1030,9 @@ jobs:
   cargo-coverage:
     name: Cargo Coverage (llvm-cov)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     needs: cargo-build
     steps:
       - name: Fetch Repository
@@ -925,11 +1040,25 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: BoringCache Cargo
+        uses: boringcache/one@a610ec5a564efd9b360925056dbade04deb5def6 # v1.30.0
+        with:
+          cli-version: ${{ inputs.cli_version }}
+          mode: archive
+          cache-profiles: dependencies
+          trust-policy: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && 'auto' || 'restore' }}
+          fail-on-cache-error: true
+
+      - name: Install sccache
+        uses: taiki-e/install-action@c44f6b046f1c29ae5918b1e0bfdbb2f1813836fd # v2.84.1
+        with:
+          tool: sccache@0.17.0
+
       - name: Install stable toolchain
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
+          cache: false
           components: llvm-tools-preview
-          cache-shared-key: "coverage"
 
       - name: Install cargo-llvm-cov and cargo-nextest
         uses: taiki-e/install-action@c44f6b046f1c29ae5918b1e0bfdbb2f1813836fd # v2.84.1
@@ -939,7 +1068,8 @@ jobs:
           tool: cargo-llvm-cov@0.6.16,nextest@0.9.101
 
       - name: Generate code coverage
-        run: cargo llvm-cov nextest --workspace --all-features --html --output-dir target/llvm-cov/html
+        run: |
+          boringcache cargo --${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && 'write' || 'read-only' }} --profile coverage llvm-cov nextest --workspace --all-features --html --output-dir target/llvm-cov/html
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,6 +71,7 @@ jobs:
     # job needs its SARIF upload scope granted here too.
     permissions:
       contents: read
+      id-token: write
       security-events: write
 
   build-and-push:
@@ -81,6 +82,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -130,29 +132,27 @@ jobs:
           labels: |
             org.opencontainers.image.description=${{ matrix.variant.description }}
 
-      - name: Build and push Docker image
-        id: build
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+      - name: Prepare Docker output
+        run: mkdir -p target
+
+      - name: BoringCache Docker
+        uses: boringcache/one@a610ec5a564efd9b360925056dbade04deb5def6 # v1.30.0
         with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=gha,scope=build-${{ matrix.variant.suffix }}
-          cache-to: type=gha,mode=max,scope=build-${{ matrix.variant.suffix }}
-          # Explicit: the action defaults to mode=max on public repos and mode=min on
-          # private, so a visibility change would silently degrade provenance.
-          #
-          # BuildKit attaches both as in-toto manifests in the pushed index, which is
-          # why the image cannot be scanned before it is pushed.
-          provenance: mode=max
-          sbom: true
-          build-args: |
-            FEATURES=${{ matrix.variant.features }}
-          labels: ${{ steps.meta.outputs.labels }}
-          annotations: |
-            index,manifest:org.opencontainers.image.description=${{ matrix.variant.description }}
+          mode: docker
+          fail-on-cache-error: true
+        env:
+          RELEASE_BUILD: "true"
+          BUILD_VARIANT: ${{ matrix.variant.suffix }}
+          FEATURES: ${{ matrix.variant.features }}
+          DOCKER_METADATA_OUTPUT_JSON: ${{ steps.meta.outputs.json }}
+
+      - name: Read built image digest
+        id: build
+        env:
+          SUFFIX: ${{ matrix.variant.suffix }}
+        run: |
+          digest=$(jq -er '.[env.SUFFIX]["containerimage.digest"]' target/docker-metadata.json)
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
       - name: Assert a digest was produced
         # An empty digest would silently fall back to tag-based deployment, which is
@@ -168,7 +168,7 @@ jobs:
           SUFFIX: ${{ matrix.variant.suffix }}
         run: |
           if [ -z "$DIGEST" ]; then
-            echo "::error::build-push-action produced no image digest for variant ${SUFFIX}."
+            echo "::error::Docker build produced no image digest for variant ${SUFFIX}."
             exit 1
           fi
           echo "image digest for ${SUFFIX}: $DIGEST"

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,23 @@ ARG TARGETPLATFORM
 ARG TARGETARCH
 WORKDIR /app
 
+ARG SCCACHE_VERSION=0.17.0
+RUN set -eu; \
+    case "$(uname -m)" in \
+        x86_64) checksum=67c4a96dd237c1f518f6b36083f270f9976d516f1e57fce891755ea782e50006 ;; \
+        aarch64) checksum=821a86343191aa1cbab74bd42f9e93c9a63bf85e4742945f40d3ae84193c1c77 ;; \
+        *) echo "Unsupported build architecture"; exit 1 ;; \
+    esac; \
+    archive="sccache-v${SCCACHE_VERSION}-$(uname -m)-unknown-linux-musl"; \
+    curl --fail --location --silent --show-error \
+        "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/${archive}.tar.gz" \
+        --output /tmp/sccache.tar.gz; \
+    printf '%s  /tmp/sccache.tar.gz\n' "$checksum" | sha256sum --check -; \
+    tar -xzf /tmp/sccache.tar.gz -C /tmp; \
+    install -m 755 "/tmp/${archive}/sccache" /usr/local/bin/sccache; \
+    rm -rf /tmp/sccache.tar.gz "/tmp/${archive}"; \
+    sccache --version
+
 # cargo-auditable records the dependency graph in a .dep-v0 linker section. Without
 # it the scratch runtime image carries one static binary and no package metadata, so
 # scanners enumerate zero packages and the published SBOM is empty.
@@ -38,10 +55,12 @@ ARG FEATURES="postgres,aws"
 # dependency graph exits zero, so an exit-status check alone would pass on exactly the
 # empty-but-present artifact it exists to catch. The decode is captured before it is
 # counted so a rust-audit-info crash fails as itself rather than as a count of 0.
-RUN --mount=type=bind,source=src,target=src \
-    --mount=type=bind,source=test_data,target=test_data \
-    --mount=type=bind,source=Cargo.toml,target=Cargo.toml \
-    --mount=type=bind,source=Cargo.lock,target=Cargo.lock \
+# BoringCache repairs source timestamps when restoring the Cargo target mount.
+# BuildKit discards writes to these bind mounts after this RUN.
+RUN --mount=type=bind,source=src,target=src,rw \
+    --mount=type=bind,source=test_data,target=test_data,rw \
+    --mount=type=bind,source=Cargo.toml,target=Cargo.toml,rw \
+    --mount=type=bind,source=Cargo.lock,target=Cargo.lock,rw \
     --mount=type=cache,target=/app/target,id=target-cache-${TARGETPLATFORM} \
     --mount=type=cache,target=/root/.cargo/registry,id=registry-cache-${TARGETPLATFORM} \
     set -eu; \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "stable"
+channel = "1.98.1"


### PR DESCRIPTION
Follow-up to [#496](https://github.com/adorsys/status-list-server/issues/496), following [Hermann’s invitation to try a PR](https://github.com/adorsys/status-list-server/issues/496#issuecomment-5582643980). 

This uses the cache sharing and base-branch population added in #497. It moves Cargo and Docker build caches into BoringCache while preserving the existing checks, runners and release destinations. [BoringCache](https://boringcache.com/about) is a fast shared content-addressed build cache for CI, Docker & anywhere really.

## Changes

- Use the pinned BoringCache One action v1.30.0 with its default CLI and managed BuildKit.
- Pin rust to 1.98.1 for cache consistency
- Configure Cargo dependencies, target snapshots, a separate coverage profile and shared sccache storage in `.boringcache.toml`.
- Keep Cargo Build as the shared target producer; downstream checks restore that target without publishing competing snapshots. Coverage saves its own target.
- Allow cache writes on pushes and manual runs; PR and merge-queue runs use read-only cache access.
- Add Docker layer caching, persisted Cargo target/registry mounts and in-container sccache.
- Preserve the five release variants, amd64/arm64 builds, GHCR destination, image metadata, provenance, SBOM, scans and digest-based deployment. Docker Bake uses the existing build settings.

I have kept the changes minimal and focussed but please let me know if anything doesn't make sense.

## Validation and results

The fork includes upstream `develop` at `9476030`. I ran warm rebuilds and successive upstream changes between September 7 and 9.

[Latest validation run: 34332315250](https://github.com/boringcache/status-list-server/actions/runs/34332315250):

- All 29 CI jobs passed with Action/CLI 1.30.0.
- Nextest and coverage each passed 331 tests, with no skips.
- BoringCache recorded 1,534 cache hits, 12 misses and zero cache errors.
- Workflow lint, security checks and Docker Bake rendering passed. All five release configurations preserve their platforms, feature flags, tags, labels and attestations.

The latest warm run compared with the [upstream run on the same application source](https://github.com/adorsys/status-list-server/actions/runs/34214485446):

| Measurement | Upstream | BoringCache |
| --- | ---: | ---: |
| Cargo Build | 3m37s | 1m20s |
| Cargo Nextest | 4m37s | 2m25s |
| Docker Build Smoke | 7m56s | 29s |
| Cargo Coverage | 5m14s | 5m52s |
| Elapsed CI, first job start to last job finish | 9m16s | 7m45s |
| Sum of job execution times | 43m23s | 34m19s |

## Storage

The benchmark workspace snapshot on September 9 shows:

- **11.2 GB** across 16 current saved targets.
- **13.5 GB** ready to restore, including retained versions.
- **13.5 GB** of physical stored objects at the last measurement, approximately four hours before this review.
- **98.4%** dashboard warm hit rate over 24 hours, with 12,719 hits and 72 GB served.

**Note**: This inventory includes older benchmark tags and toolchain generations

<img width="1272" height="413" alt="Screenshot 2026-09-09 at 11 14 04" src="https://github.com/user-attachments/assets/a81d09ed-c312-46c7-a71b-da6a16d99f07" />

vs

<img width="1300" height="160" alt="Screenshot 2026-09-09 at 11 14 41" src="https://github.com/user-attachments/assets/3b464c56-9242-4ebe-bf6d-8fcfe94fe0e4" />

## Onboarding

The branch currently uses the fork’s `boringcache/status-list-server` workspace. Before merging, I will configure an Adorsys-owned workspace, approve its repository OIDC connection, and update the workspace path. No static BoringCache token is required for the proposed setup.

cc// @Hermann-Core
